### PR TITLE
Design spec: nasde-dev-skill self-testing benchmark

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+**/jobs/
+**/__pycache__/
+**/.venv/
+**/*.pyc
+.git/
+.claude/
+docs/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ build/
 .env
 harbor_config.json
 .claude/worktrees/
+nasde-registry-*.json
+pytest-of-*/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -103,6 +103,10 @@ flowchart LR
 
 Harbor only measures **functional correctness** — tests pass or fail, yielding a binary reward. Whether the agent wrote the code *well* is not something Harbor measures. That's where assessment evaluation comes in.
 
+### Docker environment auto-generation
+
+When a task has no `environment/Dockerfile`, the runner calls `docker.py:ensure_task_environment()` to auto-generate one from `source.git` + `[docker]` config. For local paths (not starting with `http`/`https`/`git`/`file`), it also generates `environment/docker-compose.yaml` with a `build.context` override pointing to the repo root, so Harbor's `DockerEnvironment` uses the correct build context for `COPY`-based Dockerfiles.
+
 ---
 
 ## Cloud sandbox providers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the full system architecture with dia
 - **Evaluator**: Uses Claude Code SDK async API to run a Claude agent that reads trial artifacts and scores them against assessment criteria. Configurable via `[evaluation]` in `nasde.toml` — model, tools, MCP servers, skills, and system prompt can all be customized. Default model is `claude-opus-4-6` (best available for review quality). Monkeypatches SDK's `parse_message` to handle unknown message types (remove when SDK fixes this). Results written to `assessment_eval.json` per trial and optionally uploaded to Opik.
 - **Variant system**: Each variant is a directory under `variants/` with a required `variant.toml` declaring the agent type (`agent = "claude"` or `agent = "codex"`). For Claude Code variants, `CLAUDE.md` is injected into `/app/CLAUDE.md`; for Codex variants, `AGENTS.md` is injected into `/app/AGENTS.md`. An optional `skills/` subdirectory contains Claude skill snapshots — each `skills/<name>/SKILL.md` is injected into `/app/.claude/skills/<name>/SKILL.md`. An optional `agents_skills/` subdirectory contains Codex skill snapshots — all files under `agents_skills/<name>/` are injected into `/app/.agents/skills/<name>/`. If no `harbor_config.json` exists, one is auto-generated from `variant.toml`.
 - **All dependencies are core**: `harbor`, `opik`, `claude-code-sdk` are in `[project.dependencies]`. No optional extras — `uv tool install .` gives full functionality. Assessment evaluation is on by default (`--without-eval` to skip).
+- **Auto-generated Dockerfile**: When a task has no `environment/Dockerfile`, nasde generates one from `source.git` + `[docker]`. For local paths, also generates `docker-compose.yaml` to override the build context. See `docker.py:ensure_task_environment()`.
 - **Pass-through CLI**: `nasde harbor ...` delegates to Harbor's Typer app via `add_typer()`. `nasde opik ...` forwards args to Opik's Click CLI via `ctx.args`.
 - See `docs/adr/` for detailed decision records.
 
