### PR TITLE
Make evaluator agent configurable (model, MCP, skills, system prompt)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,7 +33,7 @@ flowchart TB
 
     subgraph ASSESSMENT ["3. Assessment evaluation (host machine, always local)"]
         ARTIFACTS -->|"Harbor done,\nsandboxes torn down"| EVAL["evaluator.evaluate_job()"]
-        EVAL --> SDK["Claude Code SDK\n(local subprocess, sonnet)\ntools: Read/Glob/Grep\ncwd = artifacts/workspace/"]
+        EVAL --> SDK["Claude Code SDK\n(local subprocess, opus)\ntools: Read/Glob/Grep + MCP\ncwd = artifacts/workspace/\n+ optional skills & system prompt"]
         SDK --> SCORE["Score across N dimensions\n0-25 pts each"]
         SCORE --> JSON_OUT["assessment_eval.json"]
         SCORE --> OPIK_FB["Opik feedback scores\narch_*, reward, duration"]
@@ -157,7 +157,7 @@ flowchart TB
 
     subgraph Evaluator["Claude Code SDK as evaluator"]
         PROMPT["Composite prompt:\ninstruction + rubric +\ndimension constraints"]
-        SDK_RUN["query() with tools:\nRead, Glob, Grep\ncwd = workspace\nmodel = sonnet\nmax_turns = 30"]
+        SDK_RUN["query() with configurable:\nmodel (default: opus)\ntools (default: Read/Glob/Grep)\nMCP servers (optional)\nskills (optional)\nsystem prompt (optional)\nmax_turns (default: 30)"]
         PARSE["Parse JSON from\nlast json code block"]
     end
 
@@ -177,6 +177,26 @@ flowchart TB
     SCORE --> FILE
     SCORE --> OPIK
 ```
+
+---
+
+## Evaluator configuration
+
+The evaluator agent is configurable via `[evaluation]` in `nasde.toml`. All options are optional — defaults provide a working evaluator out of the box.
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `model` | `claude-opus-4-6` | Evaluator model (Opus recommended for review quality) |
+| `dimensions_file` | `assessment_dimensions.json` | Path to scoring dimensions |
+| `max_turns` | `30` | Max conversation turns for evaluator |
+| `allowed_tools` | `["Read", "Glob", "Grep"]` | Tool whitelist for evaluator |
+| `mcp_config` | — | Path to MCP server config JSON (same format as Claude Code MCP config) |
+| `skills_dir` | — | Path to skills directory (copied into evaluator's `.claude/skills/`) |
+| `append_system_prompt` | — | Extra text appended to evaluator's system prompt |
+
+When `skills_dir` is set, the evaluator runs in a temporary workspace with skills installed. Trial artifacts are made accessible via `add_dirs`, and the prompt references the artifact path explicitly.
+
+When `mcp_config` is set, MCP servers are loaded from the JSON file and passed to the Claude Code SDK. MCP tool names follow the `mcp__<server>__<tool>` convention and must be included in `allowed_tools` if that field is overridden.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the full system architecture with dia
 - **CLI framework**: Typer with Rich markup mode. The `app` object in `cli.py` is the entry point registered in `pyproject.toml` as `nasde`.
 - **Configuration**: Two-layer config — `nasde.toml` for project-level settings, `task.json` per task. Both parsed into `@dataclass` models in `config.py`. Task discovery walks `tasks/` (or `.nasde/tasks/`) automatically.
 - **Benchmark runner**: Uses Harbor Python API (`Job`, `JobConfig`) directly instead of subprocess. The runner merges variant config with task registry into a dict, passes it to `JobConfig.model_validate()`, then runs `await job.run()`. Opik tracking via `track_harbor()` (monkey-patches Harbor at runtime).
-- **Evaluator**: Uses Claude Code SDK async API to run a Claude agent that reads trial artifacts and scores them against assessment criteria. Monkeypatches SDK's `parse_message` to handle unknown message types (remove when SDK fixes this). Results written to `assessment_eval.json` per trial and optionally uploaded to Opik.
+- **Evaluator**: Uses Claude Code SDK async API to run a Claude agent that reads trial artifacts and scores them against assessment criteria. Configurable via `[evaluation]` in `nasde.toml` — model, tools, MCP servers, skills, and system prompt can all be customized. Default model is `claude-opus-4-6` (best available for review quality). Monkeypatches SDK's `parse_message` to handle unknown message types (remove when SDK fixes this). Results written to `assessment_eval.json` per trial and optionally uploaded to Opik.
 - **Variant system**: Each variant is a directory under `variants/`. The `CLAUDE.md` inside is injected into `/app/CLAUDE.md` in the Harbor sandbox. An optional `skills/` subdirectory contains skill snapshots — each `skills/<name>/SKILL.md` is injected into `/app/.claude/skills/<name>/SKILL.md`. If no `harbor_config.json` exists, one is auto-generated from discovered files.
 - **All dependencies are core**: `harbor`, `opik`, `claude-code-sdk` are in `[project.dependencies]`. No optional extras — `uv tool install .` gives full functionality. Assessment evaluation is on by default (`--without-eval` to skip).
 - **Pass-through CLI**: `nasde harbor ...` delegates to Harbor's Typer app via `add_typer()`. `nasde opik ...` forwards args to Opik's Click CLI via `ctx.args`.
@@ -109,6 +109,10 @@ my-benchmark/
           SKILL.md              # Skill content (snapshot for deterministic testing)
       harbor_config.json        # Optional: agent import path + sandbox_files mapping
       claude_config.json        # Optional: MCP server configuration
+  evaluator_skills/             # Optional: skills for the evaluator agent
+    <skill-name>/
+      SKILL.md
+  evaluator_mcp.json            # Optional: MCP server config for the evaluator agent
   jobs/                         # Trial output (gitignored)
 ```
 
@@ -132,8 +136,13 @@ base_image = "ubuntu:22.04"
 build_commands = []
 
 [evaluation]
-model = "claude-sonnet-4-6"
+model = "claude-opus-4-6"
 dimensions_file = "assessment_dimensions.json"
+# max_turns = 30                              # Max evaluator conversation turns
+# allowed_tools = ["Read", "Glob", "Grep"]    # Override default tool whitelist
+# mcp_config = "./evaluator_mcp.json"         # MCP server config for evaluator
+# skills_dir = "./evaluator_skills"           # Skills directory for evaluator
+# append_system_prompt = ""                   # Extra system prompt for evaluator
 
 [reporting]
 platform = "opik"

--- a/README.md
+++ b/README.md
@@ -163,6 +163,83 @@ harbor_env = "daytona"
 
 See the [Harbor documentation](https://harborframework.com/docs/cloud) for detailed provider configuration.
 
+## Configuring the reviewer agent
+
+The reviewer agent (assessment evaluator) is configurable via the `[evaluation]` section in `nasde.toml`. By default it uses `claude-opus-4-6` with read-only tools (`Read`, `Glob`, `Grep`).
+
+### Model
+
+Use the best available model for review quality:
+
+```toml
+[evaluation]
+model = "claude-opus-4-6"   # Default — recommended for review quality
+```
+
+### Skills
+
+Give the reviewer agent skills (e.g. a code review methodology). Create a directory with `SKILL.md` files:
+
+```
+my-benchmark/
+  evaluator_skills/
+    code-review/
+      SKILL.md              # Review methodology, scoring principles
+```
+
+```toml
+[evaluation]
+skills_dir = "./evaluator_skills"
+```
+
+Skills are copied into the evaluator's workspace and loaded natively by Claude Code. The evaluator's prompt automatically adjusts to reference artifact paths correctly.
+
+### MCP servers
+
+Add external analysis tools (linters, complexity analyzers) as MCP servers:
+
+```json
+// evaluator_mcp.json
+{
+  "mcpServers": {
+    "code-analysis": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["@some-org/code-analysis-mcp"]
+    }
+  }
+}
+```
+
+```toml
+[evaluation]
+mcp_config = "./evaluator_mcp.json"
+allowed_tools = ["Read", "Glob", "Grep", "mcp__code-analysis__analyze"]
+```
+
+MCP tool names follow the `mcp__<server>__<tool>` convention. If you override `allowed_tools`, you must include the MCP tools explicitly.
+
+### System prompt
+
+Append custom instructions to the evaluator's system prompt:
+
+```toml
+[evaluation]
+append_system_prompt = "Pay special attention to SOLID principles when scoring."
+```
+
+### All options
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `model` | `claude-opus-4-6` | Evaluator model |
+| `dimensions_file` | `assessment_dimensions.json` | Scoring dimensions file |
+| `max_turns` | `30` | Max conversation turns |
+| `allowed_tools` | `["Read", "Glob", "Grep"]` | Tool whitelist |
+| `mcp_config` | — | Path to MCP server config JSON |
+| `skills_dir` | — | Path to evaluator skills directory |
+| `append_system_prompt` | — | Extra system prompt text |
+
 ## Commands
 
 ### Core

--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ my-benchmark/
       CLAUDE.md                # Agent system prompt for this variant
     guided/
       CLAUDE.md
+  evaluator_skills/            # Optional: skills for the evaluator agent
+    code-review/
+      SKILL.md
+  evaluator_mcp.json           # Optional: MCP server config for evaluator
   jobs/                        # Trial output (gitignored)
 ```
 
@@ -234,8 +238,13 @@ base_image = "ubuntu:22.04"
 build_commands = []
 
 [evaluation]
-model = "claude-sonnet-4-6"
+model = "claude-opus-4-6"
 dimensions_file = "assessment_dimensions.json"
+# max_turns = 30                              # Max evaluator conversation turns
+# allowed_tools = ["Read", "Glob", "Grep"]    # Override default tool whitelist
+# mcp_config = "./evaluator_mcp.json"         # MCP server config for evaluator
+# skills_dir = "./evaluator_skills"           # Skills directory for evaluator
+# append_system_prompt = ""                   # Extra system prompt for evaluator
 
 [reporting]
 platform = "opik"

--- a/examples/ddd-architectural-challenges/evaluator_skills/code-review/SKILL.md
+++ b/examples/ddd-architectural-challenges/evaluator_skills/code-review/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: code-review
+description: Use when reviewing AI-generated code for architectural quality, design patterns, and engineering practices
+---
+
+# Code Review for Assessment Evaluation
+
+You are reviewing code produced by an AI coding agent. Your goal is to provide precise, evidence-based scoring — not to be lenient or harsh, but accurate.
+
+## Review methodology
+
+1. **Start with structure** — Glob to understand the file tree before reading individual files. The shape of the codebase tells you about architectural decisions.
+
+2. **Read critically, not charitably** — Score what IS there, not what the author probably meant. If a pattern is half-implemented, score it as half-implemented.
+
+3. **Trace the domain model** — Follow the flow from entry point to persistence. Look for:
+   - Are domain concepts explicit types or buried in primitives?
+   - Do boundaries between modules/layers exist and hold?
+   - Is business logic in the domain or scattered across infrastructure?
+
+4. **Check encapsulation** — Look for:
+   - Public fields that should be private
+   - Getter/setter pairs that expose internals
+   - Domain objects that are just data bags with no behavior
+   - Invariants that are enforced externally rather than internally
+
+5. **Evaluate test quality** — Tests that merely exist are not enough. Check:
+   - Do tests verify behavior or just call methods?
+   - Are edge cases and failure modes covered?
+   - Do test names describe the scenario being tested?
+   - Are tests testing the unit or the framework?
+
+6. **Look for anti-patterns** — Common problems to flag:
+   - Anemic domain models (logic in services, entities are just DTOs)
+   - Leaking abstractions (domain depends on infrastructure types)
+   - God classes or methods doing too many things
+   - Copy-paste with minor variations instead of proper abstraction
+
+## Scoring principles
+
+- **Evidence required** — Every score must cite specific files, classes, or code patterns. "The code generally looks good" is not evidence.
+- **Calibration** — A max score means excellent, not merely acceptable. Reserve top scores for genuinely well-crafted code.
+- **Partial credit** — If the agent solved the core problem but cut corners on secondary concerns, reflect both in the score and reasoning.
+- **Zero scores are valid** — If a dimension was completely ignored by the agent, score 0 with explanation.

--- a/examples/ddd-architectural-challenges/nasde.toml
+++ b/examples/ddd-architectural-challenges/nasde.toml
@@ -12,8 +12,9 @@ base_image = "ubuntu:22.04"
 build_commands = []
 
 [evaluation]
-model = "claude-sonnet-4-6"
+model = "claude-opus-4-6"
 dimensions_file = "assessment_dimensions.json"
+skills_dir = "./evaluator_skills"
 
 [reporting]
 platform = "opik"

--- a/examples/refactoring-skill/evaluator_skills/code-review/SKILL.md
+++ b/examples/refactoring-skill/evaluator_skills/code-review/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: code-review
+description: Use when reviewing AI-generated code for architectural quality, design patterns, and engineering practices
+---
+
+# Code Review for Assessment Evaluation
+
+You are reviewing code produced by an AI coding agent. Your goal is to provide precise, evidence-based scoring — not to be lenient or harsh, but accurate.
+
+## Review methodology
+
+1. **Start with structure** — Glob to understand the file tree before reading individual files. The shape of the codebase tells you about architectural decisions.
+
+2. **Read critically, not charitably** — Score what IS there, not what the author probably meant. If a pattern is half-implemented, score it as half-implemented.
+
+3. **Trace the domain model** — Follow the flow from entry point to persistence. Look for:
+   - Are domain concepts explicit types or buried in primitives?
+   - Do boundaries between modules/layers exist and hold?
+   - Is business logic in the domain or scattered across infrastructure?
+
+4. **Check encapsulation** — Look for:
+   - Public fields that should be private
+   - Getter/setter pairs that expose internals
+   - Domain objects that are just data bags with no behavior
+   - Invariants that are enforced externally rather than internally
+
+5. **Evaluate test quality** — Tests that merely exist are not enough. Check:
+   - Do tests verify behavior or just call methods?
+   - Are edge cases and failure modes covered?
+   - Do test names describe the scenario being tested?
+   - Are tests testing the unit or the framework?
+
+6. **Look for anti-patterns** — Common problems to flag:
+   - Anemic domain models (logic in services, entities are just DTOs)
+   - Leaking abstractions (domain depends on infrastructure types)
+   - God classes or methods doing too many things
+   - Copy-paste with minor variations instead of proper abstraction
+
+## Scoring principles
+
+- **Evidence required** — Every score must cite specific files, classes, or code patterns. "The code generally looks good" is not evidence.
+- **Calibration** — A max score means excellent, not merely acceptable. Reserve top scores for genuinely well-crafted code.
+- **Partial credit** — If the agent solved the core problem but cut corners on secondary concerns, reflect both in the score and reasoning.
+- **Zero scores are valid** — If a dimension was completely ignored by the agent, score 0 with explanation.

--- a/examples/refactoring-skill/nasde.toml
+++ b/examples/refactoring-skill/nasde.toml
@@ -12,8 +12,9 @@ base_image = "ubuntu:22.04"
 build_commands = []
 
 [evaluation]
-model = "claude-sonnet-4-6"
+model = "claude-opus-4-6"
 dimensions_file = "assessment_dimensions.json"
+skills_dir = "./evaluator_skills"
 
 [reporting]
 platform = "opik"

--- a/src/nasde_toolkit/cli.py
+++ b/src/nasde_toolkit/cli.py
@@ -246,6 +246,7 @@ def eval_command(
         project_name=config.reporting.project_name,
         with_opik=with_opik,
         max_concurrent=max_concurrent_eval,
+        eval_config=config.evaluation,
     ))
 
 

--- a/src/nasde_toolkit/config.py
+++ b/src/nasde_toolkit/config.py
@@ -40,8 +40,13 @@ class DockerConfig:
 class EvaluationConfig:
     """Assessment evaluation settings."""
 
-    model: str = "claude-sonnet-4-6"
+    model: str = "claude-opus-4-6"
     dimensions_file: str = "assessment_dimensions.json"
+    max_turns: int = 30
+    allowed_tools: list[str] | None = None
+    mcp_config: str | None = None
+    skills_dir: str | None = None
+    append_system_prompt: str | None = None
 
 
 @dataclass
@@ -127,8 +132,13 @@ def _parse_toml(raw: dict, project_dir: Path) -> ProjectConfig:
             build_commands=docker_raw.get("build_commands", []),
         ),
         evaluation=EvaluationConfig(
-            model=eval_raw.get("model", "claude-sonnet-4-6"),
+            model=eval_raw.get("model", "claude-opus-4-6"),
             dimensions_file=eval_raw.get("dimensions_file", "assessment_dimensions.json"),
+            max_turns=eval_raw.get("max_turns", 30),
+            allowed_tools=eval_raw.get("allowed_tools"),
+            mcp_config=eval_raw.get("mcp_config"),
+            skills_dir=eval_raw.get("skills_dir"),
+            append_system_prompt=eval_raw.get("append_system_prompt"),
         ),
         reporting=ReportingConfig(
             platform=reporting_raw.get("platform", "opik"),

--- a/src/nasde_toolkit/evaluator.py
+++ b/src/nasde_toolkit/evaluator.py
@@ -11,7 +11,9 @@ import asyncio
 import json
 import os
 import re
+import shutil
 import sys
+import tempfile
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -21,6 +23,8 @@ from claude_code_sdk._internal import client as _sdk_client
 from claude_code_sdk._internal import message_parser as _mp
 from claude_code_sdk.types import AssistantMessage, TextBlock
 from rich.console import Console
+
+from nasde_toolkit.config import EvaluationConfig
 
 # ---------------------------------------------------------------------------
 # Monkeypatch: claude-code-sdk 0.0.25 — unknown message type crash
@@ -97,8 +101,10 @@ async def evaluate_job(
     project_name: str,
     with_opik: bool = False,
     max_concurrent: int = 10,
+    eval_config: EvaluationConfig | None = None,
 ) -> list[EvaluationResult]:
     """Evaluate all trials in a job directory (concurrently)."""
+    eval_config = eval_config or EvaluationConfig()
     trial_dirs = _collect_trial_dirs(job_dir)
 
     if not trial_dirs:
@@ -108,7 +114,9 @@ async def evaluate_job(
     _warn_if_throttled(trial_dirs, max_concurrent)
     semaphore = asyncio.Semaphore(max_concurrent)
     coros = [
-        _evaluate_and_record_trial(td, project_root, project_name, with_opik, semaphore)
+        _evaluate_and_record_trial(
+            td, project_root, project_name, with_opik, semaphore, eval_config,
+        )
         for td in trial_dirs
     ]
     all_results = await asyncio.gather(*coros)
@@ -121,13 +129,15 @@ async def evaluate_and_record_trial(
     project_name: str,
     with_opik: bool,
     semaphore: asyncio.Semaphore,
+    eval_config: EvaluationConfig | None = None,
 ) -> EvaluationResult | None:
     """Evaluate a single trial with semaphore-based concurrency control.
 
     Public wrapper used by runner.py for streaming (Level 2) assessment.
     """
+    eval_config = eval_config or EvaluationConfig()
     return await _evaluate_and_record_trial(
-        trial_dir, project_root, project_name, with_opik, semaphore,
+        trial_dir, project_root, project_name, with_opik, semaphore, eval_config,
     )
 
 
@@ -137,11 +147,13 @@ async def _evaluate_and_record_trial(
     project_name: str,
     with_opik: bool,
     semaphore: asyncio.Semaphore,
+    eval_config: EvaluationConfig | None = None,
 ) -> EvaluationResult | None:
+    eval_config = eval_config or EvaluationConfig()
     async with semaphore:
         console.print(f"\n[bold]Evaluating: {trial_dir.name}[/bold]")
         try:
-            evaluation = await evaluate_trial(trial_dir, project_root)
+            evaluation = await evaluate_trial(trial_dir, project_root, eval_config)
             if not evaluation:
                 return None
             _write_evaluation_result(trial_dir, evaluation)
@@ -170,8 +182,10 @@ def _warn_if_throttled(trial_dirs: list[Path], max_concurrent: int) -> None:
 async def evaluate_trial(
     trial_dir: Path,
     project_root: Path,
+    eval_config: EvaluationConfig | None = None,
 ) -> EvaluationResult | None:
     """Orchestrate assessment evaluation for a single trial."""
+    eval_config = eval_config or EvaluationConfig()
     workspace_path = trial_dir / "artifacts" / "workspace"
     if not workspace_path.exists():
         console.print(f"  [dim]SKIP: No artifacts/workspace/ in {trial_dir.name}[/dim]")
@@ -205,14 +219,17 @@ async def evaluate_trial(
     ground_truth_path = task_dir / "ground_truth_decisions.json"
     ground_truth = ground_truth_path.read_text() if ground_truth_path.exists() else ""
 
+    artifacts_dir = str(workspace_path) if eval_config.skills_dir else None
     prompt = _build_evaluator_prompt(
-        instruction, criteria, expected_dimensions, ground_truth,
+        instruction, criteria, expected_dimensions, ground_truth, artifacts_dir,
     )
     console.print(f"  Task: {task_name}")
     console.print(f"  Workspace: {workspace_path}")
     console.print("  Running Claude Code evaluation...")
 
-    raw_response = await _run_claude_code_evaluation(prompt, workspace_path)
+    raw_response = await _run_claude_code_evaluation(
+        prompt, workspace_path, eval_config, project_root,
+    )
     evaluation = _parse_evaluation_response(raw_response, expected_dimensions)
 
     if not evaluation:
@@ -224,7 +241,7 @@ async def evaluate_trial(
     evaluation.agent_name = agent_name
     evaluation.harbor_reward = harbor_reward
     evaluation.duration_sec = duration_sec
-    evaluation.evaluator_model = "claude-code-sdk"
+    evaluation.evaluator_model = eval_config.model
     evaluation.timestamp = datetime.now(timezone.utc).isoformat()
 
     console.print(f"  Score: {evaluation.total_score}/100 ({evaluation.normalized_score:.2f})")
@@ -298,16 +315,23 @@ def _build_evaluator_prompt(
     criteria: str,
     expected_dimensions: list[dict] | None,
     ground_truth: str = "",
+    artifacts_dir: str | None = None,
 ) -> str:
     """Build the evaluation prompt with optional dimension constraints and ground truth."""
     dimension_constraint = _format_dimension_constraint(expected_dimensions)
     ground_truth_section = _format_ground_truth_section(ground_truth)
 
+    location_hint = (
+        f"Analyze the artifacts in `{artifacts_dir}`."
+        if artifacts_dir
+        else "Analyze the artifacts in the current working directory."
+    )
+
     return f"""You are an expert evaluator assessing AI-generated artifacts against defined criteria.
 
 ## Your task
 
-Analyze the artifacts in the current working directory. These were generated by an AI agent that was given the following task instruction:
+{location_hint} These were generated by an AI agent that was given the following task instruction:
 
 <task_instruction>
 {instruction}
@@ -378,28 +402,90 @@ Use the following ground truth to evaluate completeness and accuracy. The agent'
 # ---------------------------------------------------------------------------
 
 
-async def _run_claude_code_evaluation(prompt: str, workspace_path: Path) -> str:
+async def _run_claude_code_evaluation(
+    prompt: str,
+    workspace_path: Path,
+    eval_config: EvaluationConfig | None = None,
+    project_root: Path = Path(),
+) -> str:
+    eval_config = eval_config or EvaluationConfig()
     _validate_auth()
+    options, temp_dir = _build_claude_code_options(
+        workspace_path, eval_config, project_root,
+    )
 
-    text_parts: list[str] = []
-    async for message in query(
-        prompt=prompt,
-        options=ClaudeCodeOptions(
-            allowed_tools=["Read", "Glob", "Grep"],
-            cwd=str(workspace_path),
-            max_turns=30,
-            model="claude-sonnet-4-6",
-            env={"CLAUDECODE": ""},
-        ),
-    ):
-        if message is None:
-            continue
-        if isinstance(message, AssistantMessage):
-            for block in message.content:
-                if isinstance(block, TextBlock):
-                    text_parts.append(block.text)
+    try:
+        text_parts: list[str] = []
+        async for message in query(prompt=prompt, options=options):
+            if message is None:
+                continue
+            if isinstance(message, AssistantMessage):
+                for block in message.content:
+                    if isinstance(block, TextBlock):
+                        text_parts.append(block.text)
 
-    return "\n".join(text_parts)
+        return "\n".join(text_parts)
+    finally:
+        if temp_dir:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _build_claude_code_options(
+    workspace_path: Path,
+    eval_config: EvaluationConfig,
+    project_root: Path,
+) -> tuple[ClaudeCodeOptions, Path | None]:
+    allowed_tools = eval_config.allowed_tools or ["Read", "Glob", "Grep"]
+    cwd = str(workspace_path)
+    add_dirs: list[str | Path] = []
+    temp_dir: Path | None = None
+
+    if eval_config.skills_dir:
+        temp_dir = Path(tempfile.mkdtemp(prefix="nasde_eval_"))
+        skills_source = _resolve_path(eval_config.skills_dir, project_root)
+        _prepare_skills_workspace(temp_dir, skills_source)
+        add_dirs.append(str(workspace_path))
+        cwd = str(temp_dir)
+
+    mcp_servers: dict | str | Path = {}
+    if eval_config.mcp_config:
+        mcp_config_path = _resolve_path(eval_config.mcp_config, project_root)
+        mcp_servers = str(mcp_config_path)
+
+    kwargs: dict = {}
+    if mcp_servers:
+        kwargs["mcp_servers"] = mcp_servers
+    if eval_config.append_system_prompt:
+        kwargs["append_system_prompt"] = eval_config.append_system_prompt
+
+    options = ClaudeCodeOptions(
+        allowed_tools=allowed_tools,
+        cwd=cwd,
+        max_turns=eval_config.max_turns,
+        model=eval_config.model,
+        env={"CLAUDECODE": ""},
+        add_dirs=add_dirs,
+        **kwargs,
+    )
+
+    return options, temp_dir
+
+
+def _prepare_skills_workspace(temp_dir: Path, skills_source: Path) -> None:
+    if not skills_source.is_dir():
+        console.print(
+            f"  [yellow]WARN: skills_dir '{skills_source}' not found or not a directory[/yellow]"
+        )
+        return
+    target_skills_dir = temp_dir / ".claude" / "skills"
+    shutil.copytree(skills_source, target_skills_dir)
+
+
+def _resolve_path(relative_or_absolute: str, project_root: Path) -> Path:
+    path = Path(relative_or_absolute)
+    if path.is_absolute():
+        return path
+    return project_root / path
 
 
 def _validate_auth() -> dict[str, str]:

--- a/src/nasde_toolkit/runner.py
+++ b/src/nasde_toolkit/runner.py
@@ -301,6 +301,7 @@ async def _run_job_with_streaming_eval(
                 project_name=project_name,
                 with_opik=with_opik,
                 semaphore=eval_semaphore,
+                eval_config=config.evaluation,
             )
         )
         assessment_tasks.append(task)
@@ -406,6 +407,7 @@ async def _run_post_hoc_assessment(
         project_name=config.reporting.project_name,
         with_opik=with_opik,
         max_concurrent=max_concurrent_eval,
+        eval_config=config.evaluation,
     )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-"""Tests for config module — harbor_env in nasde.toml."""
+"""Tests for config module — harbor_env and evaluation settings in nasde.toml."""
 
 from __future__ import annotations
 
@@ -48,3 +48,58 @@ harbor_env = "docker"
 """)
     config = load_project_config(tmp_path)
     assert config.default_harbor_env == "docker"
+
+
+def test_evaluation_defaults_when_section_absent(tmp_path: Path) -> None:
+    _write_nasde_toml(tmp_path, """
+[project]
+name = "test"
+""")
+    config = load_project_config(tmp_path)
+    assert config.evaluation.model == "claude-opus-4-6"
+    assert config.evaluation.dimensions_file == "assessment_dimensions.json"
+    assert config.evaluation.max_turns == 30
+    assert config.evaluation.allowed_tools is None
+    assert config.evaluation.mcp_config is None
+    assert config.evaluation.skills_dir is None
+    assert config.evaluation.append_system_prompt is None
+
+
+def test_evaluation_all_fields_from_toml(tmp_path: Path) -> None:
+    _write_nasde_toml(tmp_path, """
+[project]
+name = "test"
+
+[evaluation]
+model = "claude-sonnet-4-6"
+dimensions_file = "custom_dims.json"
+max_turns = 50
+allowed_tools = ["Read", "Glob", "Grep", "Bash"]
+mcp_config = "./evaluator_mcp.json"
+skills_dir = "./evaluator_skills"
+append_system_prompt = "Focus on SOLID principles."
+""")
+    config = load_project_config(tmp_path)
+    assert config.evaluation.model == "claude-sonnet-4-6"
+    assert config.evaluation.dimensions_file == "custom_dims.json"
+    assert config.evaluation.max_turns == 50
+    assert config.evaluation.allowed_tools == ["Read", "Glob", "Grep", "Bash"]
+    assert config.evaluation.mcp_config == "./evaluator_mcp.json"
+    assert config.evaluation.skills_dir == "./evaluator_skills"
+    assert config.evaluation.append_system_prompt == "Focus on SOLID principles."
+
+
+def test_evaluation_partial_override(tmp_path: Path) -> None:
+    _write_nasde_toml(tmp_path, """
+[project]
+name = "test"
+
+[evaluation]
+model = "claude-sonnet-4-6"
+max_turns = 15
+""")
+    config = load_project_config(tmp_path)
+    assert config.evaluation.model == "claude-sonnet-4-6"
+    assert config.evaluation.max_turns == 15
+    assert config.evaluation.mcp_config is None
+    assert config.evaluation.skills_dir is None


### PR DESCRIPTION
## Summary

- **Default evaluator model changed to `claude-opus-4-6`** — review/assessment uses the best available model
- New `[evaluation]` config fields in `nasde.toml`: `max_turns`, `allowed_tools`, `mcp_config`, `skills_dir`, `append_system_prompt`
- Skills support via workspace overlay (temp dir with `.claude/skills/` + `add_dirs` for artifact access)
- MCP server config loaded from JSON file and passed to Claude Code SDK
- System prompt injection via `append_system_prompt`
- **Bug fix:** `EvaluationConfig.model` was parsed from TOML but never wired to the SDK call (hardcoded sonnet)
- **Bug fix:** `evaluator_model` in assessment results now reflects the actual model used
- Added `evaluator_skills/code-review/SKILL.md` to both example benchmarks with review methodology
- Both examples configured for Opus + skills_dir
- Added "Configuring the reviewer agent" section to README with examples for model, skills, MCP, system prompt

## Test plan

- [x] 20/20 unit tests pass (3 new config tests added)
- [x] CLI smoke test (`nasde --version`, `nasde --help`)
- [x] Import verification (`evaluator`, `config` modules)
- [x] E2E: `nasde run` with default config (Sonnet evaluator) — reward 1.0, score 80/100, 8 Opik feedback scores
- [x] E2E: `nasde eval` re-evaluation with Opus evaluator on same artifacts — score 78/100, `evaluator_model: claude-opus-4-6` confirmed
- [x] E2E: `nasde run` with `skills_dir` + Opus — reward 1.0, score 82/100, 8 Opik scores, `evaluator_model: claude-opus-4-6`
- [ ] E2E with `mcp_config` — not tested (no MCP server available; config wiring is trivial path resolution + SDK pass-through)

## Comparison: Sonnet vs Opus evaluator (same artifacts)

| Dimension | Sonnet | Opus |
|---|---|---|
| domain_modeling | 20/25 | 20/25 |
| encapsulation | 15/20 | 15/20 |
| architecture_compliance | 18/20 | 20/20 |
| extensibility | 15/15 | 15/15 |
| test_quality | 12/20 | 8/20 |
| **Total** | **80/100** | **78/100** |

Opus is stricter on test quality but gives full marks on architecture compliance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)