@@ -189,6 +190,8 @@ Dimensions are benchmark-specific. Total scores should sum to 100. Typically 3-5
   }
 }
 ```
+
+**Auto-generated environment:** If `environment/Dockerfile` is absent, nasde auto-generates one from `source.git` + `[docker]` config in `nasde.toml`. For local repos (paths not starting with `http`/`https`/`git`/`file`), the generated Dockerfile uses `COPY . /app` instead of `git clone`, and a `docker-compose.yaml` is also generated to set the Docker build context to the repo root.
 
 ### task.toml (required by Harbor)
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,21 @@ append_system_prompt = "Pay special attention to SOLID principles when scoring."
 | `skills_dir` | — | Path to evaluator skills directory |
 | `append_system_prompt` | — | Extra system prompt text |
 
+## Local repo benchmarks
+
+You can build benchmarks from local (private) repositories by setting `source.git` to a relative path:
+
+```json
+{
+  "source": {
+    "git": "../..",
+    "ref": "abc1234"
+  }
+}
+```
+
+nasde auto-generates the Docker environment — no custom `Dockerfile` needed. See `examples/nasde-dev-skill/` for a complete example that tests nasde-toolkit itself.
+
 ## Commands
 
 ### Core

--- a/docs/superpowers/plans/2026-03-23-nasde-dev-skill-benchmark.md
+++ b/docs/superpowers/plans/2026-03-23-nasde-dev-skill-benchmark.md
@@ -1,0 +1,571 @@
+# nasde-dev-skill Benchmark Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create a self-testing benchmark for nasde-toolkit that measures skill value through 4 variant combinations, using local repo as source (first local-repo benchmark example).
+
+**Architecture:** Three prerequisites (fix existing tests, source.git integration with docker-compose override for local paths, nasde-dev skill already cleaned) then benchmark project creation in `examples/nasde-dev-skill/`. For local repos, nasde generates both a Dockerfile (with `COPY . /app`) and a `docker-compose.yaml` override (pointing build context to the repo root). Harbor merges the compose override so `COPY` sees the full repo. 4 variants compose nasde-dev with external Python skills from skills.sh.
+
+**Tech Stack:** Python 3.12, Typer, Harbor, pytest, Docker, skills.sh (python-testing, python-best-practices)
+
+**Spec:** `docs/superpowers/specs/2026-03-20-nasde-dev-skill-benchmark-design.md`
+
+**Key Harbor insight:** Harbor's `DockerEnvironment` uses `environment/` as the default Docker build context (`context_dir=self.environment_dir`). But if an `environment/docker-compose.yaml` exists, Harbor merges it — and relative paths in that compose file resolve relative to the compose file's location. So `build.context: ../../../..` in `environment/docker-compose.yaml` changes the context to the repo root, making `COPY . /app` work for local repos.
+
+---
+
+### Task 0: Fix existing broken tests in test_runner.py
+
+The 4 existing tests in `test_runner.py` are broken — `_build_merged_config()` requires `variant_name` as a positional arg but tests don't pass it.
+
+**Files:**
+- Modify: `tests/test_runner.py`
+
+- [ ] **Step 1: Run existing tests to confirm failure**
+
+Run: `uv run pytest tests/test_runner.py -v`
+Expected: FAIL with `TypeError: _build_merged_config() missing 1 required positional argument`
+
+- [ ] **Step 2: Fix all 4 test calls by adding `variant_name="vanilla"`**
+
+In `tests/test_runner.py`, add `variant_name="vanilla"` to each of the 4 `_build_merged_config()` calls (lines 60, 72, 85, 99).
+
+- [ ] **Step 3: Run tests to verify fix**
+
+Run: `uv run pytest tests/test_runner.py -v`
+Expected: PASS (all 4 tests)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_runner.py
+git commit -m "fix: add missing variant_name arg to test_runner.py tests"
+```
+
+---
+
+### Task 1: Fix source.git integration — auto-generate Dockerfile + docker-compose for local repos
+
+Harbor expects `environment/Dockerfile` inside each task directory. When missing, nasde should auto-generate it. For local repos (`source.git` is a filesystem path), we also generate `docker-compose.yaml` that overrides the build context to point to the repo root — this is required because Harbor's default build context is the `environment/` directory, but `COPY . /app` needs the repo root.
+
+**Files:**
+- Modify: `src/nasde_toolkit/docker.py`
+- Modify: `src/nasde_toolkit/runner.py`
+- Create: `tests/test_docker.py`
+
+- [ ] **Step 1: Write tests for `generate_dockerfile` with remote URL (validate existing code)**
+
+```python
+# tests/test_docker.py
+from __future__ import annotations
+
+from nasde_toolkit.config import DockerConfig, SourceConfig
+from nasde_toolkit.docker import generate_dockerfile
+
+
+def test_generate_dockerfile_remote_url() -> None:
+    source = SourceConfig(git="https://github.com/org/repo.git", ref="main")
+    docker = DockerConfig(base_image="python:3.12-slim", build_commands=["pip install uv"])
+    result = generate_dockerfile(source, docker)
+    assert "FROM python:3.12-slim" in result
+    assert "git clone https://github.com/org/repo.git" in result
+    assert "git checkout main" in result
+    assert "RUN pip install uv" in result
+```
+
+- [ ] **Step 2: Run test — should pass (existing code)**
+
+Run: `uv run pytest tests/test_docker.py::test_generate_dockerfile_remote_url -v`
+Expected: PASS
+
+- [ ] **Step 3: Write failing tests for local path Dockerfile**
+
+```python
+# tests/test_docker.py (append)
+def test_generate_dockerfile_local_path() -> None:
+    source = SourceConfig(git="/tmp/my-repo", ref="abc1234")
+    docker = DockerConfig(base_image="python:3.12-slim", build_commands=[])
+    result = generate_dockerfile(source, docker)
+    assert "COPY . /app" in result
+    assert "git checkout abc1234" in result
+    assert "git clone" not in result
+
+
+def test_generate_dockerfile_relative_path() -> None:
+    source = SourceConfig(git="../..", ref="7e1a804")
+    docker = DockerConfig(base_image="python:3.12-slim", build_commands=["uv sync"])
+    result = generate_dockerfile(source, docker)
+    assert "COPY . /app" in result
+    assert "git checkout 7e1a804" in result
+    assert "RUN uv sync" in result
+```
+
+- [ ] **Step 4: Run — should fail**
+
+Run: `uv run pytest tests/test_docker.py -v`
+Expected: FAIL — existing `generate_dockerfile` uses `git clone` for all paths
+
+- [ ] **Step 5: Implement local path support in `generate_dockerfile`**
+
+Refactor `src/nasde_toolkit/docker.py`: branch on whether `source.git` is a URL or a local path. Local paths use `COPY . /app` + `git checkout`. Remote paths keep the existing `git clone` behavior.
+
+Key changes:
+- Add `_is_local_path()` helper
+- Split into `_generate_remote_dockerfile()` and `_generate_local_dockerfile()`
+- `_generate_local_dockerfile` uses `COPY . /app` (assumes build context is repo root — enforced by the docker-compose override in Step 9)
+
+- [ ] **Step 6: Run tests — should pass**
+
+Run: `uv run pytest tests/test_docker.py -v`
+Expected: PASS (all 3 tests)
+
+- [ ] **Step 7: Write failing tests for `ensure_task_environment`**
+
+This function generates both Dockerfile AND docker-compose.yaml for local repos.
+
+```python
+# tests/test_docker.py (append)
+from pathlib import Path
+
+from nasde_toolkit.docker import ensure_task_environment
+
+
+def test_ensure_task_environment_existing_dockerfile_skips(tmp_path: Path) -> None:
+    task_dir = tmp_path / "tasks" / "my-task"
+    env_dir = task_dir / "environment"
+    env_dir.mkdir(parents=True)
+    (env_dir / "Dockerfile").write_text("FROM ubuntu:22.04")
+    source = SourceConfig(git="https://example.com/repo.git", ref="main")
+    docker = DockerConfig()
+
+    ensure_task_environment(task_dir, source, docker)
+    assert not (env_dir / "docker-compose.yaml").exists()
+
+
+def test_ensure_task_environment_generates_for_remote(tmp_path: Path) -> None:
+    task_dir = tmp_path / "tasks" / "my-task"
+    task_dir.mkdir(parents=True)
+    source = SourceConfig(git="https://example.com/repo.git", ref="main")
+    docker = DockerConfig(base_image="python:3.12-slim", build_commands=[])
+
+    ensure_task_environment(task_dir, source, docker)
+    dockerfile_path = task_dir / "environment" / "Dockerfile"
+    assert dockerfile_path.exists()
+    assert "git clone" in dockerfile_path.read_text()
+    assert not (task_dir / "environment" / "docker-compose.yaml").exists()
+
+
+def test_ensure_task_environment_generates_compose_for_local(tmp_path: Path) -> None:
+    task_dir = tmp_path / "tasks" / "my-task"
+    task_dir.mkdir(parents=True)
+    source = SourceConfig(git="../..", ref="abc1234")
+    docker = DockerConfig(base_image="python:3.12-slim", build_commands=["uv sync"])
+
+    ensure_task_environment(task_dir, source, docker)
+
+    dockerfile_path = task_dir / "environment" / "Dockerfile"
+    assert dockerfile_path.exists()
+    assert "COPY . /app" in dockerfile_path.read_text()
+
+    compose_path = task_dir / "environment" / "docker-compose.yaml"
+    assert compose_path.exists()
+    compose_content = compose_path.read_text()
+    assert "context:" in compose_content
+
+
+def test_ensure_task_environment_compose_context_resolves_to_repo(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    task_dir = project_dir / "tasks" / "my-task"
+    task_dir.mkdir(parents=True)
+    source = SourceConfig(git="../..", ref="abc1234")
+    docker = DockerConfig()
+
+    ensure_task_environment(task_dir, source, docker)
+
+    compose_path = task_dir / "environment" / "docker-compose.yaml"
+    compose_content = compose_path.read_text()
+    # context path should be relative from environment/ to project_dir/../../
+    # environment/ is at tasks/my-task/environment/ → ../../../.. gets to project_dir/../..
+    assert "../../../.." in compose_content
+```
+
+- [ ] **Step 8: Run — should fail**
+
+Run: `uv run pytest tests/test_docker.py -v -k ensure`
+Expected: FAIL — `ensure_task_environment` doesn't exist
+
+- [ ] **Step 9: Implement `ensure_task_environment`**
+
+Add to `src/nasde_toolkit/docker.py`:
+
+```python
+def ensure_task_environment(
+    task_dir: Path,
+    source: SourceConfig,
+    docker: DockerConfig,
+) -> None:
+    """Generate environment/Dockerfile (and docker-compose.yaml for local repos) if missing."""
+    env_dir = task_dir / "environment"
+    if (env_dir / "Dockerfile").exists():
+        return
+
+    env_dir.mkdir(parents=True, exist_ok=True)
+
+    dockerfile_content = generate_dockerfile(source, docker)
+    (env_dir / "Dockerfile").write_text(dockerfile_content)
+    console.print(f"  [dim]Generated Dockerfile for {task_dir.name}[/dim]")
+
+    if _is_local_path(source.git):
+        compose_content = _generate_build_context_compose(task_dir, source.git)
+        (env_dir / "docker-compose.yaml").write_text(compose_content)
+        console.print(f"  [dim]Generated docker-compose.yaml for local repo build context[/dim]")
+```
+
+And the compose generator:
+
+```python
+def _generate_build_context_compose(task_dir: Path, git_path: str) -> str:
+    """Generate docker-compose.yaml that overrides build context to point to the local repo root.
+
+    Harbor's default build context is environment/. For COPY to see the repo,
+    we override context to the resolved repo path, relative from environment/.
+    """
+    repo_abs = (task_dir / git_path).resolve()
+    env_dir = task_dir / "environment"
+    context_relative = os.path.relpath(repo_abs, env_dir)
+
+    return dedent(f"""\
+        services:
+          main:
+            build:
+              context: {context_relative}
+    """)
+```
+
+Add `import os` at module top.
+
+- [ ] **Step 10: Run all docker tests**
+
+Run: `uv run pytest tests/test_docker.py -v`
+Expected: PASS (all 7 tests)
+
+- [ ] **Step 11: Integrate into runner**
+
+Modify `src/nasde_toolkit/runner.py` — in `run_benchmark()`, after variant resolution and before `_build_merged_config()`:
+
+```python
+from nasde_toolkit.docker import ensure_task_environment
+
+for task in config.tasks:
+    ensure_task_environment(task.path, task.source, config.docker)
+```
+
+- [ ] **Step 12: Run full test suite**
+
+Run: `uv run pytest -x -q`
+Expected: PASS
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add src/nasde_toolkit/docker.py src/nasde_toolkit/runner.py tests/test_docker.py
+git commit -m "feat: auto-generate Dockerfile + docker-compose from source.git
+
+For local repos, generates COPY-based Dockerfile and docker-compose.yaml
+that overrides build context to the repo root. Harbor merges the compose
+file, so COPY sees the full repository.
+
+Enables benchmarks using source.git: '../..' without custom Dockerfile."
+```
+
+---
+
+### Task 2: Download and snapshot external Python skills
+
+Fetch `python-testing` and `python-best-practices` from skills.sh and save as snapshots for deterministic benchmark evaluation.
+
+**Files:**
+- Create: `examples/nasde-dev-skill/variants/nasde-dev-with-arch/skills/python-best-practices/SKILL.md`
+- Create: `examples/nasde-dev-skill/variants/nasde-dev-with-testing/skills/python-testing/SKILL.md`
+- Create: `examples/nasde-dev-skill/variants/nasde-dev-full-stack/skills/python-best-practices/SKILL.md`
+- Create: `examples/nasde-dev-skill/variants/nasde-dev-full-stack/skills/python-testing/SKILL.md`
+
+- [ ] **Step 1: Install skills temporarily to get their content**
+
+```bash
+npx skills add 0xbigboss/claude-code@python-best-practices -g -y
+npx skills add affaan-m/everything-claude-code@python-testing -g -y
+```
+
+- [ ] **Step 2: Find and read the installed skill files**
+
+```bash
+find ~/.claude -name "SKILL.md" -path "*python-best*" 2>/dev/null
+find ~/.claude -name "SKILL.md" -path "*python-testing*" 2>/dev/null
+```
+
+- [ ] **Step 3: Create variant directories and copy skill snapshots**
+
+```bash
+mkdir -p examples/nasde-dev-skill/variants/nasde-dev-with-arch/skills/{nasde-dev,python-best-practices}
+mkdir -p examples/nasde-dev-skill/variants/nasde-dev-with-testing/skills/{nasde-dev,python-testing}
+mkdir -p examples/nasde-dev-skill/variants/nasde-dev-full-stack/skills/{nasde-dev,python-best-practices,python-testing}
+
+# Copy snapshots (replace <path> with actual found paths)
+cp <python-best-practices-path>/SKILL.md examples/nasde-dev-skill/variants/nasde-dev-with-arch/skills/python-best-practices/SKILL.md
+cp <python-best-practices-path>/SKILL.md examples/nasde-dev-skill/variants/nasde-dev-full-stack/skills/python-best-practices/SKILL.md
+
+cp <python-testing-path>/SKILL.md examples/nasde-dev-skill/variants/nasde-dev-with-testing/skills/python-testing/SKILL.md
+cp <python-testing-path>/SKILL.md examples/nasde-dev-skill/variants/nasde-dev-full-stack/skills/python-testing/SKILL.md
+
+cp .claude/skills/nasde-dev/SKILL.md examples/nasde-dev-skill/variants/nasde-dev-with-arch/skills/nasde-dev/SKILL.md
+cp .claude/skills/nasde-dev/SKILL.md examples/nasde-dev-skill/variants/nasde-dev-with-testing/skills/nasde-dev/SKILL.md
+cp .claude/skills/nasde-dev/SKILL.md examples/nasde-dev-skill/variants/nasde-dev-full-stack/skills/nasde-dev/SKILL.md
+```
+
+- [ ] **Step 4: Verify YAML frontmatter on all snapshots**
+
+```bash
+head -5 examples/nasde-dev-skill/variants/*/skills/*/SKILL.md
+```
+
+Each should start with `---` and have `name:` field.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/nasde-dev-skill/variants/*/skills/
+git commit -m "feat: snapshot python-testing and python-best-practices skills
+
+Frozen at 2026-03-23 for deterministic benchmark evaluation.
+Sources: affaan-m/everything-claude-code@python-testing (1.6K installs),
+0xbigboss/claude-code@python-best-practices (802 installs)"
+```
+
+---
+
+### Task 3: Create benchmark project scaffold
+
+Create all static benchmark files per the spec.
+
+**Files:**
+- Create: `examples/nasde-dev-skill/.gitignore`
+- Create: `examples/nasde-dev-skill/nasde.toml`
+- Create: `examples/nasde-dev-skill/assessment_dimensions.json`
+- Create: `examples/nasde-dev-skill/tasks/add-multi-attempt-support/task.json`
+- Create: `examples/nasde-dev-skill/tasks/add-multi-attempt-support/task.toml`
+- Create: `examples/nasde-dev-skill/tasks/add-multi-attempt-support/instruction.md`
+- Create: `examples/nasde-dev-skill/tasks/add-multi-attempt-support/assessment_criteria.md`
+- Create: `examples/nasde-dev-skill/tasks/add-multi-attempt-support/tests/test.sh`
+- Create: `examples/nasde-dev-skill/tasks/add-multi-attempt-support/solution/solve.sh`
+- Create: `examples/nasde-dev-skill/variants/vanilla/CLAUDE.md`
+- Create: `examples/nasde-dev-skill/variants/nasde-dev-with-{arch,testing,full-stack}/CLAUDE.md`
+
+All file contents are specified verbatim in the spec. Copy them exactly.
+
+- [ ] **Step 1: Create .gitignore** — `jobs/` + `tasks/*/environment/` (generated files)
+
+- [ ] **Step 2: Create nasde.toml** — from spec
+
+- [ ] **Step 3: Create assessment_dimensions.json** — from spec (4 × 25 = 100)
+
+- [ ] **Step 4: Create task.json** — from spec (`source.git: "../.."`, no `environment` block)
+
+- [ ] **Step 5: Create task.toml** — from spec
+
+- [ ] **Step 6: Create instruction.md** — from spec
+
+- [ ] **Step 7: Create assessment_criteria.md** — from spec (4 dimensions with rubrics)
+
+- [ ] **Step 8: Create tests/test.sh** — from spec (6 steps), `chmod +x`
+
+- [ ] **Step 9: Create solution/solve.sh** — `git cherry-pick 812b189 --no-commit`, `chmod +x`
+
+- [ ] **Step 10: Create vanilla/CLAUDE.md** — minimal instructions from spec
+
+- [ ] **Step 11: Create shared CLAUDE.md** for the 3 skill variants — from spec
+
+- [ ] **Step 12: Verify directory structure**
+
+```bash
+find examples/nasde-dev-skill -type f | sort
+```
+
+- [ ] **Step 13: Run full test suite**
+
+Run: `uv run pytest -x -q`
+Expected: PASS
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add examples/nasde-dev-skill/
+git commit -m "feat: add nasde-dev-skill benchmark example
+
+First local-repo benchmark: source.git='../..' references nasde-toolkit itself.
+4 variants: vanilla, nasde-dev+arch, nasde-dev+testing, nasde-dev+full-stack.
+Task: implement multi-attempt support (commit 812b189)."
+```
+
+---
+
+### Task 4: Update documentation (CLAUDE.md, README.md, ARCHITECTURE.md)
+
+Document the source.git integration fix and the local-repo benchmark pattern.
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+- Modify: `ARCHITECTURE.md`
+
+- [ ] **Step 1: Update CLAUDE.md** — add note that `environment/Dockerfile` is optional (auto-generated from `source.git` + `[docker]`). Add local path note. Verify `--attempts`/`-n` in CLI reference.
+
+- [ ] **Step 2: Update README.md** — add "Local repo benchmarks" section referencing `examples/nasde-dev-skill/`.
+
+- [ ] **Step 3: Update ARCHITECTURE.md** — add Dockerfile auto-generation path to Docker environment flow.
+
+- [ ] **Step 4: Verify doc consistency**
+
+```bash
+grep -n "source.git\|environment/Dockerfile\|auto-generat" CLAUDE.md README.md ARCHITECTURE.md
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CLAUDE.md README.md ARCHITECTURE.md
+git commit -m "docs: add local-repo benchmark pattern and source.git auto-generation"
+```
+
+---
+
+### Task 5: Verify end-to-end (solution dry run)
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Generate environment files and build Docker image**
+
+```bash
+cd examples/nasde-dev-skill
+uv run python -c "
+from nasde_toolkit.config import load_project_config
+from nasde_toolkit.docker import ensure_task_environment
+config = load_project_config()
+for task in config.tasks:
+    ensure_task_environment(task.path, task.source, config.docker)
+print('Generated OK')
+"
+```
+
+Verify `tasks/add-multi-attempt-support/environment/Dockerfile` and `docker-compose.yaml` were created.
+
+Then build using the generated compose override's context:
+
+```bash
+docker build -t nasde-dev-skill-test \
+  -f tasks/add-multi-attempt-support/environment/Dockerfile \
+  $(cd tasks/add-multi-attempt-support && python -c "
+import yaml
+with open('environment/docker-compose.yaml') as f:
+    c = yaml.safe_load(f)
+print(c['services']['main']['build']['context'])
+")
+```
+
+Or simpler — let docker compose handle it:
+
+```bash
+cd tasks/add-multi-attempt-support
+docker compose -f ../../.venv/lib/python3.12/site-packages/harbor/environments/docker/docker-compose-base.yaml \
+  -f ../../.venv/lib/python3.12/site-packages/harbor/environments/docker/docker-compose-build.yaml \
+  -f environment/docker-compose.yaml build
+```
+
+Expected: Image builds successfully.
+
+- [ ] **Step 2: Run solution + test.sh in container**
+
+```bash
+docker run --rm \
+  -v $(pwd)/tasks/add-multi-attempt-support/solution:/solution \
+  -v $(pwd)/tasks/add-multi-attempt-support/tests:/tests \
+  nasde-dev-skill-test bash -c "
+    mkdir -p /logs/verifier
+    bash /solution/solve.sh
+    bash /tests/test.sh
+    echo 'Reward:' && cat /logs/verifier/reward.txt
+  "
+```
+
+Expected: All 6 test steps pass, reward.txt = 1.
+
+- [ ] **Step 3: Verify nasde config parses**
+
+```bash
+uv run python -c "
+from nasde_toolkit.config import load_project_config
+from pathlib import Path
+config = load_project_config(Path('examples/nasde-dev-skill'))
+print(f'Project: {config.name}')
+print(f'Tasks: {[t.name for t in config.tasks]}')
+print(f'Source: {config.tasks[0].source.git} @ {config.tasks[0].source.ref}')
+"
+```
+
+Expected: Parses OK, source.git="../..".
+
+- [ ] **Step 4: Full test suite**
+
+Run: `uv run pytest -x -q`
+Expected: PASS
+
+- [ ] **Step 5: Push**
+
+```bash
+git push
+```
+
+---
+
+### Task 6 (optional): Full benchmark dry run with Harbor
+
+Requires Docker daemon and ANTHROPIC_API_KEY/CLAUDE_CODE_OAUTH_TOKEN.
+
+- [ ] **Step 1: Run vanilla without eval**
+
+```bash
+source scripts/export_oauth_token.sh
+nasde run --variant vanilla --tasks add-multi-attempt-support --without-eval \
+  -C examples/nasde-dev-skill
+```
+
+Expected: Harbor trial completes, reward 1.0.
+
+- [ ] **Step 2: Run with eval**
+
+```bash
+nasde run --variant vanilla --tasks add-multi-attempt-support \
+  -C examples/nasde-dev-skill
+```
+
+Expected: Assessment scores for all 4 dimensions.
+
+- [ ] **Step 3: Run all variants with Opik**
+
+```bash
+for variant in vanilla nasde-dev-with-arch nasde-dev-with-testing nasde-dev-full-stack; do
+  nasde run --variant $variant --tasks add-multi-attempt-support \
+    --with-opik -C examples/nasde-dev-skill
+done
+```
+
+Expected: 4 traces in Opik with differentiated scores.
+
+- [ ] **Step 4: Critical log analysis**
+
+Inspect for each run:
+- Harbor trial log — errors, warnings, timeout
+- Docker build output — local path handling, compose merge
+- Assessment evaluator log — scoring rationale differentiates variants
+- Agent transcript — evidence of skill usage (ran pytest, checked --help, updated docs)
+- test.sh output — all 6 steps pass

--- a/docs/superpowers/specs/2026-03-20-nasde-dev-skill-benchmark-design.md
+++ b/docs/superpowers/specs/2026-03-20-nasde-dev-skill-benchmark-design.md
@@ -1,0 +1,616 @@
+# Design: nasde-dev-skill Benchmark
+
+Self-testing benchmark for nasde-toolkit that measures whether the `nasde-dev` skill improves agent effectiveness when developing nasde-toolkit itself.
+
+## Prerequisites
+
+### 1. Refocus nasde-dev skill as domain-only (before creating benchmark)
+
+nasde-dev must be purely domain-specific — no generic Python conventions. Generic Python quality is handled by external skills (python-testing, python-best-practices) composed in separate variants.
+
+nasde-dev covers ONLY:
+- **Pre-change analysis** — dependency chain mapping, test baseline, CLI alias collision check
+- **Nasde-specific rules** — lazy imports for harbor/opik/sdk, `@dataclass` modification protocol, Rich console output
+- **Monkeypatch awareness** — evaluator.py SDK patch, CLAUDECODE env var, opik patch
+- **Verification protocol** — pytest, CLI help verification, documentation sync table, e2e benchmark run
+
+This separation enables clean variant combinations that measure the value of each skill layer independently.
+
+### 2. Fix source.git integration (before creating benchmark)
+
+`docker.py:generate_dockerfile()` exists but is never called — `source.git` in task.json is dead metadata. Fix this so the benchmark can use `source.git: "../.."` without a custom Dockerfile.
+
+Implementation:
+1. In the runner pipeline (before Harbor job launch), check if `tasks/<name>/environment/Dockerfile` exists
+2. If missing, call `docker.py:generate_dockerfile(source, docker)` and write to a generated location
+3. For local paths (`source.git` not starting with `http`/`https`/`git`): resolve to absolute path, set Docker build context to the repo root, use `COPY . /app` + `git checkout {ref}` instead of `git clone`
+4. Pass the generated Dockerfile path to Harbor
+
+This unblocks the benchmark's main goal: demonstrating local-repo workflow without custom Dockerfile.
+
+## Task
+
+**Source commit:** `812b189` — "Add multi-attempt support (--attempts/-n) and cloud DNS fix"
+**Before state:** `7e1a804` (parent commit)
+
+The agent starts from the codebase at `7e1a804` and must implement multi-attempt support:
+
+1. Add `--attempts` / `-n` CLI flag to `nasde run` (cli.py)
+2. Propagate `n_attempts` parameter through `run_benchmark()` and `_build_merged_config()` (runner.py)
+3. Generate a deterministic `job_name` with timestamp + variant name
+4. Pass explicit `job_dir` to post-hoc assessment instead of relying on `_find_latest_job()`
+5. Add DNS resolution fix for cloud sandboxes in `ConfigurableClaude` (configurable_claude.py)
+6. Update CLI header display to show attempts count
+
+## Project structure
+
+```
+examples/nasde-dev-skill/
+  .gitignore                    # jobs/
+  nasde.toml
+  assessment_dimensions.json
+  tasks/
+    add-multi-attempt-support/
+      task.json
+      task.toml
+      instruction.md
+      assessment_criteria.md
+      tests/test.sh
+      solution/solve.sh
+  variants/
+    vanilla/
+      CLAUDE.md
+    nasde-dev-with-arch/                  # domain + code architecture
+      CLAUDE.md
+      skills/
+        nasde-dev/SKILL.md                # domain knowledge (nasde-specific)
+        python-best-practices/SKILL.md    # type-first, dataclasses, error handling, module structure
+    nasde-dev-with-testing/               # domain + testing methodology
+      CLAUDE.md
+      skills/
+        nasde-dev/SKILL.md
+        python-testing/SKILL.md           # pytest, TDD, fixtures, mocking, async testing
+    nasde-dev-full-stack/                 # domain + architecture + testing
+      CLAUDE.md
+      skills/
+        nasde-dev/SKILL.md
+        python-best-practices/SKILL.md
+        python-testing/SKILL.md
+```
+
+This structure showcases nasde's variant system: same task, different skill combinations, measurable impact. Users see how to compose domain-specific + generic skills in their own benchmarks.
+
+No `environment/Dockerfile` — uses auto-generated Dockerfile from `source.git: "../.."` (the source.git fix above).
+
+## nasde.toml
+
+```toml
+[project]
+name = "nasde-dev-skill"
+version = "1.0.0"
+
+[defaults]
+variant = "vanilla"
+model = "claude-sonnet-4-6"
+timeout_sec = 1800
+
+[docker]
+base_image = "python:3.12-slim"
+build_commands = [
+  "pip install uv",
+  "uv sync",
+  "nasde --version",
+]
+
+[evaluation]
+model = "claude-sonnet-4-6"
+dimensions_file = "assessment_dimensions.json"
+
+[reporting]
+platform = "opik"
+project_name = "nasde-dev-skill"
+```
+
+## assessment_dimensions.json
+
+```json
+{
+  "dimensions": [
+    {
+      "name": "verification_discipline",
+      "title": "Verification Discipline",
+      "max_score": 25,
+      "description": "Agent ran tests before and after changes, verified CLI help output, checked that flag parses correctly, did not leave regressions. Evidence of systematic verification in the workspace."
+    },
+    {
+      "name": "code_conventions",
+      "title": "Code Conventions",
+      "max_score": 25,
+      "description": "Lazy imports for heavy deps (harbor/opik/sdk inside functions), Typer option patterns match existing style (Optional with None default), Rich console output (no bare print), error handling follows project patterns."
+    },
+    {
+      "name": "architecture_quality",
+      "title": "Architecture Quality",
+      "max_score": 25,
+      "description": "Deterministic job naming with timestamp+variant, explicit job_dir passed to assessment eval instead of latest-job heuristic, DNS resolution fix conditional and before super().setup(), n_attempts propagated through full chain."
+    },
+    {
+      "name": "documentation_completeness",
+      "title": "Documentation Completeness",
+      "max_score": 25,
+      "description": "CLAUDE.md CLI reference updated with --attempts flag, README.md CLI options table updated, help text is clear and descriptive, header display shows attempts count, ARCHITECTURE.md updated if pipeline flow changed."
+    }
+  ]
+}
+```
+
+Dimensions are designed to differentiate skill value:
+- **verification_discipline** — nasde-dev mandates "run pytest before coding" and "verify --help output"; python-testing adds TDD methodology
+- **code_conventions** — nasde-dev knows lazy import rule; python-best-practices knows type-first and dataclass patterns
+- **architecture_quality** — nasde-dev knows the module dependency chain; python-best-practices knows module structure principles
+- **documentation_completeness** — nasde-dev has the doc sync table with section-level specifics
+
+## task.json
+
+```json
+{
+  "name": "add-multi-attempt-support",
+  "description": "Add --attempts/-n CLI flag for multiple independent trial attempts per task, with deterministic job naming and cloud DNS fix",
+  "difficulty": "intermediate",
+  "estimated_time_minutes": 30,
+  "tags": ["python", "cli", "typer", "async", "harbor-integration"],
+  "source": {
+    "git": "../..",
+    "ref": "7e1a804"
+  },
+  "instruction": "./instruction.md",
+  "evaluation": {
+    "type": "script",
+    "script": "./tests/test.sh",
+    "timeout_seconds": 300
+  },
+  "metadata": {
+    "language": "Python",
+    "framework": "Typer + Harbor",
+    "source_commit": "812b189"
+  }
+}
+```
+
+No `environment` block — nasde auto-generates Dockerfile from `source.git` + `[docker]` config in nasde.toml.
+
+## task.toml
+
+```toml
+version = "1.0"
+
+[metadata]
+name = "add-multi-attempt-support"
+description = "Add --attempts/-n flag for multiple independent trial attempts per task"
+difficulty = "intermediate"
+language = "Python"
+framework = "Typer + Harbor"
+
+[agent]
+timeout_sec = 1800
+
+[verifier]
+timeout_sec = 300
+```
+
+## instruction.md
+
+```markdown
+# Task: Add Multi-Attempt Support to nasde CLI
+
+## Context
+
+You are working in `/app`, a Python toolkit called `nasde-toolkit` (Noesis Agentic Software Development Evals). The CLI entry point is `nasde`, built with Typer. The main command `nasde run` executes benchmark tasks via the Harbor evaluation framework.
+
+Key files:
+- `src/nasde_toolkit/cli.py` — Typer CLI definitions
+- `src/nasde_toolkit/runner.py` — Harbor job execution and config merging
+- `src/nasde_toolkit/agents/configurable_claude.py` — Custom Harbor agent with sandbox file injection
+
+Read `CLAUDE.md` in the project root for architecture details.
+
+## Requirement
+
+Currently `nasde run` executes each task exactly once. Users need to run multiple independent attempts per task to measure variance in agent performance (e.g., `nasde run -n 3` runs 3 independent trials per task).
+
+Implement:
+
+1. **CLI flag**: Add `--attempts` / `-n` option to `nasde run` (integer, default 1)
+2. **Runner propagation**: Pass the attempts count through `run_benchmark()` into the Harbor `JobConfig` as `n_attempts`
+3. **Deterministic job naming**: Generate a predictable job directory name using the format `{YYYY-MM-DD__%H-%M-%S}__{variant_name}` so that multiple runs don't collide and are easy to identify
+4. **Explicit job directory**: After the Harbor job completes, pass the specific job directory to post-hoc assessment evaluation instead of relying on the "find latest job" heuristic (which breaks when multiple jobs run close together)
+5. **Cloud DNS fix**: Cloud sandbox providers (like Daytona) sometimes have DNS resolvers that cannot reach whitelisted domains. Add a DNS resolution fix to `ConfigurableClaude.setup()` that prepends public DNS resolvers (e.g., 8.8.8.8, 1.1.1.1) to `/etc/resolv.conf` if the default resolver fails to resolve `claude.ai`
+6. **Display**: Update the CLI header panel to show the attempts count
+
+## Scope
+
+- Modify: `cli.py`, `runner.py`, `configurable_claude.py`
+- Do NOT modify: `config.py`, `evaluator.py`, `docker.py`, test files
+- Do NOT change existing CLI flags or their defaults
+
+## Quality Expectations
+
+- Follow the existing Typer option patterns in `cli.py` (see `--variant`, `--model`, etc.)
+- Match the runner's function signature style (keyword arguments with defaults)
+- The DNS fix should be conditional — only apply if default DNS fails
+- Keep changes minimal and focused
+
+## Success Criteria
+
+1. `nasde run --help` shows `--attempts` / `-n` flag with help text
+2. Running with `-n 2` would create a Harbor job with `n_attempts: 2` in the config
+3. Job directory name follows `{timestamp}__{variant}` format
+4. Assessment evaluation targets the specific job directory, not "latest"
+5. `ConfigurableClaude` has DNS fix that runs before base setup
+6. CLI header panel displays the attempts count
+```
+
+## assessment_criteria.md
+
+```markdown
+# Assessment Criteria: Add Multi-Attempt Support
+
+Evaluate the agent's solution across the following dimensions.
+
+## 1. Verification Discipline (0-25)
+
+| Score | Criteria |
+|-------|----------|
+| 0     | No evidence of testing or verification |
+| 8     | Tests pass but no evidence agent ran them proactively |
+| 15    | Agent ran pytest, code works, no regressions |
+| 20    | Agent verified CLI help output, tested flag parsing, ran pytest before and after |
+| 25    | Systematic verification: test baseline before coding, CLI help check, flag parse test, regression check, all passing |
+
+**Key checks:**
+- Evidence in workspace that agent ran `uv run pytest` (look for test output in agent logs)
+- Evidence agent checked `nasde run --help` after adding flag
+- No pre-existing tests broken by the change
+- Agent wrote new tests for the feature (bonus, not required for pass)
+
+## 2. Code Conventions (0-25)
+
+| Score | Criteria |
+|-------|----------|
+| 0     | Code doesn't follow project patterns at all |
+| 8     | Basic implementation works but ignores project conventions |
+| 15    | Follows some conventions — Typer option exists, reasonable style |
+| 20    | Clean adherence: lazy imports for heavy deps, Typer Optional+None pattern, Rich console, keyword args with defaults |
+| 25    | Perfect: indistinguishable from existing code style, including import ordering, parameter naming, error message formatting |
+
+**Key checks:**
+- Harbor/Opik/SDK imports are inside functions, not at module level
+- Typer option uses `Optional[int]` with `None` default or `int` with `1` default (matches existing flag patterns)
+- No bare `print()` — all output via `console.print()` with Rich markup
+- `run_benchmark()` and `_build_merged_config()` parameter style matches existing functions
+
+## 3. Architecture Quality (0-25)
+
+| Score | Criteria |
+|-------|----------|
+| 0     | Only basic flag added, no architectural consideration |
+| 8     | n_attempts propagated but no job naming or job_dir improvements |
+| 13    | Deterministic job naming OR explicit job_dir (one of two) |
+| 18    | Both job naming and explicit job_dir present |
+| 25    | Job naming + job_dir + DNS fix in ConfigurableClaude (conditional, before super().setup()) |
+
+**Key checks:**
+- `job_name` uses `{datetime}__{variant}` or similar deterministic format
+- `_run_post_hoc_assessment()` accepts and uses explicit `job_dir` (not latest-job heuristic)
+- DNS fix checks resolution before applying (conditional, not always overwriting)
+- DNS fix runs before `super().setup()` (order matters for cloud environments)
+- n_attempts flows: CLI → run_benchmark() → _build_merged_config() → Harbor dict
+
+## 4. Documentation Completeness (0-25)
+
+| Score | Criteria |
+|-------|----------|
+| 0     | No documentation changes |
+| 8     | CLI header display updated with attempts count |
+| 13    | Header updated + CLAUDE.md CLI reference mentions --attempts/-n |
+| 18    | Header + CLAUDE.md + README.md CLI options table updated |
+| 22    | All three docs + help text is descriptive and consistent with other flags |
+| 25    | All docs updated (CLAUDE.md, README.md, header, help text), ARCHITECTURE.md updated if pipeline flow changed |
+
+**Key checks:**
+- `_print_run_header()` displays attempts count in the Rich Panel
+- `CLAUDE.md` "CLI reference" section includes `--attempts` / `-n` with description
+- `README.md` CLI options table includes `--attempts` / `-n`
+- Help text for the flag is descriptive (sentence case, matches style of --variant, --model)
+- ARCHITECTURE.md updated if the job naming or assessment eval targeting changed the pipeline flow
+```
+
+## tests/test.sh
+
+```bash
+#!/bin/bash
+
+echo "=========================================="
+echo "Multi-Attempt Support - Evaluation"
+echo "=========================================="
+echo ""
+
+cd /app
+
+echo "Step 1: CLI flag exists with correct help text..."
+echo "--------------------------------------"
+HELP_OUTPUT=$(nasde run --help 2>&1)
+if echo "$HELP_OUTPUT" | grep -q "\-\-attempts" && echo "$HELP_OUTPUT" | grep -q "\-n"; then
+    echo "OK: --attempts and -n flags found in CLI help"
+else
+    echo "FAIL: --attempts/-n flag not found in nasde run --help"
+    echo 0 > /logs/verifier/reward.txt
+    exit 1
+fi
+if echo "$HELP_OUTPUT" | grep -qi "attempt\|independent.*per task\|number.*attempt"; then
+    echo "OK: Help text is descriptive"
+else
+    echo "FAIL: Help text missing or not descriptive for --attempts"
+    echo 0 > /logs/verifier/reward.txt
+    exit 1
+fi
+echo ""
+
+echo "Step 2: CLI flag actually parses..."
+echo "--------------------------------------"
+if nasde run --attempts 3 --help >/dev/null 2>&1; then
+    echo "OK: --attempts 3 parses without error"
+else
+    echo "FAIL: --attempts flag does not parse correctly"
+    echo 0 > /logs/verifier/reward.txt
+    exit 1
+fi
+if nasde run -n 2 --help >/dev/null 2>&1; then
+    echo "OK: -n 2 short alias parses without error"
+else
+    echo "FAIL: -n short alias does not parse correctly"
+    echo 0 > /logs/verifier/reward.txt
+    exit 1
+fi
+echo ""
+
+echo "Step 3: Running Python tests..."
+echo "--------------------------------------"
+TEST_OUTPUT=$(uv run pytest -x -q 2>&1)
+TEST_EXIT=$?
+echo "$TEST_OUTPUT"
+echo ""
+if [ $TEST_EXIT -eq 0 ]; then
+    echo "OK: All tests pass"
+else
+    echo "FAIL: Unit tests failed (exit code $TEST_EXIT)"
+    echo "Review test output above for details"
+    echo 0 > /logs/verifier/reward.txt
+    exit 1
+fi
+echo ""
+
+echo "Step 4: run_benchmark accepts n_attempts parameter..."
+echo "--------------------------------------"
+if python -c "
+import inspect
+from nasde_toolkit.runner import run_benchmark
+sig = inspect.signature(run_benchmark)
+assert 'n_attempts' in sig.parameters, f'n_attempts not in signature: {list(sig.parameters.keys())}'
+param = sig.parameters['n_attempts']
+assert param.default == 1, f'Default should be 1, got {param.default}'
+print('run_benchmark(n_attempts=1) signature OK')
+"; then
+    echo "OK: run_benchmark accepts n_attempts with default=1"
+else
+    echo "FAIL: run_benchmark does not accept n_attempts parameter"
+    echo 0 > /logs/verifier/reward.txt
+    exit 1
+fi
+echo ""
+
+echo "Step 5: ConfigurableClaude imports correctly..."
+echo "--------------------------------------"
+if python -c "
+from nasde_toolkit.agents.configurable_claude import ConfigurableClaude
+print(f'ConfigurableClaude loaded: {ConfigurableClaude.name()}')
+"; then
+    echo "OK: ConfigurableClaude imports successfully"
+else
+    echo "FAIL: ConfigurableClaude import failed"
+    echo 0 > /logs/verifier/reward.txt
+    exit 1
+fi
+echo ""
+
+echo "Step 6: Documentation updated (CLAUDE.md and README.md)..."
+echo "--------------------------------------"
+if grep -q "\-\-attempts" CLAUDE.md 2>/dev/null; then
+    echo "OK: CLAUDE.md mentions --attempts"
+else
+    echo "FAIL: CLAUDE.md does not mention --attempts flag"
+    echo 0 > /logs/verifier/reward.txt
+    exit 1
+fi
+if grep -q "\-\-attempts" README.md 2>/dev/null; then
+    echo "OK: README.md mentions --attempts"
+else
+    echo "FAIL: README.md does not mention --attempts flag"
+    echo 0 > /logs/verifier/reward.txt
+    exit 1
+fi
+echo ""
+
+echo "=========================================="
+echo "EVALUATION PASSED"
+echo "=========================================="
+echo 1 > /logs/verifier/reward.txt
+exit 0
+```
+
+## solution/solve.sh
+
+```bash
+#!/bin/bash
+cd /app
+git cherry-pick 812b189 --no-commit
+```
+
+## Variants
+
+All skill variants share the same CLAUDE.md (below). They differ only in which skills are injected.
+
+### Shared CLAUDE.md (all non-vanilla variants)
+
+```markdown
+# Agent Instructions
+
+## Approach
+
+1. Before writing any code, explore the existing codebase to understand its architecture and conventions.
+2. Follow existing architectural patterns exactly — match naming, namespaces, directory structure, and code style.
+3. Read CLAUDE.md in the project root for full architecture documentation.
+4. After making changes, verify documentation is consistent (CLAUDE.md, README.md, ARCHITECTURE.md).
+```
+
+### vanilla/CLAUDE.md
+
+```markdown
+# Agent Instructions
+
+You are a coding assistant. Work in /app.
+
+1. Follow existing patterns in the codebase.
+2. Read CLAUDE.md for project context.
+```
+
+### Variant skill composition
+
+| Variant | Skills | What it tests |
+|---|---|---|
+| `vanilla` | none | Baseline — raw agent capability |
+| `nasde-dev-with-arch` | nasde-dev + python-best-practices | Domain knowledge + code architecture (type-first, dataclasses, error handling, module structure) |
+| `nasde-dev-with-testing` | nasde-dev + python-testing | Domain knowledge + testing methodology (pytest, TDD, fixtures, mocking, async testing) |
+| `nasde-dev-full-stack` | nasde-dev + python-best-practices + python-testing | All three — domain + architecture + testing |
+
+### Hypotheses to measure
+
+- **vanilla vs any** → baseline value of skills
+- **nasde-dev-with-arch vs nasde-dev-with-testing** → architecture knowledge vs testing methodology — which matters more for this task?
+- **nasde-dev-full-stack vs 2-skill variants** → does the third skill add value or cause diminishing returns / context noise?
+
+### Skill sources
+
+| Skill | Source | Installs | What it provides |
+|---|---|---|---|
+| `nasde-dev` | `.claude/skills/nasde-dev/SKILL.md` (this repo) | — | Domain-only: module dependency chain, dataclass protocol, lazy imports, monkeypatch awareness, verification protocol with doc sync table |
+| `python-best-practices` | `0xbigboss/claude-code@python-best-practices` (skills.sh) | 802 | Type-first development, frozen dataclasses, discriminated unions, Protocol, module structure (<300 lines), error handling with `from err`, Config.from_env() |
+| `python-testing` | `affaan-m/everything-claude-code@python-testing` (skills.sh) | 1.6K | TDD (red-green-refactor), pytest fixtures (scopes, conftest), parametrize, mocking (@patch, autospec), async testing (pytest-asyncio), 80%+ coverage target |
+
+Skills are snapshots (frozen at benchmark creation time) to ensure deterministic evaluation across runs.
+
+## Key design decisions
+
+1. **First local-repo benchmark example:** This is the primary goal. Users need a working pattern for building benchmarks from local/private repositories — not just from public GitHub URLs. `source.git: "../.."` demonstrates this flow. All existing examples use public GitHub repos; this fills a critical documentation gap.
+
+2. **No custom Dockerfile:** Uses auto-generated Dockerfile from `source.git: "../.."` + `[docker]` in nasde.toml. This requires the source.git integration fix (see Prerequisites). The benchmark is an integration test for that fix.
+
+3. **No Harbor execution in tests:** test.sh validates structure and imports only. Running Harbor would require DinD which adds complexity without proportional value.
+
+4. **DNS fix included in scope:** The commit includes a DNS fix in `configurable_claude.py`. This is harder to discover without the skill's structural knowledge of the agents/ directory.
+
+5. **Deterministic job naming as architecture test:** Tests whether the agent understands why explicit naming matters (Opik tagging, assessment eval targeting the right job).
+
+## End-to-end verification protocol
+
+After implementation, run the full verification to confirm the benchmark works:
+
+### 1. Single-task dry run (no eval, no Opik)
+
+```bash
+nasde run --variant vanilla --tasks add-multi-attempt-support --without-eval \
+  -C examples/nasde-dev-skill
+```
+
+Verify:
+- Docker image builds successfully from local repo (source.git integration works)
+- Harbor trial completes
+- `/logs/verifier/reward.txt` contains `1`
+
+### 2. Full run with assessment evaluation
+
+```bash
+source scripts/export_oauth_token.sh
+nasde run --variant vanilla --tasks add-multi-attempt-support \
+  -C examples/nasde-dev-skill
+```
+
+Verify:
+- Assessment evaluation produces scores for all 4 dimensions
+- `assessment_eval.json` exists in the trial directory
+- Scores are reasonable (reference solution should score near-max)
+
+### 3. Full run with Opik tracing
+
+```bash
+nasde run --variant vanilla --tasks add-multi-attempt-support \
+  --with-opik -C examples/nasde-dev-skill
+```
+
+Verify via Opik REST API:
+```bash
+source .env
+python3 -c "
+import urllib.request, json
+req = urllib.request.Request(
+    'https://www.comet.com/opik/api/v1/private/traces?project_name=nasde-dev-skill&limit=1',
+    headers={
+        'authorization': '$OPIK_API_KEY',
+        'Comet-Workspace': '$OPIK_WORKSPACE',
+    },
+)
+resp = json.loads(urllib.request.urlopen(req).read())
+trace = resp['content'][0]
+scores = trace.get('feedback_scores', [])
+print(f'Feedback scores ({len(scores)}):')
+for s in sorted(scores, key=lambda x: x['name']):
+    print(f'  {s[\"name\"]}: {s[\"value\"]}')
+"
+```
+
+Expected: `arch_*` scores for each dimension, `arch_total`, `reward`, `duration_sec`.
+
+### 4. All-variant comparison
+
+Run all 4 variants:
+
+```bash
+source scripts/export_oauth_token.sh
+for variant in vanilla nasde-dev-with-arch nasde-dev-with-testing nasde-dev-full-stack; do
+  nasde run --variant $variant --tasks add-multi-attempt-support \
+    --with-opik -C examples/nasde-dev-skill
+done
+```
+
+Compare scores across dimensions in Opik:
+- `verification_discipline` — expect nasde-dev-with-testing and full-stack to score highest (python-testing teaches TDD)
+- `code_conventions` — expect nasde-dev-with-arch and full-stack to score highest (python-best-practices teaches type-first + module patterns)
+- `documentation_completeness` — expect all nasde-dev variants to beat vanilla (nasde-dev has the doc sync table)
+- `architecture_quality` — expect nasde-dev variants to beat vanilla (nasde-dev knows the module dependency chain)
+
+### 5. Critical log analysis
+
+After each run, inspect:
+- **Harbor trial log** — errors, warnings, agent timeout
+- **Docker build output** — source.git / local path handling (verify the fix works)
+- **Assessment evaluator log** — dimension scoring rationale (verify the LLM judge differentiates variants)
+- **Agent transcript** — did the agent actually use the skills? (look for evidence of running pytest, checking --help, updating docs)
+- **test.sh output** — all 6 steps must pass; check for edge cases in CLI help parsing and doc grep
+
+## Documentation updates (part of implementation)
+
+This work includes updating nasde-toolkit documentation:
+
+1. **CLAUDE.md** — Add `source.git` with local path to task.json format docs. Add note that `environment/Dockerfile` is optional when `source.git` + `[docker]` config are sufficient.
+2. **README.md** — Add "Local repo benchmarks" example showing how to build a benchmark from a private/local repository.
+3. **ARCHITECTURE.md** — Update Docker environment diagram if the source.git auto-generation flow changes the pipeline.

--- a/examples/nasde-dev-skill/.gitignore
+++ b/examples/nasde-dev-skill/.gitignore
@@ -1,0 +1,3 @@
+jobs/
+tasks/*/environment/
+variants/*/harbor_config.json

--- a/examples/nasde-dev-skill/assessment_dimensions.json
+++ b/examples/nasde-dev-skill/assessment_dimensions.json
@@ -1,0 +1,28 @@
+{
+  "dimensions": [
+    {
+      "name": "verification_discipline",
+      "title": "Verification Discipline",
+      "max_score": 25,
+      "description": "Agent ran tests before and after changes, verified CLI help output, checked that flag parses correctly, did not leave regressions. Evidence of systematic verification in the workspace."
+    },
+    {
+      "name": "code_conventions",
+      "title": "Code Conventions",
+      "max_score": 25,
+      "description": "Lazy imports for heavy deps (harbor/opik/sdk inside functions), Typer option patterns match existing style (Optional with None default), Rich console output (no bare print), error handling follows project patterns."
+    },
+    {
+      "name": "architecture_quality",
+      "title": "Architecture Quality",
+      "max_score": 25,
+      "description": "Deterministic job naming with timestamp+variant, explicit job_dir passed to assessment eval instead of latest-job heuristic, DNS resolution fix conditional and before super().setup(), n_attempts propagated through full chain."
+    },
+    {
+      "name": "documentation_completeness",
+      "title": "Documentation Completeness",
+      "max_score": 25,
+      "description": "CLAUDE.md CLI reference updated with --attempts flag, README.md CLI options table updated, help text is clear and descriptive, header display shows attempts count, ARCHITECTURE.md updated if pipeline flow changed."
+    }
+  ]
+}

--- a/examples/nasde-dev-skill/nasde.toml
+++ b/examples/nasde-dev-skill/nasde.toml
@@ -1,0 +1,24 @@
+[project]
+name = "nasde-dev-skill"
+version = "1.0.0"
+
+[defaults]
+variant = "vanilla"
+model = "claude-sonnet-4-6"
+timeout_sec = 1800
+
+[docker]
+base_image = "python:3.12-slim"
+build_commands = [
+  "pip install uv",
+  "uv tool install .",
+  "nasde --version",
+]
+
+[evaluation]
+model = "claude-sonnet-4-6"
+dimensions_file = "assessment_dimensions.json"
+
+[reporting]
+platform = "opik"
+project_name = "nasde-dev-skill"

--- a/examples/nasde-dev-skill/tasks/add-multi-attempt-support/assessment_criteria.md
+++ b/examples/nasde-dev-skill/tasks/add-multi-attempt-support/assessment_criteria.md
@@ -1,0 +1,70 @@
+# Assessment Criteria: Add Multi-Attempt Support
+
+Evaluate the agent's solution across the following dimensions.
+
+## 1. Verification Discipline (0-25)
+
+| Score | Criteria |
+|-------|----------|
+| 0     | No evidence of testing or verification |
+| 8     | Tests pass but no evidence agent ran them proactively |
+| 15    | Agent ran pytest, code works, no regressions |
+| 20    | Agent verified CLI help output, tested flag parsing, ran pytest before and after |
+| 25    | Systematic verification: test baseline before coding, CLI help check, flag parse test, regression check, all passing |
+
+**Key checks:**
+- Evidence in workspace that agent ran `uv run pytest` (look for test output in agent logs)
+- Evidence agent checked `nasde run --help` after adding flag
+- No pre-existing tests broken by the change
+- Agent wrote new tests for the feature (bonus, not required for pass)
+
+## 2. Code Conventions (0-25)
+
+| Score | Criteria |
+|-------|----------|
+| 0     | Code doesn't follow project patterns at all |
+| 8     | Basic implementation works but ignores project conventions |
+| 15    | Follows some conventions — Typer option exists, reasonable style |
+| 20    | Clean adherence: lazy imports for heavy deps, Typer Optional+None pattern, Rich console, keyword args with defaults |
+| 25    | Perfect: indistinguishable from existing code style, including import ordering, parameter naming, error message formatting |
+
+**Key checks:**
+- Harbor/Opik/SDK imports are inside functions, not at module level
+- Typer option uses `Optional[int]` with `None` default or `int` with `1` default (matches existing flag patterns)
+- No bare `print()` — all output via `console.print()` with Rich markup
+- `run_benchmark()` and `_build_merged_config()` parameter style matches existing functions
+
+## 3. Architecture Quality (0-25)
+
+| Score | Criteria |
+|-------|----------|
+| 0     | Only basic flag added, no architectural consideration |
+| 8     | n_attempts propagated but no job naming or job_dir improvements |
+| 13    | Deterministic job naming OR explicit job_dir (one of two) |
+| 18    | Both job naming and explicit job_dir present |
+| 25    | Job naming + job_dir + DNS fix in ConfigurableClaude (conditional, before super().setup()) |
+
+**Key checks:**
+- `job_name` uses `{datetime}__{variant}` or similar deterministic format
+- `_run_post_hoc_assessment()` accepts and uses explicit `job_dir` (not latest-job heuristic)
+- DNS fix checks resolution before applying (conditional, not always overwriting)
+- DNS fix runs before `super().setup()` (order matters for cloud environments)
+- n_attempts flows: CLI → run_benchmark() → _build_merged_config() → Harbor dict
+
+## 4. Documentation Completeness (0-25)
+
+| Score | Criteria |
+|-------|----------|
+| 0     | No documentation changes |
+| 8     | CLI header display updated with attempts count |
+| 13    | Header updated + CLAUDE.md CLI reference mentions --attempts/-n |
+| 18    | Header + CLAUDE.md + README.md CLI options table updated |
+| 22    | All three docs + help text is descriptive and consistent with other flags |
+| 25    | All docs updated (CLAUDE.md, README.md, header, help text), ARCHITECTURE.md updated if pipeline flow changed |
+
+**Key checks:**
+- `_print_run_header()` displays attempts count in the Rich Panel
+- `CLAUDE.md` "CLI reference" section includes `--attempts` / `-n` with description
+- `README.md` CLI options table includes `--attempts` / `-n`
+- Help text for the flag is descriptive (sentence case, matches style of --variant, --model)
+- ARCHITECTURE.md updated if the job naming or assessment eval targeting changed the pipeline flow

--- a/examples/nasde-dev-skill/tasks/add-multi-attempt-support/instruction.md
+++ b/examples/nasde-dev-skill/tasks/add-multi-attempt-support/instruction.md
@@ -1,0 +1,48 @@
+# Task: Add Multi-Attempt Support to nasde CLI
+
+## Context
+
+You are working in `/app`, a Python toolkit called `nasde-toolkit` (Noesis Agentic Software Development Evals). The CLI entry point is `nasde`, built with Typer. The main command `nasde run` executes benchmark tasks via the Harbor evaluation framework.
+
+Key files:
+- `src/nasde_toolkit/cli.py` — Typer CLI definitions
+- `src/nasde_toolkit/runner.py` — Harbor job execution and config merging
+- `src/nasde_toolkit/agents/configurable_claude.py` — Custom Harbor agent with sandbox file injection
+
+Read `CLAUDE.md` in the project root for architecture details.
+
+## Requirement
+
+Currently `nasde run` executes each task exactly once. Users need to run multiple independent attempts per task to measure variance in agent performance (e.g., `nasde run -n 3` runs 3 independent trials per task).
+
+Implement:
+
+1. **CLI flag**: Add `--attempts` / `-n` option to `nasde run` (integer, default 1)
+2. **Runner propagation**: Pass the attempts count through `run_benchmark()` into the Harbor `JobConfig` as `n_attempts`
+3. **Deterministic job naming**: Generate a predictable job directory name using the format `{YYYY-MM-DD__%H-%M-%S}__{variant_name}` so that multiple runs don't collide and are easy to identify
+4. **Explicit job directory**: After the Harbor job completes, pass the specific job directory to post-hoc assessment evaluation instead of relying on the "find latest job" heuristic (which breaks when multiple jobs run close together)
+5. **Cloud DNS fix**: Cloud sandbox providers (like Daytona) sometimes have DNS resolvers that cannot reach whitelisted domains. Add a DNS resolution fix to `ConfigurableClaude.setup()` that prepends public DNS resolvers (e.g., 8.8.8.8, 1.1.1.1) to `/etc/resolv.conf` if the default resolver fails to resolve `claude.ai`
+6. **Display**: Update the CLI header panel to show the attempts count
+
+## Scope
+
+- Modify: `cli.py`, `runner.py`, `configurable_claude.py`
+- Do NOT modify: `config.py`, `evaluator.py`, `docker.py`, test files
+- Do NOT change existing CLI flags or their defaults
+
+## Quality Expectations
+
+- Follow the existing Typer option patterns in `cli.py` (see `--variant`, `--model`, etc.)
+- Match the runner's function signature style (keyword arguments with defaults)
+- The DNS fix should be conditional — only apply if default DNS fails
+- Keep changes minimal and focused
+
+## Success Criteria
+
+1. `nasde run --help` shows `--attempts` / `-n` flag with help text
+2. Running with `-n 2` would create a Harbor job with `n_attempts: 2` in the config
+3. Job directory name follows `{timestamp}__{variant}` format
+4. Assessment evaluation targets the specific job directory, not "latest"
+5. `ConfigurableClaude` has DNS fix that runs before base setup
+6. CLI header panel displays the attempts count
+7. README.md CLI options table includes `--attempts` flag

--- a/examples/nasde-dev-skill/tasks/add-multi-attempt-support/solution/solve.sh
+++ b/examples/nasde-dev-skill/tasks/add-multi-attempt-support/solution/solve.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+cd /app
+
+git cherry-pick 812b189 --no-commit 2>/dev/null || true
+
+if ! grep -q "\-\-attempts" CLAUDE.md 2>/dev/null; then
+    sed -i '/--without-eval/a\  --attempts INT                       # Number of independent attempts per task (default: 1)\n  -n INT                               # Short alias for --attempts' CLAUDE.md
+fi
+
+if ! grep -q "\-\-attempts" README.md 2>/dev/null; then
+    sed -i '/--without-eval/a\| `--attempts` / `-n` | Number of independent attempts per task (default: 1) |' README.md
+fi

--- a/examples/nasde-dev-skill/tasks/add-multi-attempt-support/task.json
+++ b/examples/nasde-dev-skill/tasks/add-multi-attempt-support/task.json
@@ -1,0 +1,22 @@
+{
+  "name": "add-multi-attempt-support",
+  "description": "Add --attempts/-n CLI flag for multiple independent trial attempts per task, with deterministic job naming and cloud DNS fix",
+  "difficulty": "intermediate",
+  "estimated_time_minutes": 30,
+  "tags": ["python", "cli", "typer", "async", "harbor-integration"],
+  "source": {
+    "git": "../../../..",
+    "ref": "7e1a804"
+  },
+  "instruction": "./instruction.md",
+  "evaluation": {
+    "type": "script",
+    "script": "./tests/test.sh",
+    "timeout_seconds": 300
+  },
+  "metadata": {
+    "language": "Python",
+    "framework": "Typer + Harbor",
+    "source_commit": "812b189"
+  }
+}

--- a/examples/nasde-dev-skill/tasks/add-multi-attempt-support/task.toml
+++ b/examples/nasde-dev-skill/tasks/add-multi-attempt-support/task.toml
@@ -1,0 +1,14 @@
+version = "1.0"
+
+[metadata]
+name = "add-multi-attempt-support"
+description = "Add --attempts/-n flag for multiple independent trial attempts per task"
+difficulty = "intermediate"
+language = "Python"
+framework = "Typer + Harbor"
+
+[agent]
+timeout_sec = 1800
+
+[verifier]
+timeout_sec = 300

--- a/examples/nasde-dev-skill/tasks/add-multi-attempt-support/tests/test.sh
+++ b/examples/nasde-dev-skill/tasks/add-multi-attempt-support/tests/test.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+echo "=========================================="
+echo "Multi-Attempt Support - Evaluation"
+echo "=========================================="
+echo ""
+
+cd /app
+
+# Reinstall from source so agent edits are picked up
+uv tool install . --force 2>/dev/null
+
+echo "Step 1: CLI flag exists with correct help text..."
+echo "--------------------------------------"
+HELP_OUTPUT=$(nasde run --help 2>&1)
+if echo "$HELP_OUTPUT" | grep -q "\-\-attempts" && echo "$HELP_OUTPUT" | grep -q "\-n"; then
+    echo "OK: --attempts and -n flags found in CLI help"
+else
+    echo "FAIL: --attempts/-n flag not found in nasde run --help"
+    echo 0 > /logs/verifier/reward.txt
+    exit 1
+fi
+if echo "$HELP_OUTPUT" | grep -qi "attempt\|independent.*per task\|number.*attempt"; then
+    echo "OK: Help text is descriptive"
+else
+    echo "FAIL: Help text missing or not descriptive for --attempts"
+    echo 0 > /logs/verifier/reward.txt
+    exit 1
+fi
+echo ""
+
+echo "Step 2: CLI flag actually parses..."
+echo "--------------------------------------"
+if nasde run --attempts 3 --help >/dev/null 2>&1; then
+    echo "OK: --attempts 3 parses without error"
+else
+    echo "FAIL: --attempts flag does not parse correctly"
+    echo 0 > /logs/verifier/reward.txt
+    exit 1
+fi
+if nasde run -n 2 --help >/dev/null 2>&1; then
+    echo "OK: -n 2 short alias parses without error"
+else
+    echo "FAIL: -n short alias does not parse correctly"
+    echo 0 > /logs/verifier/reward.txt
+    exit 1
+fi
+echo ""
+
+echo "Step 3: Running Python tests..."
+echo "--------------------------------------"
+TEST_OUTPUT=$(uv run pytest -x -q 2>&1)
+TEST_EXIT=$?
+echo "$TEST_OUTPUT"
+echo ""
+if [ $TEST_EXIT -eq 0 ]; then
+    echo "OK: All tests pass"
+else
+    echo "FAIL: Unit tests failed (exit code $TEST_EXIT)"
+    echo "Review test output above for details"
+    echo 0 > /logs/verifier/reward.txt
+    exit 1
+fi
+echo ""
+
+echo "Step 4: run_benchmark accepts n_attempts parameter..."
+echo "--------------------------------------"
+if uv run python -c "
+import inspect
+from nasde_toolkit.runner import run_benchmark
+sig = inspect.signature(run_benchmark)
+assert 'n_attempts' in sig.parameters, f'n_attempts not in signature: {list(sig.parameters.keys())}'
+param = sig.parameters['n_attempts']
+assert param.default == 1, f'Default should be 1, got {param.default}'
+print('run_benchmark(n_attempts=1) signature OK')
+"; then
+    echo "OK: run_benchmark accepts n_attempts with default=1"
+else
+    echo "FAIL: run_benchmark does not accept n_attempts parameter"
+    echo 0 > /logs/verifier/reward.txt
+    exit 1
+fi
+echo ""
+
+echo "Step 5: ConfigurableClaude imports correctly..."
+echo "--------------------------------------"
+if uv run python -c "
+from nasde_toolkit.agents.configurable_claude import ConfigurableClaude
+print(f'ConfigurableClaude loaded: {ConfigurableClaude.name()}')
+"; then
+    echo "OK: ConfigurableClaude imports successfully"
+else
+    echo "FAIL: ConfigurableClaude import failed"
+    echo 0 > /logs/verifier/reward.txt
+    exit 1
+fi
+echo ""
+
+echo "Step 6: README.md CLI options table updated..."
+echo "--------------------------------------"
+if grep -q "\-\-attempts" README.md 2>/dev/null; then
+    echo "OK: README.md mentions --attempts flag"
+else
+    echo "FAIL: README.md CLI options table not updated with --attempts flag"
+    echo 0 > /logs/verifier/reward.txt
+    exit 1
+fi
+echo ""
+
+echo "=========================================="
+echo "EVALUATION PASSED"
+echo "=========================================="
+echo 1 > /logs/verifier/reward.txt
+exit 0

--- a/examples/nasde-dev-skill/variants/nasde-dev-full-stack/CLAUDE.md
+++ b/examples/nasde-dev-skill/variants/nasde-dev-full-stack/CLAUDE.md
@@ -1,0 +1,9 @@
+# Agent Instructions
+
+## Approach
+
+1. Before writing any code, explore the existing codebase to understand its architecture and conventions.
+2. Follow existing architectural patterns exactly — match naming, namespaces, directory structure, and code style.
+3. Read CLAUDE.md in the project root for full architecture documentation.
+4. **When modifying nasde-toolkit functionality (CLI, runner, evaluator, config, agents), you MUST invoke the `/nasde-dev` skill first.** It contains the verification protocol including documentation sync requirements.
+5. After making changes, verify documentation is consistent (CLAUDE.md, README.md, ARCHITECTURE.md).

--- a/examples/nasde-dev-skill/variants/nasde-dev-full-stack/skills/nasde-dev/SKILL.md
+++ b/examples/nasde-dev-skill/variants/nasde-dev-full-stack/skills/nasde-dev/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: nasde-dev
+description: |
+  Internal skill for developing and maintaining nasde-toolkit itself. Use this skill when:
+  - Making changes to nasde-toolkit source code (CLI, runner, evaluator, config, agents)
+  - Refactoring or adding features to the toolkit
+  - Fixing bugs in the evaluation pipeline
+  - Updating dependencies or integration points (Harbor, Opik, Claude Code SDK)
+  This skill defines the verification protocol that must be followed after any significant change.
+---
+
+# NASDE Toolkit Development
+
+Internal guidelines for developing nasde-toolkit itself.
+
+> **Important context:** `nasde-toolkit/` is the current production toolkit. The repository also contains `SDLC/evals/` which is the **legacy predecessor** — the original research/prototype that has been migrated into nasde-toolkit. Do NOT modify `SDLC/evals/` for new work. It will be removed once migration is confirmed complete.
+
+## Post-change verification protocol
+
+After any significant change to the toolkit (new features, refactors, dependency updates, renamed identifiers), run the full verification pipeline before considering the work complete.
+
+### 1. Static checks
+
+```bash
+# No stale references to old names or patterns
+grep -r "sdlc.eval\|sdlc-eval\|sdlc_eval" src/ docs/ CLAUDE.md README.md .claude/skills/ pyproject.toml --include="*.py" --include="*.md" --include="*.toml" --include="*.json" | grep -v __pycache__
+
+# Package installs cleanly
+uv sync
+```
+
+### 1b. Documentation and skills consistency
+
+After any change to the evaluation pipeline, CLI flags, configuration schema, agent support, or sandbox/environment handling, update **all** of these:
+
+**Documentation:**
+- `ARCHITECTURE.md` — system architecture with mermaid diagrams (end-to-end flow, trial lifecycle, cloud sandbox providers, assessment evaluation)
+- `README.md` — user-facing documentation (CLI options table, nasde.toml example, prerequisites, authentication)
+- `CLAUDE.md` — agent instructions (CLI reference, nasde.toml example, architecture decisions)
+
+**Skills (update when relevant to the change):**
+- `.claude/skills/nasde-benchmark-runner/SKILL.md` — running benchmarks, supported models/agents, auth, troubleshooting
+- `.claude/skills/nasde-benchmark-creator/SKILL.md` — creating benchmarks, variant structure, task formats, agent conventions
+- `.claude/skills/nasde-dev/SKILL.md` — this file, verification protocol
+
+### 2. CLI smoke test
+
+```bash
+nasde --version
+nasde --help
+```
+
+### 3. End-to-end benchmark run
+
+Run a single task from the existing benchmark with full eval and Opik tracing:
+
+```bash
+source scripts/export_oauth_token.sh
+nasde run --variant baseline --tasks ddd-threshold-discount \
+  -C examples/ddd-architectural-challenges --with-opik
+```
+
+Expected output:
+- Harbor trial completes with reward 1.0
+- Assessment evaluation produces scores for all configured dimensions
+- Opik trace is created with feedback scores uploaded
+
+### 4. Opik REST API verification
+
+After any run with `--with-opik`, verify that all feedback scores arrived in Opik. Use Python `urllib.request` (never curl — it drops the `Comet-Workspace` header):
+
+```bash
+source .env
+python3 -c "
+import urllib.request, json
+
+req = urllib.request.Request(
+    'https://www.comet.com/opik/api/v1/private/traces?project_name=ddd-architectural-challenges&limit=1',
+    headers={
+        'authorization': '$OPIK_API_KEY',
+        'Comet-Workspace': '$OPIK_WORKSPACE',
+    },
+)
+resp = json.loads(urllib.request.urlopen(req).read())
+trace = resp['content'][0]
+print(f'Trace: {trace[\"name\"]}')
+print(f'ID:    {trace[\"id\"]}')
+print()
+scores = trace.get('feedback_scores', [])
+print(f'Feedback scores ({len(scores)}):')
+for s in sorted(scores, key=lambda x: x['name']):
+    print(f'  {s[\"name\"]}: {s[\"value\"]}')
+"
+```
+
+Expected feedback scores (7 total for the ddd benchmark):
+- `arch_<dimension>` for each dimension in `assessment_dimensions.json` (normalized 0.0-1.0)
+- `arch_total` — overall normalized score
+- `reward` — Harbor functional test result (0.0 or 1.0)
+- `duration_sec` — trial execution time
+
+### 5. When to run this protocol
+
+- **Full protocol (steps 1-4):** After renaming, refactoring, dependency updates, or changes to runner/evaluator/config
+- **Steps 1-2 only:** After documentation-only changes or minor code edits
+- **Skip:** Typo fixes, comment changes, .gitignore updates

--- a/examples/nasde-dev-skill/variants/nasde-dev-full-stack/skills/python-best-practices/SKILL.md
+++ b/examples/nasde-dev-skill/variants/nasde-dev-full-stack/skills/python-best-practices/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: python-best-practices
+description: Provides Python patterns for type-first development with dataclasses, discriminated unions, NewType, and Protocol. Must use when reading or writing Python files.
+---
+
+# Python Best Practices
+
+## Type-First Development
+
+Types define the contract before implementation. Follow this workflow:
+
+1. **Define data models** - dataclasses, Pydantic models, or TypedDict first
+2. **Define function signatures** - parameter and return type hints
+3. **Implement to satisfy types** - let the type checker guide completeness
+4. **Validate at boundaries** - runtime checks where data enters the system
+
+### Make Illegal States Unrepresentable
+
+Use Python's type system to prevent invalid states at type-check time.
+
+**Dataclasses for structured data:**
+```python
+from dataclasses import dataclass
+from datetime import datetime
+
+@dataclass(frozen=True)
+class User:
+    id: str
+    email: str
+    name: str
+    created_at: datetime
+
+@dataclass(frozen=True)
+class CreateUser:
+    email: str
+    name: str
+
+# Frozen dataclasses are immutable - no accidental mutation
+```
+
+**Discriminated unions with Literal:**
+```python
+from dataclasses import dataclass
+from typing import Literal
+
+@dataclass
+class Idle:
+    status: Literal["idle"] = "idle"
+
+@dataclass
+class Loading:
+    status: Literal["loading"] = "loading"
+
+@dataclass
+class Success:
+    status: Literal["success"] = "success"
+    data: str
+
+@dataclass
+class Failure:
+    status: Literal["error"] = "error"
+    error: Exception
+
+RequestState = Idle | Loading | Success | Failure
+
+def handle_state(state: RequestState) -> None:
+    match state:
+        case Idle():
+            pass
+        case Loading():
+            show_spinner()
+        case Success(data=data):
+            render(data)
+        case Failure(error=err):
+            show_error(err)
+```
+
+**NewType for domain primitives:**
+```python
+from typing import NewType
+
+UserId = NewType("UserId", str)
+OrderId = NewType("OrderId", str)
+
+def get_user(user_id: UserId) -> User:
+    # Type checker prevents passing OrderId here
+    ...
+
+def create_user_id(raw: str) -> UserId:
+    return UserId(raw)
+```
+
+**Enums for constrained values:**
+```python
+from enum import Enum, auto
+
+class Role(Enum):
+    ADMIN = auto()
+    USER = auto()
+    GUEST = auto()
+
+def check_permission(role: Role) -> bool:
+    match role:
+        case Role.ADMIN:
+            return True
+        case Role.USER:
+            return limited_check()
+        case Role.GUEST:
+            return False
+    # Type checker warns if case is missing
+```
+
+**Protocol for structural typing:**
+```python
+from typing import Protocol
+
+class Readable(Protocol):
+    def read(self, n: int = -1) -> bytes: ...
+
+def process_input(source: Readable) -> bytes:
+    # Accepts any object with a read() method
+    return source.read()
+```
+
+**TypedDict for external data shapes:**
+```python
+from typing import TypedDict, Required, NotRequired
+
+class UserResponse(TypedDict):
+    id: Required[str]
+    email: Required[str]
+    name: Required[str]
+    avatar_url: NotRequired[str]
+
+def parse_user(data: dict) -> UserResponse:
+    # Runtime validation needed - TypedDict is structural
+    return UserResponse(
+        id=data["id"],
+        email=data["email"],
+        name=data["name"],
+    )
+```
+
+## Module Structure
+
+Prefer smaller, focused files: one class or closely related set of functions per module. Split when a file handles multiple concerns or exceeds ~300 lines. Use `__init__.py` to expose public API; keep implementation details in private modules (`_internal.py`). Colocate tests in `tests/` mirroring the source structure.
+
+## Functional Patterns
+
+- Use list/dict/set comprehensions and generator expressions over explicit loops.
+- Prefer `@dataclass(frozen=True)` for immutable data; avoid mutable default arguments.
+- Use `functools.partial` for partial application; compose small functions over large classes.
+- Avoid class-level mutable state; prefer pure functions that take inputs and return outputs.
+
+## Instructions
+
+- Raise descriptive exceptions for unsupported cases; every code path returns a value or raises. This makes failures debuggable and prevents silent corruption.
+- Propagate exceptions with context using `from err`; catching requires re-raising or returning a meaningful result. Swallowed exceptions hide root causes.
+- Handle edge cases explicitly: empty inputs, `None`, boundary values. Include `else` clauses in conditionals where appropriate.
+- Use context managers for I/O; prefer `pathlib` and explicit encodings. Resource leaks cause production issues.
+- Add or adjust unit tests when touching logic; prefer minimal repros that isolate the failure.
+
+## Examples
+
+Explicit failure for unimplemented logic:
+```python
+def build_widget(widget_type: str) -> Widget:
+    raise NotImplementedError(f"build_widget not implemented for type: {widget_type}")
+```
+
+Propagate with context to preserve the original traceback:
+```python
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError as err:
+    raise ValueError(f"invalid JSON payload: {err}") from err
+```
+
+Exhaustive match with explicit default:
+```python
+def process_status(status: str) -> str:
+    match status:
+        case "active":
+            return "processing"
+        case "inactive":
+            return "skipped"
+        case _:
+            raise ValueError(f"unhandled status: {status}")
+```
+
+Debug-level tracing with namespaced logger:
+```python
+import logging
+
+logger = logging.getLogger("myapp.widgets")
+
+def create_widget(name: str) -> Widget:
+    logger.debug("creating widget: %s", name)
+    widget = Widget(name=name)
+    logger.debug("created widget id=%s", widget.id)
+    return widget
+```
+
+## Configuration
+
+- Load config from environment variables at startup; validate required values before use. Missing config should fail immediately.
+- Define a config dataclass or Pydantic model as single source of truth; avoid `os.getenv` scattered throughout code.
+- Use sensible defaults for development; require explicit values for production secrets.
+
+### Examples
+
+Typed config with dataclass:
+```python
+import os
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class Config:
+    port: int = 3000
+    database_url: str = ""
+    api_key: str = ""
+    env: str = "development"
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        database_url = os.environ.get("DATABASE_URL", "")
+        if not database_url:
+            raise ValueError("DATABASE_URL is required")
+        return cls(
+            port=int(os.environ.get("PORT", "3000")),
+            database_url=database_url,
+            api_key=os.environ["API_KEY"],  # required, will raise if missing
+            env=os.environ.get("ENV", "development"),
+        )
+
+config = Config.from_env()
+```
+
+## Optional: ty
+
+For fast type checking, consider [ty](https://docs.astral.sh/ty/) from Astral (creators of ruff and uv). Written in Rust, it's significantly faster than mypy or pyright.
+
+**Installation and usage:**
+```bash
+# Run directly with uvx (no install needed)
+uvx ty check
+
+# Check specific files
+uvx ty check src/main.py
+
+# Install permanently
+uv tool install ty
+```
+
+**Key features:**
+- Automatic virtual environment detection (via `VIRTUAL_ENV` or `.venv`)
+- Project discovery from `pyproject.toml`
+- Fast incremental checking
+- Compatible with standard Python type hints
+
+**Configuration in `pyproject.toml`:**
+```toml
+[tool.ty]
+python-version = "3.12"
+```
+
+**When to use ty vs alternatives:**
+- `ty` - fastest, good for CI and large codebases (early stage, rapidly evolving)
+- `pyright` - most complete type inference, VS Code integration
+- `mypy` - mature, extensive plugin ecosystem

--- a/examples/nasde-dev-skill/variants/nasde-dev-full-stack/skills/python-testing/SKILL.md
+++ b/examples/nasde-dev-skill/variants/nasde-dev-full-stack/skills/python-testing/SKILL.md
@@ -1,0 +1,816 @@
+---
+name: python-testing
+description: Python testing strategies using pytest, TDD methodology, fixtures, mocking, parametrization, and coverage requirements.
+origin: ECC
+---
+
+# Python Testing Patterns
+
+Comprehensive testing strategies for Python applications using pytest, TDD methodology, and best practices.
+
+## When to Activate
+
+- Writing new Python code (follow TDD: red, green, refactor)
+- Designing test suites for Python projects
+- Reviewing Python test coverage
+- Setting up testing infrastructure
+
+## Core Testing Philosophy
+
+### Test-Driven Development (TDD)
+
+Always follow the TDD cycle:
+
+1. **RED**: Write a failing test for the desired behavior
+2. **GREEN**: Write minimal code to make the test pass
+3. **REFACTOR**: Improve code while keeping tests green
+
+```python
+# Step 1: Write failing test (RED)
+def test_add_numbers():
+    result = add(2, 3)
+    assert result == 5
+
+# Step 2: Write minimal implementation (GREEN)
+def add(a, b):
+    return a + b
+
+# Step 3: Refactor if needed (REFACTOR)
+```
+
+### Coverage Requirements
+
+- **Target**: 80%+ code coverage
+- **Critical paths**: 100% coverage required
+- Use `pytest --cov` to measure coverage
+
+```bash
+pytest --cov=mypackage --cov-report=term-missing --cov-report=html
+```
+
+## pytest Fundamentals
+
+### Basic Test Structure
+
+```python
+import pytest
+
+def test_addition():
+    """Test basic addition."""
+    assert 2 + 2 == 4
+
+def test_string_uppercase():
+    """Test string uppercasing."""
+    text = "hello"
+    assert text.upper() == "HELLO"
+
+def test_list_append():
+    """Test list append."""
+    items = [1, 2, 3]
+    items.append(4)
+    assert 4 in items
+    assert len(items) == 4
+```
+
+### Assertions
+
+```python
+# Equality
+assert result == expected
+
+# Inequality
+assert result != unexpected
+
+# Truthiness
+assert result  # Truthy
+assert not result  # Falsy
+assert result is True  # Exactly True
+assert result is False  # Exactly False
+assert result is None  # Exactly None
+
+# Membership
+assert item in collection
+assert item not in collection
+
+# Comparisons
+assert result > 0
+assert 0 <= result <= 100
+
+# Type checking
+assert isinstance(result, str)
+
+# Exception testing (preferred approach)
+with pytest.raises(ValueError):
+    raise ValueError("error message")
+
+# Check exception message
+with pytest.raises(ValueError, match="invalid input"):
+    raise ValueError("invalid input provided")
+
+# Check exception attributes
+with pytest.raises(ValueError) as exc_info:
+    raise ValueError("error message")
+assert str(exc_info.value) == "error message"
+```
+
+## Fixtures
+
+### Basic Fixture Usage
+
+```python
+import pytest
+
+@pytest.fixture
+def sample_data():
+    """Fixture providing sample data."""
+    return {"name": "Alice", "age": 30}
+
+def test_sample_data(sample_data):
+    """Test using the fixture."""
+    assert sample_data["name"] == "Alice"
+    assert sample_data["age"] == 30
+```
+
+### Fixture with Setup/Teardown
+
+```python
+@pytest.fixture
+def database():
+    """Fixture with setup and teardown."""
+    # Setup
+    db = Database(":memory:")
+    db.create_tables()
+    db.insert_test_data()
+
+    yield db  # Provide to test
+
+    # Teardown
+    db.close()
+
+def test_database_query(database):
+    """Test database operations."""
+    result = database.query("SELECT * FROM users")
+    assert len(result) > 0
+```
+
+### Fixture Scopes
+
+```python
+# Function scope (default) - runs for each test
+@pytest.fixture
+def temp_file():
+    with open("temp.txt", "w") as f:
+        yield f
+    os.remove("temp.txt")
+
+# Module scope - runs once per module
+@pytest.fixture(scope="module")
+def module_db():
+    db = Database(":memory:")
+    db.create_tables()
+    yield db
+    db.close()
+
+# Session scope - runs once per test session
+@pytest.fixture(scope="session")
+def shared_resource():
+    resource = ExpensiveResource()
+    yield resource
+    resource.cleanup()
+```
+
+### Fixture with Parameters
+
+```python
+@pytest.fixture(params=[1, 2, 3])
+def number(request):
+    """Parameterized fixture."""
+    return request.param
+
+def test_numbers(number):
+    """Test runs 3 times, once for each parameter."""
+    assert number > 0
+```
+
+### Using Multiple Fixtures
+
+```python
+@pytest.fixture
+def user():
+    return User(id=1, name="Alice")
+
+@pytest.fixture
+def admin():
+    return User(id=2, name="Admin", role="admin")
+
+def test_user_admin_interaction(user, admin):
+    """Test using multiple fixtures."""
+    assert admin.can_manage(user)
+```
+
+### Autouse Fixtures
+
+```python
+@pytest.fixture(autouse=True)
+def reset_config():
+    """Automatically runs before every test."""
+    Config.reset()
+    yield
+    Config.cleanup()
+
+def test_without_fixture_call():
+    # reset_config runs automatically
+    assert Config.get_setting("debug") is False
+```
+
+### Conftest.py for Shared Fixtures
+
+```python
+# tests/conftest.py
+import pytest
+
+@pytest.fixture
+def client():
+    """Shared fixture for all tests."""
+    app = create_app(testing=True)
+    with app.test_client() as client:
+        yield client
+
+@pytest.fixture
+def auth_headers(client):
+    """Generate auth headers for API testing."""
+    response = client.post("/api/login", json={
+        "username": "test",
+        "password": "test"
+    })
+    token = response.json["token"]
+    return {"Authorization": f"Bearer {token}"}
+```
+
+## Parametrization
+
+### Basic Parametrization
+
+```python
+@pytest.mark.parametrize("input,expected", [
+    ("hello", "HELLO"),
+    ("world", "WORLD"),
+    ("PyThOn", "PYTHON"),
+])
+def test_uppercase(input, expected):
+    """Test runs 3 times with different inputs."""
+    assert input.upper() == expected
+```
+
+### Multiple Parameters
+
+```python
+@pytest.mark.parametrize("a,b,expected", [
+    (2, 3, 5),
+    (0, 0, 0),
+    (-1, 1, 0),
+    (100, 200, 300),
+])
+def test_add(a, b, expected):
+    """Test addition with multiple inputs."""
+    assert add(a, b) == expected
+```
+
+### Parametrize with IDs
+
+```python
+@pytest.mark.parametrize("input,expected", [
+    ("valid@email.com", True),
+    ("invalid", False),
+    ("@no-domain.com", False),
+], ids=["valid-email", "missing-at", "missing-domain"])
+def test_email_validation(input, expected):
+    """Test email validation with readable test IDs."""
+    assert is_valid_email(input) is expected
+```
+
+### Parametrized Fixtures
+
+```python
+@pytest.fixture(params=["sqlite", "postgresql", "mysql"])
+def db(request):
+    """Test against multiple database backends."""
+    if request.param == "sqlite":
+        return Database(":memory:")
+    elif request.param == "postgresql":
+        return Database("postgresql://localhost/test")
+    elif request.param == "mysql":
+        return Database("mysql://localhost/test")
+
+def test_database_operations(db):
+    """Test runs 3 times, once for each database."""
+    result = db.query("SELECT 1")
+    assert result is not None
+```
+
+## Markers and Test Selection
+
+### Custom Markers
+
+```python
+# Mark slow tests
+@pytest.mark.slow
+def test_slow_operation():
+    time.sleep(5)
+
+# Mark integration tests
+@pytest.mark.integration
+def test_api_integration():
+    response = requests.get("https://api.example.com")
+    assert response.status_code == 200
+
+# Mark unit tests
+@pytest.mark.unit
+def test_unit_logic():
+    assert calculate(2, 3) == 5
+```
+
+### Run Specific Tests
+
+```bash
+# Run only fast tests
+pytest -m "not slow"
+
+# Run only integration tests
+pytest -m integration
+
+# Run integration or slow tests
+pytest -m "integration or slow"
+
+# Run tests marked as unit but not slow
+pytest -m "unit and not slow"
+```
+
+### Configure Markers in pytest.ini
+
+```ini
+[pytest]
+markers =
+    slow: marks tests as slow
+    integration: marks tests as integration tests
+    unit: marks tests as unit tests
+    django: marks tests as requiring Django
+```
+
+## Mocking and Patching
+
+### Mocking Functions
+
+```python
+from unittest.mock import patch, Mock
+
+@patch("mypackage.external_api_call")
+def test_with_mock(api_call_mock):
+    """Test with mocked external API."""
+    api_call_mock.return_value = {"status": "success"}
+
+    result = my_function()
+
+    api_call_mock.assert_called_once()
+    assert result["status"] == "success"
+```
+
+### Mocking Return Values
+
+```python
+@patch("mypackage.Database.connect")
+def test_database_connection(connect_mock):
+    """Test with mocked database connection."""
+    connect_mock.return_value = MockConnection()
+
+    db = Database()
+    db.connect()
+
+    connect_mock.assert_called_once_with("localhost")
+```
+
+### Mocking Exceptions
+
+```python
+@patch("mypackage.api_call")
+def test_api_error_handling(api_call_mock):
+    """Test error handling with mocked exception."""
+    api_call_mock.side_effect = ConnectionError("Network error")
+
+    with pytest.raises(ConnectionError):
+        api_call()
+
+    api_call_mock.assert_called_once()
+```
+
+### Mocking Context Managers
+
+```python
+@patch("builtins.open", new_callable=mock_open)
+def test_file_reading(mock_file):
+    """Test file reading with mocked open."""
+    mock_file.return_value.read.return_value = "file content"
+
+    result = read_file("test.txt")
+
+    mock_file.assert_called_once_with("test.txt", "r")
+    assert result == "file content"
+```
+
+### Using Autospec
+
+```python
+@patch("mypackage.DBConnection", autospec=True)
+def test_autospec(db_mock):
+    """Test with autospec to catch API misuse."""
+    db = db_mock.return_value
+    db.query("SELECT * FROM users")
+
+    # This would fail if DBConnection doesn't have query method
+    db_mock.assert_called_once()
+```
+
+### Mock Class Instances
+
+```python
+class TestUserService:
+    @patch("mypackage.UserRepository")
+    def test_create_user(self, repo_mock):
+        """Test user creation with mocked repository."""
+        repo_mock.return_value.save.return_value = User(id=1, name="Alice")
+
+        service = UserService(repo_mock.return_value)
+        user = service.create_user(name="Alice")
+
+        assert user.name == "Alice"
+        repo_mock.return_value.save.assert_called_once()
+```
+
+### Mock Property
+
+```python
+@pytest.fixture
+def mock_config():
+    """Create a mock with a property."""
+    config = Mock()
+    type(config).debug = PropertyMock(return_value=True)
+    type(config).api_key = PropertyMock(return_value="test-key")
+    return config
+
+def test_with_mock_config(mock_config):
+    """Test with mocked config properties."""
+    assert mock_config.debug is True
+    assert mock_config.api_key == "test-key"
+```
+
+## Testing Async Code
+
+### Async Tests with pytest-asyncio
+
+```python
+import pytest
+
+@pytest.mark.asyncio
+async def test_async_function():
+    """Test async function."""
+    result = await async_add(2, 3)
+    assert result == 5
+
+@pytest.mark.asyncio
+async def test_async_with_fixture(async_client):
+    """Test async with async fixture."""
+    response = await async_client.get("/api/users")
+    assert response.status_code == 200
+```
+
+### Async Fixture
+
+```python
+@pytest.fixture
+async def async_client():
+    """Async fixture providing async test client."""
+    app = create_app()
+    async with app.test_client() as client:
+        yield client
+
+@pytest.mark.asyncio
+async def test_api_endpoint(async_client):
+    """Test using async fixture."""
+    response = await async_client.get("/api/data")
+    assert response.status_code == 200
+```
+
+### Mocking Async Functions
+
+```python
+@pytest.mark.asyncio
+@patch("mypackage.async_api_call")
+async def test_async_mock(api_call_mock):
+    """Test async function with mock."""
+    api_call_mock.return_value = {"status": "ok"}
+
+    result = await my_async_function()
+
+    api_call_mock.assert_awaited_once()
+    assert result["status"] == "ok"
+```
+
+## Testing Exceptions
+
+### Testing Expected Exceptions
+
+```python
+def test_divide_by_zero():
+    """Test that dividing by zero raises ZeroDivisionError."""
+    with pytest.raises(ZeroDivisionError):
+        divide(10, 0)
+
+def test_custom_exception():
+    """Test custom exception with message."""
+    with pytest.raises(ValueError, match="invalid input"):
+        validate_input("invalid")
+```
+
+### Testing Exception Attributes
+
+```python
+def test_exception_with_details():
+    """Test exception with custom attributes."""
+    with pytest.raises(CustomError) as exc_info:
+        raise CustomError("error", code=400)
+
+    assert exc_info.value.code == 400
+    assert "error" in str(exc_info.value)
+```
+
+## Testing Side Effects
+
+### Testing File Operations
+
+```python
+import tempfile
+import os
+
+def test_file_processing():
+    """Test file processing with temp file."""
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt') as f:
+        f.write("test content")
+        temp_path = f.name
+
+    try:
+        result = process_file(temp_path)
+        assert result == "processed: test content"
+    finally:
+        os.unlink(temp_path)
+```
+
+### Testing with pytest's tmp_path Fixture
+
+```python
+def test_with_tmp_path(tmp_path):
+    """Test using pytest's built-in temp path fixture."""
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("hello world")
+
+    result = process_file(str(test_file))
+    assert result == "hello world"
+    # tmp_path automatically cleaned up
+```
+
+### Testing with tmpdir Fixture
+
+```python
+def test_with_tmpdir(tmpdir):
+    """Test using pytest's tmpdir fixture."""
+    test_file = tmpdir.join("test.txt")
+    test_file.write("data")
+
+    result = process_file(str(test_file))
+    assert result == "data"
+```
+
+## Test Organization
+
+### Directory Structure
+
+```
+tests/
+├── conftest.py                 # Shared fixtures
+├── __init__.py
+├── unit/                       # Unit tests
+│   ├── __init__.py
+│   ├── test_models.py
+│   ├── test_utils.py
+│   └── test_services.py
+├── integration/                # Integration tests
+│   ├── __init__.py
+│   ├── test_api.py
+│   └── test_database.py
+└── e2e/                        # End-to-end tests
+    ├── __init__.py
+    └── test_user_flow.py
+```
+
+### Test Classes
+
+```python
+class TestUserService:
+    """Group related tests in a class."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Setup runs before each test in this class."""
+        self.service = UserService()
+
+    def test_create_user(self):
+        """Test user creation."""
+        user = self.service.create_user("Alice")
+        assert user.name == "Alice"
+
+    def test_delete_user(self):
+        """Test user deletion."""
+        user = User(id=1, name="Bob")
+        self.service.delete_user(user)
+        assert not self.service.user_exists(1)
+```
+
+## Best Practices
+
+### DO
+
+- **Follow TDD**: Write tests before code (red-green-refactor)
+- **Test one thing**: Each test should verify a single behavior
+- **Use descriptive names**: `test_user_login_with_invalid_credentials_fails`
+- **Use fixtures**: Eliminate duplication with fixtures
+- **Mock external dependencies**: Don't depend on external services
+- **Test edge cases**: Empty inputs, None values, boundary conditions
+- **Aim for 80%+ coverage**: Focus on critical paths
+- **Keep tests fast**: Use marks to separate slow tests
+
+### DON'T
+
+- **Don't test implementation**: Test behavior, not internals
+- **Don't use complex conditionals in tests**: Keep tests simple
+- **Don't ignore test failures**: All tests must pass
+- **Don't test third-party code**: Trust libraries to work
+- **Don't share state between tests**: Tests should be independent
+- **Don't catch exceptions in tests**: Use `pytest.raises`
+- **Don't use print statements**: Use assertions and pytest output
+- **Don't write tests that are too brittle**: Avoid over-specific mocks
+
+## Common Patterns
+
+### Testing API Endpoints (FastAPI/Flask)
+
+```python
+@pytest.fixture
+def client():
+    app = create_app(testing=True)
+    return app.test_client()
+
+def test_get_user(client):
+    response = client.get("/api/users/1")
+    assert response.status_code == 200
+    assert response.json["id"] == 1
+
+def test_create_user(client):
+    response = client.post("/api/users", json={
+        "name": "Alice",
+        "email": "alice@example.com"
+    })
+    assert response.status_code == 201
+    assert response.json["name"] == "Alice"
+```
+
+### Testing Database Operations
+
+```python
+@pytest.fixture
+def db_session():
+    """Create a test database session."""
+    session = Session(bind=engine)
+    session.begin_nested()
+    yield session
+    session.rollback()
+    session.close()
+
+def test_create_user(db_session):
+    user = User(name="Alice", email="alice@example.com")
+    db_session.add(user)
+    db_session.commit()
+
+    retrieved = db_session.query(User).filter_by(name="Alice").first()
+    assert retrieved.email == "alice@example.com"
+```
+
+### Testing Class Methods
+
+```python
+class TestCalculator:
+    @pytest.fixture
+    def calculator(self):
+        return Calculator()
+
+    def test_add(self, calculator):
+        assert calculator.add(2, 3) == 5
+
+    def test_divide_by_zero(self, calculator):
+        with pytest.raises(ZeroDivisionError):
+            calculator.divide(10, 0)
+```
+
+## pytest Configuration
+
+### pytest.ini
+
+```ini
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts =
+    --strict-markers
+    --disable-warnings
+    --cov=mypackage
+    --cov-report=term-missing
+    --cov-report=html
+markers =
+    slow: marks tests as slow
+    integration: marks tests as integration tests
+    unit: marks tests as unit tests
+```
+
+### pyproject.toml
+
+```toml
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = [
+    "--strict-markers",
+    "--cov=mypackage",
+    "--cov-report=term-missing",
+    "--cov-report=html",
+]
+markers = [
+    "slow: marks tests as slow",
+    "integration: marks tests as integration tests",
+    "unit: marks tests as unit tests",
+]
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+pytest
+
+# Run specific file
+pytest tests/test_utils.py
+
+# Run specific test
+pytest tests/test_utils.py::test_function
+
+# Run with verbose output
+pytest -v
+
+# Run with coverage
+pytest --cov=mypackage --cov-report=html
+
+# Run only fast tests
+pytest -m "not slow"
+
+# Run until first failure
+pytest -x
+
+# Run and stop on N failures
+pytest --maxfail=3
+
+# Run last failed tests
+pytest --lf
+
+# Run tests with pattern
+pytest -k "test_user"
+
+# Run with debugger on failure
+pytest --pdb
+```
+
+## Quick Reference
+
+| Pattern | Usage |
+|---------|-------|
+| `pytest.raises()` | Test expected exceptions |
+| `@pytest.fixture()` | Create reusable test fixtures |
+| `@pytest.mark.parametrize()` | Run tests with multiple inputs |
+| `@pytest.mark.slow` | Mark slow tests |
+| `pytest -m "not slow"` | Skip slow tests |
+| `@patch()` | Mock functions and classes |
+| `tmp_path` fixture | Automatic temp directory |
+| `pytest --cov` | Generate coverage report |
+| `assert` | Simple and readable assertions |
+
+**Remember**: Tests are code too. Keep them clean, readable, and maintainable. Good tests catch bugs; great tests prevent them.

--- a/examples/nasde-dev-skill/variants/nasde-dev-full-stack/variant.toml
+++ b/examples/nasde-dev-skill/variants/nasde-dev-full-stack/variant.toml
@@ -1,0 +1,1 @@
+agent = "claude"

--- a/examples/nasde-dev-skill/variants/nasde-dev-with-arch/CLAUDE.md
+++ b/examples/nasde-dev-skill/variants/nasde-dev-with-arch/CLAUDE.md
@@ -1,0 +1,9 @@
+# Agent Instructions
+
+## Approach
+
+1. Before writing any code, explore the existing codebase to understand its architecture and conventions.
+2. Follow existing architectural patterns exactly — match naming, namespaces, directory structure, and code style.
+3. Read CLAUDE.md in the project root for full architecture documentation.
+4. **When modifying nasde-toolkit functionality (CLI, runner, evaluator, config, agents), you MUST invoke the `/nasde-dev` skill first.** It contains the verification protocol including documentation sync requirements.
+5. After making changes, verify documentation is consistent (CLAUDE.md, README.md, ARCHITECTURE.md).

--- a/examples/nasde-dev-skill/variants/nasde-dev-with-arch/skills/nasde-dev/SKILL.md
+++ b/examples/nasde-dev-skill/variants/nasde-dev-with-arch/skills/nasde-dev/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: nasde-dev
+description: |
+  Internal skill for developing and maintaining nasde-toolkit itself. Use this skill when:
+  - Making changes to nasde-toolkit source code (CLI, runner, evaluator, config, agents)
+  - Refactoring or adding features to the toolkit
+  - Fixing bugs in the evaluation pipeline
+  - Updating dependencies or integration points (Harbor, Opik, Claude Code SDK)
+  This skill defines the verification protocol that must be followed after any significant change.
+---
+
+# NASDE Toolkit Development
+
+Internal guidelines for developing nasde-toolkit itself.
+
+> **Important context:** `nasde-toolkit/` is the current production toolkit. The repository also contains `SDLC/evals/` which is the **legacy predecessor** — the original research/prototype that has been migrated into nasde-toolkit. Do NOT modify `SDLC/evals/` for new work. It will be removed once migration is confirmed complete.
+
+## Post-change verification protocol
+
+After any significant change to the toolkit (new features, refactors, dependency updates, renamed identifiers), run the full verification pipeline before considering the work complete.
+
+### 1. Static checks
+
+```bash
+# No stale references to old names or patterns
+grep -r "sdlc.eval\|sdlc-eval\|sdlc_eval" src/ docs/ CLAUDE.md README.md .claude/skills/ pyproject.toml --include="*.py" --include="*.md" --include="*.toml" --include="*.json" | grep -v __pycache__
+
+# Package installs cleanly
+uv sync
+```
+
+### 1b. Documentation and skills consistency
+
+After any change to the evaluation pipeline, CLI flags, configuration schema, agent support, or sandbox/environment handling, update **all** of these:
+
+**Documentation:**
+- `ARCHITECTURE.md` — system architecture with mermaid diagrams (end-to-end flow, trial lifecycle, cloud sandbox providers, assessment evaluation)
+- `README.md` — user-facing documentation (CLI options table, nasde.toml example, prerequisites, authentication)
+- `CLAUDE.md` — agent instructions (CLI reference, nasde.toml example, architecture decisions)
+
+**Skills (update when relevant to the change):**
+- `.claude/skills/nasde-benchmark-runner/SKILL.md` — running benchmarks, supported models/agents, auth, troubleshooting
+- `.claude/skills/nasde-benchmark-creator/SKILL.md` — creating benchmarks, variant structure, task formats, agent conventions
+- `.claude/skills/nasde-dev/SKILL.md` — this file, verification protocol
+
+### 2. CLI smoke test
+
+```bash
+nasde --version
+nasde --help
+```
+
+### 3. End-to-end benchmark run
+
+Run a single task from the existing benchmark with full eval and Opik tracing:
+
+```bash
+source scripts/export_oauth_token.sh
+nasde run --variant baseline --tasks ddd-threshold-discount \
+  -C examples/ddd-architectural-challenges --with-opik
+```
+
+Expected output:
+- Harbor trial completes with reward 1.0
+- Assessment evaluation produces scores for all configured dimensions
+- Opik trace is created with feedback scores uploaded
+
+### 4. Opik REST API verification
+
+After any run with `--with-opik`, verify that all feedback scores arrived in Opik. Use Python `urllib.request` (never curl — it drops the `Comet-Workspace` header):
+
+```bash
+source .env
+python3 -c "
+import urllib.request, json
+
+req = urllib.request.Request(
+    'https://www.comet.com/opik/api/v1/private/traces?project_name=ddd-architectural-challenges&limit=1',
+    headers={
+        'authorization': '$OPIK_API_KEY',
+        'Comet-Workspace': '$OPIK_WORKSPACE',
+    },
+)
+resp = json.loads(urllib.request.urlopen(req).read())
+trace = resp['content'][0]
+print(f'Trace: {trace[\"name\"]}')
+print(f'ID:    {trace[\"id\"]}')
+print()
+scores = trace.get('feedback_scores', [])
+print(f'Feedback scores ({len(scores)}):')
+for s in sorted(scores, key=lambda x: x['name']):
+    print(f'  {s[\"name\"]}: {s[\"value\"]}')
+"
+```
+
+Expected feedback scores (7 total for the ddd benchmark):
+- `arch_<dimension>` for each dimension in `assessment_dimensions.json` (normalized 0.0-1.0)
+- `arch_total` — overall normalized score
+- `reward` — Harbor functional test result (0.0 or 1.0)
+- `duration_sec` — trial execution time
+
+### 5. When to run this protocol
+
+- **Full protocol (steps 1-4):** After renaming, refactoring, dependency updates, or changes to runner/evaluator/config
+- **Steps 1-2 only:** After documentation-only changes or minor code edits
+- **Skip:** Typo fixes, comment changes, .gitignore updates

--- a/examples/nasde-dev-skill/variants/nasde-dev-with-arch/skills/python-best-practices/SKILL.md
+++ b/examples/nasde-dev-skill/variants/nasde-dev-with-arch/skills/python-best-practices/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: python-best-practices
+description: Provides Python patterns for type-first development with dataclasses, discriminated unions, NewType, and Protocol. Must use when reading or writing Python files.
+---
+
+# Python Best Practices
+
+## Type-First Development
+
+Types define the contract before implementation. Follow this workflow:
+
+1. **Define data models** - dataclasses, Pydantic models, or TypedDict first
+2. **Define function signatures** - parameter and return type hints
+3. **Implement to satisfy types** - let the type checker guide completeness
+4. **Validate at boundaries** - runtime checks where data enters the system
+
+### Make Illegal States Unrepresentable
+
+Use Python's type system to prevent invalid states at type-check time.
+
+**Dataclasses for structured data:**
+```python
+from dataclasses import dataclass
+from datetime import datetime
+
+@dataclass(frozen=True)
+class User:
+    id: str
+    email: str
+    name: str
+    created_at: datetime
+
+@dataclass(frozen=True)
+class CreateUser:
+    email: str
+    name: str
+
+# Frozen dataclasses are immutable - no accidental mutation
+```
+
+**Discriminated unions with Literal:**
+```python
+from dataclasses import dataclass
+from typing import Literal
+
+@dataclass
+class Idle:
+    status: Literal["idle"] = "idle"
+
+@dataclass
+class Loading:
+    status: Literal["loading"] = "loading"
+
+@dataclass
+class Success:
+    status: Literal["success"] = "success"
+    data: str
+
+@dataclass
+class Failure:
+    status: Literal["error"] = "error"
+    error: Exception
+
+RequestState = Idle | Loading | Success | Failure
+
+def handle_state(state: RequestState) -> None:
+    match state:
+        case Idle():
+            pass
+        case Loading():
+            show_spinner()
+        case Success(data=data):
+            render(data)
+        case Failure(error=err):
+            show_error(err)
+```
+
+**NewType for domain primitives:**
+```python
+from typing import NewType
+
+UserId = NewType("UserId", str)
+OrderId = NewType("OrderId", str)
+
+def get_user(user_id: UserId) -> User:
+    # Type checker prevents passing OrderId here
+    ...
+
+def create_user_id(raw: str) -> UserId:
+    return UserId(raw)
+```
+
+**Enums for constrained values:**
+```python
+from enum import Enum, auto
+
+class Role(Enum):
+    ADMIN = auto()
+    USER = auto()
+    GUEST = auto()
+
+def check_permission(role: Role) -> bool:
+    match role:
+        case Role.ADMIN:
+            return True
+        case Role.USER:
+            return limited_check()
+        case Role.GUEST:
+            return False
+    # Type checker warns if case is missing
+```
+
+**Protocol for structural typing:**
+```python
+from typing import Protocol
+
+class Readable(Protocol):
+    def read(self, n: int = -1) -> bytes: ...
+
+def process_input(source: Readable) -> bytes:
+    # Accepts any object with a read() method
+    return source.read()
+```
+
+**TypedDict for external data shapes:**
+```python
+from typing import TypedDict, Required, NotRequired
+
+class UserResponse(TypedDict):
+    id: Required[str]
+    email: Required[str]
+    name: Required[str]
+    avatar_url: NotRequired[str]
+
+def parse_user(data: dict) -> UserResponse:
+    # Runtime validation needed - TypedDict is structural
+    return UserResponse(
+        id=data["id"],
+        email=data["email"],
+        name=data["name"],
+    )
+```
+
+## Module Structure
+
+Prefer smaller, focused files: one class or closely related set of functions per module. Split when a file handles multiple concerns or exceeds ~300 lines. Use `__init__.py` to expose public API; keep implementation details in private modules (`_internal.py`). Colocate tests in `tests/` mirroring the source structure.
+
+## Functional Patterns
+
+- Use list/dict/set comprehensions and generator expressions over explicit loops.
+- Prefer `@dataclass(frozen=True)` for immutable data; avoid mutable default arguments.
+- Use `functools.partial` for partial application; compose small functions over large classes.
+- Avoid class-level mutable state; prefer pure functions that take inputs and return outputs.
+
+## Instructions
+
+- Raise descriptive exceptions for unsupported cases; every code path returns a value or raises. This makes failures debuggable and prevents silent corruption.
+- Propagate exceptions with context using `from err`; catching requires re-raising or returning a meaningful result. Swallowed exceptions hide root causes.
+- Handle edge cases explicitly: empty inputs, `None`, boundary values. Include `else` clauses in conditionals where appropriate.
+- Use context managers for I/O; prefer `pathlib` and explicit encodings. Resource leaks cause production issues.
+- Add or adjust unit tests when touching logic; prefer minimal repros that isolate the failure.
+
+## Examples
+
+Explicit failure for unimplemented logic:
+```python
+def build_widget(widget_type: str) -> Widget:
+    raise NotImplementedError(f"build_widget not implemented for type: {widget_type}")
+```
+
+Propagate with context to preserve the original traceback:
+```python
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError as err:
+    raise ValueError(f"invalid JSON payload: {err}") from err
+```
+
+Exhaustive match with explicit default:
+```python
+def process_status(status: str) -> str:
+    match status:
+        case "active":
+            return "processing"
+        case "inactive":
+            return "skipped"
+        case _:
+            raise ValueError(f"unhandled status: {status}")
+```
+
+Debug-level tracing with namespaced logger:
+```python
+import logging
+
+logger = logging.getLogger("myapp.widgets")
+
+def create_widget(name: str) -> Widget:
+    logger.debug("creating widget: %s", name)
+    widget = Widget(name=name)
+    logger.debug("created widget id=%s", widget.id)
+    return widget
+```
+
+## Configuration
+
+- Load config from environment variables at startup; validate required values before use. Missing config should fail immediately.
+- Define a config dataclass or Pydantic model as single source of truth; avoid `os.getenv` scattered throughout code.
+- Use sensible defaults for development; require explicit values for production secrets.
+
+### Examples
+
+Typed config with dataclass:
+```python
+import os
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class Config:
+    port: int = 3000
+    database_url: str = ""
+    api_key: str = ""
+    env: str = "development"
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        database_url = os.environ.get("DATABASE_URL", "")
+        if not database_url:
+            raise ValueError("DATABASE_URL is required")
+        return cls(
+            port=int(os.environ.get("PORT", "3000")),
+            database_url=database_url,
+            api_key=os.environ["API_KEY"],  # required, will raise if missing
+            env=os.environ.get("ENV", "development"),
+        )
+
+config = Config.from_env()
+```
+
+## Optional: ty
+
+For fast type checking, consider [ty](https://docs.astral.sh/ty/) from Astral (creators of ruff and uv). Written in Rust, it's significantly faster than mypy or pyright.
+
+**Installation and usage:**
+```bash
+# Run directly with uvx (no install needed)
+uvx ty check
+
+# Check specific files
+uvx ty check src/main.py
+
+# Install permanently
+uv tool install ty
+```
+
+**Key features:**
+- Automatic virtual environment detection (via `VIRTUAL_ENV` or `.venv`)
+- Project discovery from `pyproject.toml`
+- Fast incremental checking
+- Compatible with standard Python type hints
+
+**Configuration in `pyproject.toml`:**
+```toml
+[tool.ty]
+python-version = "3.12"
+```
+
+**When to use ty vs alternatives:**
+- `ty` - fastest, good for CI and large codebases (early stage, rapidly evolving)
+- `pyright` - most complete type inference, VS Code integration
+- `mypy` - mature, extensive plugin ecosystem

--- a/examples/nasde-dev-skill/variants/nasde-dev-with-arch/variant.toml
+++ b/examples/nasde-dev-skill/variants/nasde-dev-with-arch/variant.toml
@@ -1,0 +1,1 @@
+agent = "claude"

--- a/examples/nasde-dev-skill/variants/nasde-dev-with-testing/CLAUDE.md
+++ b/examples/nasde-dev-skill/variants/nasde-dev-with-testing/CLAUDE.md
@@ -1,0 +1,9 @@
+# Agent Instructions
+
+## Approach
+
+1. Before writing any code, explore the existing codebase to understand its architecture and conventions.
+2. Follow existing architectural patterns exactly — match naming, namespaces, directory structure, and code style.
+3. Read CLAUDE.md in the project root for full architecture documentation.
+4. **When modifying nasde-toolkit functionality (CLI, runner, evaluator, config, agents), you MUST invoke the `/nasde-dev` skill first.** It contains the verification protocol including documentation sync requirements.
+5. After making changes, verify documentation is consistent (CLAUDE.md, README.md, ARCHITECTURE.md).

--- a/examples/nasde-dev-skill/variants/nasde-dev-with-testing/skills/nasde-dev/SKILL.md
+++ b/examples/nasde-dev-skill/variants/nasde-dev-with-testing/skills/nasde-dev/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: nasde-dev
+description: |
+  Internal skill for developing and maintaining nasde-toolkit itself. Use this skill when:
+  - Making changes to nasde-toolkit source code (CLI, runner, evaluator, config, agents)
+  - Refactoring or adding features to the toolkit
+  - Fixing bugs in the evaluation pipeline
+  - Updating dependencies or integration points (Harbor, Opik, Claude Code SDK)
+  This skill defines the verification protocol that must be followed after any significant change.
+---
+
+# NASDE Toolkit Development
+
+Internal guidelines for developing nasde-toolkit itself.
+
+> **Important context:** `nasde-toolkit/` is the current production toolkit. The repository also contains `SDLC/evals/` which is the **legacy predecessor** — the original research/prototype that has been migrated into nasde-toolkit. Do NOT modify `SDLC/evals/` for new work. It will be removed once migration is confirmed complete.
+
+## Post-change verification protocol
+
+After any significant change to the toolkit (new features, refactors, dependency updates, renamed identifiers), run the full verification pipeline before considering the work complete.
+
+### 1. Static checks
+
+```bash
+# No stale references to old names or patterns
+grep -r "sdlc.eval\|sdlc-eval\|sdlc_eval" src/ docs/ CLAUDE.md README.md .claude/skills/ pyproject.toml --include="*.py" --include="*.md" --include="*.toml" --include="*.json" | grep -v __pycache__
+
+# Package installs cleanly
+uv sync
+```
+
+### 1b. Documentation and skills consistency
+
+After any change to the evaluation pipeline, CLI flags, configuration schema, agent support, or sandbox/environment handling, update **all** of these:
+
+**Documentation:**
+- `ARCHITECTURE.md` — system architecture with mermaid diagrams (end-to-end flow, trial lifecycle, cloud sandbox providers, assessment evaluation)
+- `README.md` — user-facing documentation (CLI options table, nasde.toml example, prerequisites, authentication)
+- `CLAUDE.md` — agent instructions (CLI reference, nasde.toml example, architecture decisions)
+
+**Skills (update when relevant to the change):**
+- `.claude/skills/nasde-benchmark-runner/SKILL.md` — running benchmarks, supported models/agents, auth, troubleshooting
+- `.claude/skills/nasde-benchmark-creator/SKILL.md` — creating benchmarks, variant structure, task formats, agent conventions
+- `.claude/skills/nasde-dev/SKILL.md` — this file, verification protocol
+
+### 2. CLI smoke test
+
+```bash
+nasde --version
+nasde --help
+```
+
+### 3. End-to-end benchmark run
+
+Run a single task from the existing benchmark with full eval and Opik tracing:
+
+```bash
+source scripts/export_oauth_token.sh
+nasde run --variant baseline --tasks ddd-threshold-discount \
+  -C examples/ddd-architectural-challenges --with-opik
+```
+
+Expected output:
+- Harbor trial completes with reward 1.0
+- Assessment evaluation produces scores for all configured dimensions
+- Opik trace is created with feedback scores uploaded
+
+### 4. Opik REST API verification
+
+After any run with `--with-opik`, verify that all feedback scores arrived in Opik. Use Python `urllib.request` (never curl — it drops the `Comet-Workspace` header):
+
+```bash
+source .env
+python3 -c "
+import urllib.request, json
+
+req = urllib.request.Request(
+    'https://www.comet.com/opik/api/v1/private/traces?project_name=ddd-architectural-challenges&limit=1',
+    headers={
+        'authorization': '$OPIK_API_KEY',
+        'Comet-Workspace': '$OPIK_WORKSPACE',
+    },
+)
+resp = json.loads(urllib.request.urlopen(req).read())
+trace = resp['content'][0]
+print(f'Trace: {trace[\"name\"]}')
+print(f'ID:    {trace[\"id\"]}')
+print()
+scores = trace.get('feedback_scores', [])
+print(f'Feedback scores ({len(scores)}):')
+for s in sorted(scores, key=lambda x: x['name']):
+    print(f'  {s[\"name\"]}: {s[\"value\"]}')
+"
+```
+
+Expected feedback scores (7 total for the ddd benchmark):
+- `arch_<dimension>` for each dimension in `assessment_dimensions.json` (normalized 0.0-1.0)
+- `arch_total` — overall normalized score
+- `reward` — Harbor functional test result (0.0 or 1.0)
+- `duration_sec` — trial execution time
+
+### 5. When to run this protocol
+
+- **Full protocol (steps 1-4):** After renaming, refactoring, dependency updates, or changes to runner/evaluator/config
+- **Steps 1-2 only:** After documentation-only changes or minor code edits
+- **Skip:** Typo fixes, comment changes, .gitignore updates

--- a/examples/nasde-dev-skill/variants/nasde-dev-with-testing/skills/python-testing/SKILL.md
+++ b/examples/nasde-dev-skill/variants/nasde-dev-with-testing/skills/python-testing/SKILL.md
@@ -1,0 +1,816 @@
+---
+name: python-testing
+description: Python testing strategies using pytest, TDD methodology, fixtures, mocking, parametrization, and coverage requirements.
+origin: ECC
+---
+
+# Python Testing Patterns
+
+Comprehensive testing strategies for Python applications using pytest, TDD methodology, and best practices.
+
+## When to Activate
+
+- Writing new Python code (follow TDD: red, green, refactor)
+- Designing test suites for Python projects
+- Reviewing Python test coverage
+- Setting up testing infrastructure
+
+## Core Testing Philosophy
+
+### Test-Driven Development (TDD)
+
+Always follow the TDD cycle:
+
+1. **RED**: Write a failing test for the desired behavior
+2. **GREEN**: Write minimal code to make the test pass
+3. **REFACTOR**: Improve code while keeping tests green
+
+```python
+# Step 1: Write failing test (RED)
+def test_add_numbers():
+    result = add(2, 3)
+    assert result == 5
+
+# Step 2: Write minimal implementation (GREEN)
+def add(a, b):
+    return a + b
+
+# Step 3: Refactor if needed (REFACTOR)
+```
+
+### Coverage Requirements
+
+- **Target**: 80%+ code coverage
+- **Critical paths**: 100% coverage required
+- Use `pytest --cov` to measure coverage
+
+```bash
+pytest --cov=mypackage --cov-report=term-missing --cov-report=html
+```
+
+## pytest Fundamentals
+
+### Basic Test Structure
+
+```python
+import pytest
+
+def test_addition():
+    """Test basic addition."""
+    assert 2 + 2 == 4
+
+def test_string_uppercase():
+    """Test string uppercasing."""
+    text = "hello"
+    assert text.upper() == "HELLO"
+
+def test_list_append():
+    """Test list append."""
+    items = [1, 2, 3]
+    items.append(4)
+    assert 4 in items
+    assert len(items) == 4
+```
+
+### Assertions
+
+```python
+# Equality
+assert result == expected
+
+# Inequality
+assert result != unexpected
+
+# Truthiness
+assert result  # Truthy
+assert not result  # Falsy
+assert result is True  # Exactly True
+assert result is False  # Exactly False
+assert result is None  # Exactly None
+
+# Membership
+assert item in collection
+assert item not in collection
+
+# Comparisons
+assert result > 0
+assert 0 <= result <= 100
+
+# Type checking
+assert isinstance(result, str)
+
+# Exception testing (preferred approach)
+with pytest.raises(ValueError):
+    raise ValueError("error message")
+
+# Check exception message
+with pytest.raises(ValueError, match="invalid input"):
+    raise ValueError("invalid input provided")
+
+# Check exception attributes
+with pytest.raises(ValueError) as exc_info:
+    raise ValueError("error message")
+assert str(exc_info.value) == "error message"
+```
+
+## Fixtures
+
+### Basic Fixture Usage
+
+```python
+import pytest
+
+@pytest.fixture
+def sample_data():
+    """Fixture providing sample data."""
+    return {"name": "Alice", "age": 30}
+
+def test_sample_data(sample_data):
+    """Test using the fixture."""
+    assert sample_data["name"] == "Alice"
+    assert sample_data["age"] == 30
+```
+
+### Fixture with Setup/Teardown
+
+```python
+@pytest.fixture
+def database():
+    """Fixture with setup and teardown."""
+    # Setup
+    db = Database(":memory:")
+    db.create_tables()
+    db.insert_test_data()
+
+    yield db  # Provide to test
+
+    # Teardown
+    db.close()
+
+def test_database_query(database):
+    """Test database operations."""
+    result = database.query("SELECT * FROM users")
+    assert len(result) > 0
+```
+
+### Fixture Scopes
+
+```python
+# Function scope (default) - runs for each test
+@pytest.fixture
+def temp_file():
+    with open("temp.txt", "w") as f:
+        yield f
+    os.remove("temp.txt")
+
+# Module scope - runs once per module
+@pytest.fixture(scope="module")
+def module_db():
+    db = Database(":memory:")
+    db.create_tables()
+    yield db
+    db.close()
+
+# Session scope - runs once per test session
+@pytest.fixture(scope="session")
+def shared_resource():
+    resource = ExpensiveResource()
+    yield resource
+    resource.cleanup()
+```
+
+### Fixture with Parameters
+
+```python
+@pytest.fixture(params=[1, 2, 3])
+def number(request):
+    """Parameterized fixture."""
+    return request.param
+
+def test_numbers(number):
+    """Test runs 3 times, once for each parameter."""
+    assert number > 0
+```
+
+### Using Multiple Fixtures
+
+```python
+@pytest.fixture
+def user():
+    return User(id=1, name="Alice")
+
+@pytest.fixture
+def admin():
+    return User(id=2, name="Admin", role="admin")
+
+def test_user_admin_interaction(user, admin):
+    """Test using multiple fixtures."""
+    assert admin.can_manage(user)
+```
+
+### Autouse Fixtures
+
+```python
+@pytest.fixture(autouse=True)
+def reset_config():
+    """Automatically runs before every test."""
+    Config.reset()
+    yield
+    Config.cleanup()
+
+def test_without_fixture_call():
+    # reset_config runs automatically
+    assert Config.get_setting("debug") is False
+```
+
+### Conftest.py for Shared Fixtures
+
+```python
+# tests/conftest.py
+import pytest
+
+@pytest.fixture
+def client():
+    """Shared fixture for all tests."""
+    app = create_app(testing=True)
+    with app.test_client() as client:
+        yield client
+
+@pytest.fixture
+def auth_headers(client):
+    """Generate auth headers for API testing."""
+    response = client.post("/api/login", json={
+        "username": "test",
+        "password": "test"
+    })
+    token = response.json["token"]
+    return {"Authorization": f"Bearer {token}"}
+```
+
+## Parametrization
+
+### Basic Parametrization
+
+```python
+@pytest.mark.parametrize("input,expected", [
+    ("hello", "HELLO"),
+    ("world", "WORLD"),
+    ("PyThOn", "PYTHON"),
+])
+def test_uppercase(input, expected):
+    """Test runs 3 times with different inputs."""
+    assert input.upper() == expected
+```
+
+### Multiple Parameters
+
+```python
+@pytest.mark.parametrize("a,b,expected", [
+    (2, 3, 5),
+    (0, 0, 0),
+    (-1, 1, 0),
+    (100, 200, 300),
+])
+def test_add(a, b, expected):
+    """Test addition with multiple inputs."""
+    assert add(a, b) == expected
+```
+
+### Parametrize with IDs
+
+```python
+@pytest.mark.parametrize("input,expected", [
+    ("valid@email.com", True),
+    ("invalid", False),
+    ("@no-domain.com", False),
+], ids=["valid-email", "missing-at", "missing-domain"])
+def test_email_validation(input, expected):
+    """Test email validation with readable test IDs."""
+    assert is_valid_email(input) is expected
+```
+
+### Parametrized Fixtures
+
+```python
+@pytest.fixture(params=["sqlite", "postgresql", "mysql"])
+def db(request):
+    """Test against multiple database backends."""
+    if request.param == "sqlite":
+        return Database(":memory:")
+    elif request.param == "postgresql":
+        return Database("postgresql://localhost/test")
+    elif request.param == "mysql":
+        return Database("mysql://localhost/test")
+
+def test_database_operations(db):
+    """Test runs 3 times, once for each database."""
+    result = db.query("SELECT 1")
+    assert result is not None
+```
+
+## Markers and Test Selection
+
+### Custom Markers
+
+```python
+# Mark slow tests
+@pytest.mark.slow
+def test_slow_operation():
+    time.sleep(5)
+
+# Mark integration tests
+@pytest.mark.integration
+def test_api_integration():
+    response = requests.get("https://api.example.com")
+    assert response.status_code == 200
+
+# Mark unit tests
+@pytest.mark.unit
+def test_unit_logic():
+    assert calculate(2, 3) == 5
+```
+
+### Run Specific Tests
+
+```bash
+# Run only fast tests
+pytest -m "not slow"
+
+# Run only integration tests
+pytest -m integration
+
+# Run integration or slow tests
+pytest -m "integration or slow"
+
+# Run tests marked as unit but not slow
+pytest -m "unit and not slow"
+```
+
+### Configure Markers in pytest.ini
+
+```ini
+[pytest]
+markers =
+    slow: marks tests as slow
+    integration: marks tests as integration tests
+    unit: marks tests as unit tests
+    django: marks tests as requiring Django
+```
+
+## Mocking and Patching
+
+### Mocking Functions
+
+```python
+from unittest.mock import patch, Mock
+
+@patch("mypackage.external_api_call")
+def test_with_mock(api_call_mock):
+    """Test with mocked external API."""
+    api_call_mock.return_value = {"status": "success"}
+
+    result = my_function()
+
+    api_call_mock.assert_called_once()
+    assert result["status"] == "success"
+```
+
+### Mocking Return Values
+
+```python
+@patch("mypackage.Database.connect")
+def test_database_connection(connect_mock):
+    """Test with mocked database connection."""
+    connect_mock.return_value = MockConnection()
+
+    db = Database()
+    db.connect()
+
+    connect_mock.assert_called_once_with("localhost")
+```
+
+### Mocking Exceptions
+
+```python
+@patch("mypackage.api_call")
+def test_api_error_handling(api_call_mock):
+    """Test error handling with mocked exception."""
+    api_call_mock.side_effect = ConnectionError("Network error")
+
+    with pytest.raises(ConnectionError):
+        api_call()
+
+    api_call_mock.assert_called_once()
+```
+
+### Mocking Context Managers
+
+```python
+@patch("builtins.open", new_callable=mock_open)
+def test_file_reading(mock_file):
+    """Test file reading with mocked open."""
+    mock_file.return_value.read.return_value = "file content"
+
+    result = read_file("test.txt")
+
+    mock_file.assert_called_once_with("test.txt", "r")
+    assert result == "file content"
+```
+
+### Using Autospec
+
+```python
+@patch("mypackage.DBConnection", autospec=True)
+def test_autospec(db_mock):
+    """Test with autospec to catch API misuse."""
+    db = db_mock.return_value
+    db.query("SELECT * FROM users")
+
+    # This would fail if DBConnection doesn't have query method
+    db_mock.assert_called_once()
+```
+
+### Mock Class Instances
+
+```python
+class TestUserService:
+    @patch("mypackage.UserRepository")
+    def test_create_user(self, repo_mock):
+        """Test user creation with mocked repository."""
+        repo_mock.return_value.save.return_value = User(id=1, name="Alice")
+
+        service = UserService(repo_mock.return_value)
+        user = service.create_user(name="Alice")
+
+        assert user.name == "Alice"
+        repo_mock.return_value.save.assert_called_once()
+```
+
+### Mock Property
+
+```python
+@pytest.fixture
+def mock_config():
+    """Create a mock with a property."""
+    config = Mock()
+    type(config).debug = PropertyMock(return_value=True)
+    type(config).api_key = PropertyMock(return_value="test-key")
+    return config
+
+def test_with_mock_config(mock_config):
+    """Test with mocked config properties."""
+    assert mock_config.debug is True
+    assert mock_config.api_key == "test-key"
+```
+
+## Testing Async Code
+
+### Async Tests with pytest-asyncio
+
+```python
+import pytest
+
+@pytest.mark.asyncio
+async def test_async_function():
+    """Test async function."""
+    result = await async_add(2, 3)
+    assert result == 5
+
+@pytest.mark.asyncio
+async def test_async_with_fixture(async_client):
+    """Test async with async fixture."""
+    response = await async_client.get("/api/users")
+    assert response.status_code == 200
+```
+
+### Async Fixture
+
+```python
+@pytest.fixture
+async def async_client():
+    """Async fixture providing async test client."""
+    app = create_app()
+    async with app.test_client() as client:
+        yield client
+
+@pytest.mark.asyncio
+async def test_api_endpoint(async_client):
+    """Test using async fixture."""
+    response = await async_client.get("/api/data")
+    assert response.status_code == 200
+```
+
+### Mocking Async Functions
+
+```python
+@pytest.mark.asyncio
+@patch("mypackage.async_api_call")
+async def test_async_mock(api_call_mock):
+    """Test async function with mock."""
+    api_call_mock.return_value = {"status": "ok"}
+
+    result = await my_async_function()
+
+    api_call_mock.assert_awaited_once()
+    assert result["status"] == "ok"
+```
+
+## Testing Exceptions
+
+### Testing Expected Exceptions
+
+```python
+def test_divide_by_zero():
+    """Test that dividing by zero raises ZeroDivisionError."""
+    with pytest.raises(ZeroDivisionError):
+        divide(10, 0)
+
+def test_custom_exception():
+    """Test custom exception with message."""
+    with pytest.raises(ValueError, match="invalid input"):
+        validate_input("invalid")
+```
+
+### Testing Exception Attributes
+
+```python
+def test_exception_with_details():
+    """Test exception with custom attributes."""
+    with pytest.raises(CustomError) as exc_info:
+        raise CustomError("error", code=400)
+
+    assert exc_info.value.code == 400
+    assert "error" in str(exc_info.value)
+```
+
+## Testing Side Effects
+
+### Testing File Operations
+
+```python
+import tempfile
+import os
+
+def test_file_processing():
+    """Test file processing with temp file."""
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt') as f:
+        f.write("test content")
+        temp_path = f.name
+
+    try:
+        result = process_file(temp_path)
+        assert result == "processed: test content"
+    finally:
+        os.unlink(temp_path)
+```
+
+### Testing with pytest's tmp_path Fixture
+
+```python
+def test_with_tmp_path(tmp_path):
+    """Test using pytest's built-in temp path fixture."""
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("hello world")
+
+    result = process_file(str(test_file))
+    assert result == "hello world"
+    # tmp_path automatically cleaned up
+```
+
+### Testing with tmpdir Fixture
+
+```python
+def test_with_tmpdir(tmpdir):
+    """Test using pytest's tmpdir fixture."""
+    test_file = tmpdir.join("test.txt")
+    test_file.write("data")
+
+    result = process_file(str(test_file))
+    assert result == "data"
+```
+
+## Test Organization
+
+### Directory Structure
+
+```
+tests/
+├── conftest.py                 # Shared fixtures
+├── __init__.py
+├── unit/                       # Unit tests
+│   ├── __init__.py
+│   ├── test_models.py
+│   ├── test_utils.py
+│   └── test_services.py
+├── integration/                # Integration tests
+│   ├── __init__.py
+│   ├── test_api.py
+│   └── test_database.py
+└── e2e/                        # End-to-end tests
+    ├── __init__.py
+    └── test_user_flow.py
+```
+
+### Test Classes
+
+```python
+class TestUserService:
+    """Group related tests in a class."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Setup runs before each test in this class."""
+        self.service = UserService()
+
+    def test_create_user(self):
+        """Test user creation."""
+        user = self.service.create_user("Alice")
+        assert user.name == "Alice"
+
+    def test_delete_user(self):
+        """Test user deletion."""
+        user = User(id=1, name="Bob")
+        self.service.delete_user(user)
+        assert not self.service.user_exists(1)
+```
+
+## Best Practices
+
+### DO
+
+- **Follow TDD**: Write tests before code (red-green-refactor)
+- **Test one thing**: Each test should verify a single behavior
+- **Use descriptive names**: `test_user_login_with_invalid_credentials_fails`
+- **Use fixtures**: Eliminate duplication with fixtures
+- **Mock external dependencies**: Don't depend on external services
+- **Test edge cases**: Empty inputs, None values, boundary conditions
+- **Aim for 80%+ coverage**: Focus on critical paths
+- **Keep tests fast**: Use marks to separate slow tests
+
+### DON'T
+
+- **Don't test implementation**: Test behavior, not internals
+- **Don't use complex conditionals in tests**: Keep tests simple
+- **Don't ignore test failures**: All tests must pass
+- **Don't test third-party code**: Trust libraries to work
+- **Don't share state between tests**: Tests should be independent
+- **Don't catch exceptions in tests**: Use `pytest.raises`
+- **Don't use print statements**: Use assertions and pytest output
+- **Don't write tests that are too brittle**: Avoid over-specific mocks
+
+## Common Patterns
+
+### Testing API Endpoints (FastAPI/Flask)
+
+```python
+@pytest.fixture
+def client():
+    app = create_app(testing=True)
+    return app.test_client()
+
+def test_get_user(client):
+    response = client.get("/api/users/1")
+    assert response.status_code == 200
+    assert response.json["id"] == 1
+
+def test_create_user(client):
+    response = client.post("/api/users", json={
+        "name": "Alice",
+        "email": "alice@example.com"
+    })
+    assert response.status_code == 201
+    assert response.json["name"] == "Alice"
+```
+
+### Testing Database Operations
+
+```python
+@pytest.fixture
+def db_session():
+    """Create a test database session."""
+    session = Session(bind=engine)
+    session.begin_nested()
+    yield session
+    session.rollback()
+    session.close()
+
+def test_create_user(db_session):
+    user = User(name="Alice", email="alice@example.com")
+    db_session.add(user)
+    db_session.commit()
+
+    retrieved = db_session.query(User).filter_by(name="Alice").first()
+    assert retrieved.email == "alice@example.com"
+```
+
+### Testing Class Methods
+
+```python
+class TestCalculator:
+    @pytest.fixture
+    def calculator(self):
+        return Calculator()
+
+    def test_add(self, calculator):
+        assert calculator.add(2, 3) == 5
+
+    def test_divide_by_zero(self, calculator):
+        with pytest.raises(ZeroDivisionError):
+            calculator.divide(10, 0)
+```
+
+## pytest Configuration
+
+### pytest.ini
+
+```ini
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts =
+    --strict-markers
+    --disable-warnings
+    --cov=mypackage
+    --cov-report=term-missing
+    --cov-report=html
+markers =
+    slow: marks tests as slow
+    integration: marks tests as integration tests
+    unit: marks tests as unit tests
+```
+
+### pyproject.toml
+
+```toml
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = [
+    "--strict-markers",
+    "--cov=mypackage",
+    "--cov-report=term-missing",
+    "--cov-report=html",
+]
+markers = [
+    "slow: marks tests as slow",
+    "integration: marks tests as integration tests",
+    "unit: marks tests as unit tests",
+]
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+pytest
+
+# Run specific file
+pytest tests/test_utils.py
+
+# Run specific test
+pytest tests/test_utils.py::test_function
+
+# Run with verbose output
+pytest -v
+
+# Run with coverage
+pytest --cov=mypackage --cov-report=html
+
+# Run only fast tests
+pytest -m "not slow"
+
+# Run until first failure
+pytest -x
+
+# Run and stop on N failures
+pytest --maxfail=3
+
+# Run last failed tests
+pytest --lf
+
+# Run tests with pattern
+pytest -k "test_user"
+
+# Run with debugger on failure
+pytest --pdb
+```
+
+## Quick Reference
+
+| Pattern | Usage |
+|---------|-------|
+| `pytest.raises()` | Test expected exceptions |
+| `@pytest.fixture()` | Create reusable test fixtures |
+| `@pytest.mark.parametrize()` | Run tests with multiple inputs |
+| `@pytest.mark.slow` | Mark slow tests |
+| `pytest -m "not slow"` | Skip slow tests |
+| `@patch()` | Mock functions and classes |
+| `tmp_path` fixture | Automatic temp directory |
+| `pytest --cov` | Generate coverage report |
+| `assert` | Simple and readable assertions |
+
+**Remember**: Tests are code too. Keep them clean, readable, and maintainable. Good tests catch bugs; great tests prevent them.

--- a/examples/nasde-dev-skill/variants/nasde-dev-with-testing/variant.toml
+++ b/examples/nasde-dev-skill/variants/nasde-dev-with-testing/variant.toml
@@ -1,0 +1,1 @@
+agent = "claude"

--- a/examples/nasde-dev-skill/variants/vanilla/CLAUDE.md
+++ b/examples/nasde-dev-skill/variants/vanilla/CLAUDE.md
@@ -1,0 +1,6 @@
+# Agent Instructions
+
+You are a coding assistant. Work in /app.
+
+1. Follow existing patterns in the codebase.
+2. Read CLAUDE.md for project context.

--- a/examples/nasde-dev-skill/variants/vanilla/variant.toml
+++ b/examples/nasde-dev-skill/variants/vanilla/variant.toml
@@ -1,0 +1,1 @@
+agent = "claude"

--- a/src/nasde_toolkit/agents/configurable_claude.py
+++ b/src/nasde_toolkit/agents/configurable_claude.py
@@ -64,10 +64,16 @@ class ConfigurableClaude(ClaudeCode):
         return "configurable-claude-code"
 
     async def setup(self, environment: BaseEnvironment) -> None:
-        """Fix cloud DNS, run base setup, then upload configured files."""
+        """Fix cloud DNS, upload files, then run base setup.
+
+        Files must be uploaded BEFORE super().setup() because Harbor's
+        ClaudeCode.setup() copies skills from ~/.claude/skills/ into
+        the Claude config directory. Our sandbox_files that target
+        ~/.claude/skills/ need to be in place before that copy happens.
+        """
         await self._ensure_dns_resolution(environment)
-        await super().setup(environment)
         await self._upload_sandbox_files(environment)
+        await super().setup(environment)
 
     async def _ensure_dns_resolution(self, environment: BaseEnvironment) -> None:
         """Prepend 1.1.1.1 to resolv.conf if missing.
@@ -90,9 +96,26 @@ class ConfigurableClaude(ClaudeCode):
                 raise FileNotFoundError(
                     f"sandbox_files: source '{source_path}' (resolved to '{resolved}') does not exist"
                 )
-            parent_dir = str(Path(target_path).parent)
-            await environment.exec(command=f"mkdir -p {parent_dir}")
-            await environment.upload_file(
-                source_path=resolved,
-                target_path=target_path,
-            )
+            upload_targets = _expand_skill_targets(target_path)
+            for upload_path in upload_targets:
+                parent_dir = str(Path(upload_path).parent)
+                await environment.exec(command=f"mkdir -p {parent_dir}")
+                await environment.upload_file(
+                    source_path=resolved,
+                    target_path=upload_path,
+                )
+
+
+def _expand_skill_targets(target_path: str) -> list[str]:
+    """Expand a skill target path to include both /app/ and ~/.claude/ locations.
+
+    Harbor's ClaudeCode.setup() copies skills from ~/.claude/skills/ into
+    its internal config directory. Skills placed only under /app/.claude/
+    won't be discovered. This ensures skills are available in both locations.
+    """
+    app_skills_prefix = "/app/.claude/skills/"
+    if target_path.startswith(app_skills_prefix):
+        relative = target_path[len(app_skills_prefix) :]
+        home_path = f"/root/.claude/skills/{relative}"
+        return [target_path, home_path]
+    return [target_path]

--- a/src/nasde_toolkit/docker.py
+++ b/src/nasde_toolkit/docker.py
@@ -1,12 +1,19 @@
 """Docker environment preparation for benchmark tasks.
 
-Generates Dockerfiles that clone a git repo (local path or URL) at a specific
-ref and run build commands to prepare the environment for agent evaluation.
+Generates Dockerfiles that clone a git repo (remote URL) or copy from a local
+path at a specific ref, and run build commands to prepare the environment for
+agent evaluation. For local repos, creates a temporary git worktree at the
+specified ref so Docker builds from a clean snapshot — not the current working
+tree. Also generates a docker-compose.yaml that overrides the build context.
 """
 
 from __future__ import annotations
 
+import atexit
+import contextlib
+import os
 import subprocess
+import tempfile
 from pathlib import Path
 from textwrap import dedent
 
@@ -16,29 +23,45 @@ from nasde_toolkit.config import DockerConfig, SourceConfig
 
 console = Console()
 
+_active_worktrees: list[Path] = []
+
+
+def ensure_task_environment(
+    task_dir: Path,
+    source: SourceConfig,
+    docker: DockerConfig,
+) -> None:
+    """Generate environment/Dockerfile (and docker-compose.yaml for local repos) if missing.
+
+    For local repos with a ref, creates a temporary git worktree checked out
+    at the specified commit so Docker builds from that snapshot — not the
+    current working tree which may contain later changes.
+    """
+    env_dir = task_dir / "environment"
+    if (env_dir / "Dockerfile").exists():
+        return
+
+    env_dir.mkdir(parents=True, exist_ok=True)
+
+    dockerfile_content = generate_dockerfile(source, docker)
+    (env_dir / "Dockerfile").write_text(dockerfile_content)
+    console.print(f"  [dim]Generated Dockerfile in {env_dir}[/dim]")
+
+    if _is_local_path(source.git):
+        build_context_dir = _resolve_local_build_context(task_dir, source)
+        compose_content = _generate_build_context_compose(env_dir, build_context_dir)
+        (env_dir / "docker-compose.yaml").write_text(compose_content)
+        console.print(f"  [dim]Generated docker-compose.yaml in {env_dir}[/dim]")
+
 
 def generate_dockerfile(
     source: SourceConfig,
     docker: DockerConfig,
 ) -> str:
-    """Generate a Dockerfile that clones a git repo at a specific ref."""
-    git_url = _normalize_git_url(source.git)
-    build_steps = "\n".join(f"RUN {cmd}" for cmd in docker.build_commands)
-
-    return dedent(f"""\
-        FROM {docker.base_image}
-
-        RUN apt-get update && apt-get install -y \\
-            git curl wget ca-certificates \\
-            && rm -rf /var/lib/apt/lists/*
-
-        WORKDIR /app
-        RUN git clone {git_url} . && git checkout {source.ref}
-
-        {build_steps}
-
-        CMD ["/bin/bash"]
-    """)
+    """Generate a Dockerfile for the given source — dispatches on local vs remote."""
+    if _is_local_path(source.git):
+        return _generate_local_dockerfile(source, docker)
+    return _generate_remote_dockerfile(source, docker)
 
 
 def build_task_image(
@@ -70,6 +93,124 @@ def build_task_image(
 
     console.print(f"  [green]Image built:[/green] {image_tag}")
     return image_tag
+
+
+def _generate_build_context_compose(env_dir: Path, build_context_dir: Path) -> str:
+    """Generate a docker-compose.yaml that overrides the build context.
+
+    Also sets dockerfile to point back to environment/Dockerfile since
+    changing the context moves the Dockerfile lookup root.
+    """
+    relative_context = os.path.relpath(build_context_dir, env_dir)
+    dockerfile_from_context = os.path.relpath(env_dir / "Dockerfile", build_context_dir)
+
+    return dedent(f"""\
+        services:
+          main:
+            build:
+              context: {relative_context}
+              dockerfile: {dockerfile_from_context}
+    """)
+
+
+def cleanup_worktrees() -> None:
+    """Remove all temporary worktrees created during the run."""
+    for worktree_path in _active_worktrees:
+        with contextlib.suppress(OSError):
+            subprocess.run(
+                ["git", "worktree", "remove", "--force", str(worktree_path)],
+                capture_output=True,
+                check=False,
+            )
+    _active_worktrees.clear()
+
+
+def _resolve_local_build_context(task_dir: Path, source: SourceConfig) -> Path:
+    """Determine the Docker build context directory for a local repo.
+
+    If source has a ref, creates a temporary git worktree at that commit
+    so Docker builds from a clean historical snapshot. Without a ref,
+    falls back to the repo directory as-is.
+    """
+    repo_abs = (task_dir / source.git).resolve()
+
+    if not source.ref:
+        return repo_abs
+
+    return _create_ref_worktree(repo_abs, source.ref)
+
+
+def _create_ref_worktree(repo_dir: Path, ref: str) -> Path:
+    """Create a temporary git worktree checked out at the given ref."""
+    worktree_dir = Path(tempfile.mkdtemp(prefix="nasde-build-"))
+
+    result = subprocess.run(
+        ["git", "worktree", "add", "--detach", str(worktree_dir), ref],
+        cwd=repo_dir,
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to create worktree at {ref} in {repo_dir}: {result.stderr}")
+
+    _active_worktrees.append(worktree_dir)
+    atexit.register(cleanup_worktrees)
+    console.print(f"  [dim]Created build worktree at {ref} → {worktree_dir}[/dim]")
+    return worktree_dir
+
+
+def _generate_local_dockerfile(source: SourceConfig, docker: DockerConfig) -> str:
+    """Generate a Dockerfile that copies from a local repo.
+
+    Uses COPY instead of git clone. The build context is set by the
+    compose override — either the repo root (no ref) or a temporary
+    worktree checked out at the specified ref.
+    """
+    build_steps = "\n".join(f"RUN {cmd}" for cmd in docker.build_commands)
+
+    return dedent(f"""\
+        FROM {docker.base_image}
+
+        ENV PATH="/root/.local/bin:$PATH"
+
+        RUN apt-get update && apt-get install -y \\
+            git curl wget ca-certificates \\
+            && rm -rf /var/lib/apt/lists/*
+
+        WORKDIR /app
+        COPY . /app
+
+        {build_steps}
+
+        CMD ["/bin/bash"]
+    """)
+
+
+def _generate_remote_dockerfile(source: SourceConfig, docker: DockerConfig) -> str:
+    """Generate a Dockerfile that clones a remote git repo at a specific ref."""
+    git_url = _normalize_git_url(source.git)
+    build_steps = "\n".join(f"RUN {cmd}" for cmd in docker.build_commands)
+
+    return dedent(f"""\
+        FROM {docker.base_image}
+
+        RUN apt-get update && apt-get install -y \\
+            git curl wget ca-certificates \\
+            && rm -rf /var/lib/apt/lists/*
+
+        WORKDIR /app
+        RUN git clone {git_url} . && git checkout {source.ref}
+
+        {build_steps}
+
+        CMD ["/bin/bash"]
+    """)
+
+
+def _is_local_path(git_path: str) -> bool:
+    """Return True if the git path is a local filesystem path rather than a URL."""
+    return not git_path.startswith(("http://", "https://", "git://", "file://"))
 
 
 def _normalize_git_url(git_path: str) -> str:

--- a/src/nasde_toolkit/runner.py
+++ b/src/nasde_toolkit/runner.py
@@ -20,6 +20,7 @@ from rich.console import Console
 from rich.table import Table
 
 from nasde_toolkit.config import ProjectConfig
+from nasde_toolkit.docker import cleanup_worktrees, ensure_task_environment
 
 if TYPE_CHECKING:
     from harbor.models.job.result import JobResult
@@ -66,6 +67,9 @@ async def run_benchmark(
         harbor_config_path = variant_dir / "harbor_config.json"
 
     _ensure_auth(_read_agent_import_path(harbor_config_path))
+
+    for task in config.tasks:
+        ensure_task_environment(task.path, task.source, config.docker)
 
     merged_config = _build_merged_config(
         config=config,
@@ -440,6 +444,7 @@ async def _run_job(
             job.on_trial_ended(on_trial_ended)
         return await job.run()
     finally:
+        cleanup_worktrees()
         os.chdir(saved_cwd)
 
 

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,0 +1,211 @@
+"""Tests for docker module — Dockerfile generation and task environment setup."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from nasde_toolkit.config import DockerConfig, SourceConfig
+from nasde_toolkit.docker import (
+    cleanup_worktrees,
+    ensure_task_environment,
+    generate_dockerfile,
+)
+
+
+@pytest.fixture()
+def default_docker() -> DockerConfig:
+    return DockerConfig(base_image="ubuntu:22.04", build_commands=["apt-get install -y python3"])
+
+
+def _init_git_repo(repo_dir: Path, *, with_commit: bool = True) -> str:
+    """Initialize a git repo and optionally create a commit. Returns the commit hash."""
+    subprocess.run(["git", "init"], cwd=repo_dir, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=repo_dir,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=repo_dir,
+        capture_output=True,
+        check=True,
+    )
+
+    if not with_commit:
+        return ""
+
+    (repo_dir / "hello.txt").write_text("initial")
+    subprocess.run(["git", "add", "."], cwd=repo_dir, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=repo_dir,
+        capture_output=True,
+        check=True,
+    )
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_dir,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def test_generate_dockerfile_remote_url(default_docker: DockerConfig) -> None:
+    source = SourceConfig(git="https://github.com/org/repo.git", ref="main")
+    dockerfile = generate_dockerfile(source, default_docker)
+
+    assert "FROM ubuntu:22.04" in dockerfile
+    assert "git clone https://github.com/org/repo.git . && git checkout main" in dockerfile
+    assert "COPY . /app" not in dockerfile
+    assert "apt-get install -y python3" in dockerfile
+
+
+def test_generate_dockerfile_local_absolute_path(default_docker: DockerConfig) -> None:
+    source = SourceConfig(git="/tmp/my-repo", ref="feature-branch")
+    dockerfile = generate_dockerfile(source, default_docker)
+
+    assert "FROM ubuntu:22.04" in dockerfile
+    assert "COPY . /app" in dockerfile
+    assert "git clone" not in dockerfile
+    assert "git checkout" not in dockerfile
+    assert "apt-get install -y python3" in dockerfile
+
+
+def test_generate_dockerfile_relative_path(default_docker: DockerConfig) -> None:
+    source = SourceConfig(git="../..", ref="HEAD")
+    dockerfile = generate_dockerfile(source, default_docker)
+
+    assert "COPY . /app" in dockerfile
+    assert "git clone" not in dockerfile
+    assert "git checkout" not in dockerfile
+
+
+def test_ensure_task_environment_existing_dockerfile_skips(
+    tmp_path: Path,
+    default_docker: DockerConfig,
+) -> None:
+    task_dir = tmp_path / "tasks" / "my-task"
+    env_dir = task_dir / "environment"
+    env_dir.mkdir(parents=True)
+    (env_dir / "Dockerfile").write_text("FROM scratch\n")
+
+    source = SourceConfig(git="https://github.com/org/repo.git", ref="main")
+
+    ensure_task_environment(task_dir, source, default_docker)
+
+    assert (env_dir / "Dockerfile").read_text() == "FROM scratch\n"
+    assert not (env_dir / "docker-compose.yaml").exists()
+
+
+def test_ensure_task_environment_generates_for_remote(
+    tmp_path: Path,
+    default_docker: DockerConfig,
+) -> None:
+    task_dir = tmp_path / "tasks" / "my-task"
+    task_dir.mkdir(parents=True)
+
+    source = SourceConfig(git="https://github.com/org/repo.git", ref="main")
+
+    ensure_task_environment(task_dir, source, default_docker)
+
+    env_dir = task_dir / "environment"
+    assert (env_dir / "Dockerfile").exists()
+    dockerfile = (env_dir / "Dockerfile").read_text()
+    assert "git clone https://github.com/org/repo.git" in dockerfile
+    assert not (env_dir / "docker-compose.yaml").exists()
+
+
+def test_ensure_task_environment_generates_compose_for_local_no_ref(
+    tmp_path: Path,
+    default_docker: DockerConfig,
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    task_dir = tmp_path / "project" / "tasks" / "my-task"
+    task_dir.mkdir(parents=True)
+
+    source = SourceConfig(git=str(repo_dir), ref="")
+
+    ensure_task_environment(task_dir, source, default_docker)
+
+    env_dir = task_dir / "environment"
+    assert (env_dir / "Dockerfile").exists()
+    assert (env_dir / "docker-compose.yaml").exists()
+    compose = (env_dir / "docker-compose.yaml").read_text()
+    assert "context:" in compose
+    assert "dockerfile:" in compose
+
+
+def test_ensure_task_environment_compose_context_resolves_to_repo_no_ref(
+    tmp_path: Path,
+    default_docker: DockerConfig,
+) -> None:
+    repo_dir = tmp_path / "upstream-repo"
+    repo_dir.mkdir()
+    task_dir = tmp_path / "project" / "tasks" / "my-task"
+    task_dir.mkdir(parents=True)
+
+    source = SourceConfig(git=str(repo_dir), ref="")
+
+    ensure_task_environment(task_dir, source, default_docker)
+
+    env_dir = task_dir / "environment"
+    compose = (env_dir / "docker-compose.yaml").read_text()
+
+    context_line = [line.strip() for line in compose.splitlines() if "context:" in line][0]
+    relative_context = context_line.split("context:")[1].strip()
+
+    resolved_from_env = (env_dir / relative_context).resolve()
+    assert resolved_from_env == repo_dir.resolve()
+
+    dockerfile_line = [line.strip() for line in compose.splitlines() if "dockerfile:" in line][0]
+    relative_dockerfile = dockerfile_line.split("dockerfile:")[1].strip()
+
+    resolved_dockerfile = (repo_dir / relative_dockerfile).resolve()
+    assert resolved_dockerfile == (env_dir / "Dockerfile").resolve()
+
+
+def test_ensure_task_environment_creates_worktree_for_local_with_ref(
+    tmp_path: Path,
+    default_docker: DockerConfig,
+) -> None:
+    repo_dir = tmp_path / "my-repo"
+    repo_dir.mkdir()
+    initial_commit = _init_git_repo(repo_dir)
+
+    (repo_dir / "new_file.txt").write_text("later change")
+    subprocess.run(["git", "add", "."], cwd=repo_dir, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "second"],
+        cwd=repo_dir,
+        capture_output=True,
+        check=True,
+    )
+
+    task_dir = tmp_path / "project" / "tasks" / "my-task"
+    task_dir.mkdir(parents=True)
+
+    source = SourceConfig(git=str(repo_dir), ref=initial_commit)
+
+    try:
+        ensure_task_environment(task_dir, source, default_docker)
+
+        env_dir = task_dir / "environment"
+        compose = (env_dir / "docker-compose.yaml").read_text()
+
+        context_line = [line.strip() for line in compose.splitlines() if "context:" in line][0]
+        relative_context = context_line.split("context:")[1].strip()
+        worktree_dir = (env_dir / relative_context).resolve()
+
+        assert worktree_dir.exists()
+        assert (worktree_dir / "hello.txt").exists()
+        assert not (worktree_dir / "new_file.txt").exists()
+    finally:
+        cleanup_worktrees()


### PR DESCRIPTION
## Summary

- Design spec for a self-testing benchmark (`examples/nasde-dev-skill/`) that measures whether the `nasde-dev` skill improves agent effectiveness when developing nasde-toolkit itself
- Task: implement multi-attempt support (based on commit `812b189`) — agent starts from `7e1a804` and must add `--attempts/-n` flag, propagate to Harbor, add DNS fix, update docs
- Two variants: `vanilla` (baseline) vs `nasde-dev-skill` (with skill snapshot) to measure skill value

## Scope of this PR (spec only — implementation follows)

This PR includes the **design spec** only. The implementation will include:

1. **Fix `source.git` integration** — connect `docker.py:generate_dockerfile()` to the runner pipeline so benchmarks can use local repo paths (e.g., `source.git: "../.."`) without a custom Dockerfile. This is NOT a separate task — it is part of this work.
2. **Create benchmark project** `examples/nasde-dev-skill/` per the spec — the first example of a benchmark built from a local repository
3. **Update documentation** — CLAUDE.md, README.md with local repo benchmark example, ARCHITECTURE.md if source.git flow changes
4. **Verify end-to-end** — run benchmark with `export_oauth_token.sh`, analyze Harbor logs, compare variant scores, verify Opik traces

## Why this matters

This is the **first local-repo benchmark example** in nasde-toolkit. Users need to see a working pattern for building benchmarks from their own private/local repositories, not just from public GitHub URLs.

## Test plan

- [ ] Review spec for completeness against existing examples (`examples/refactoring-skill/`)
- [ ] Verify assessment dimensions sum to 100
- [ ] Confirm instruction.md doesn't leak implementation details from the reference commit
- [ ] Validate that test.sh checks are achievable without running Harbor
- [ ] After implementation: run benchmark end-to-end, verify Opik traces, compare variant scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)