### PR TITLE
Add OpenAI Codex agent support for cross-agent benchmarking

### DIFF
--- a/.claude/skills/nasde-benchmark-creator/SKILL.md
+++ b/.claude/skills/nasde-benchmark-creator/SKILL.md
@@ -218,9 +218,33 @@ Reference solution for verifying test.sh works. Not executed by Harbor.
 
 ## Step 5: Create variants
 
-Each variant is a directory under `variants/<variant-name>/`. At minimum it contains `CLAUDE.md` — the instructions injected into the agent's sandbox.
+Each variant is a directory under `variants/<variant-name>/` with a required `variant.toml` declaring the agent type.
 
-If no `harbor_config.json` exists, `nasde` auto-generates one. To customize (e.g., add MCP servers), create it explicitly:
+### variant.toml (required)
+
+```toml
+agent = "claude"   # or "codex"
+```
+
+### Claude Code variant
+
+```
+variants/vanilla/
+  variant.toml       # agent = "claude"
+  CLAUDE.md          # Instructions (injected to /app/CLAUDE.md)
+  skills/            # Optional: skill snapshots (injected to /app/.claude/skills/)
+```
+
+### Codex variant
+
+```
+variants/codex-baseline/
+  variant.toml       # agent = "codex"
+  AGENTS.md          # Instructions (injected to /app/AGENTS.md)
+  agents_skills/     # Optional: skill snapshots (injected to /app/.agents/skills/)
+```
+
+If no `harbor_config.json` exists, `nasde` auto-generates one from `variant.toml`. To customize (e.g., add MCP servers), create it explicitly:
 
 ```json
 {
@@ -246,8 +270,9 @@ Critical: `"name"` field is REQUIRED — without it, Opik tagging breaks.
 Design variants to test specific hypotheses:
 - **Minimal** (baseline) — bare instructions, no extra guidance
 - **Guided** — detailed domain-specific guidance, patterns to follow
+- **Skill-augmented** — skills injected for domain expertise (e.g., tactical DDD)
 - **Tool-augmented** — MCP server access (e.g., codebase search)
-- **Constrained** — specific restrictions or requirements
+- **Cross-agent** — same instructions for Claude and Codex to compare agent performance
 
 Every benchmark needs at least one variant (typically `vanilla` or `baseline`).
 

--- a/.claude/skills/nasde-benchmark-runner/SKILL.md
+++ b/.claude/skills/nasde-benchmark-runner/SKILL.md
@@ -67,6 +67,39 @@ For deterministic job names, use `--job-suffix`:
 nasde run --variant vanilla --job-suffix run1 -C path/to/benchmark
 ```
 
+### Running Codex variants
+
+Codex variants use `AGENTS.md` (instead of `CLAUDE.md`) and require `CODEX_API_KEY` (standard OpenAI API key from platform.openai.com):
+
+```bash
+# Set Codex API key
+export CODEX_API_KEY=sk-...
+
+# Run a Codex variant — must specify a Codex-compatible model
+nasde run --variant codex-vanilla --model gpt-5-codex -C path/to/benchmark
+```
+
+**Supported Codex models** (via API key): `gpt-5-codex`, `gpt-5.3-codex`, `gpt-5.4`, `gpt-5.4-mini`. Models like `codex-mini-latest` or `o3-mini` do NOT work with API keys.
+
+### Cross-agent comparison (Claude vs Codex)
+
+Run all variants (both Claude and Codex) on the same tasks:
+
+```bash
+export CODEX_API_KEY=sk-...           # For Codex variants
+export CLAUDE_CODE_OAUTH_TOKEN=...     # For Claude variants
+
+nasde run --all-variants -C path/to/benchmark --with-opik
+```
+
+Or run specific variants in parallel:
+
+```bash
+nasde run --variant vanilla --tasks my-task -C path/to/benchmark --with-opik &
+nasde run --variant codex-vanilla --model gpt-5-codex --tasks my-task -C path/to/benchmark --with-opik &
+wait
+```
+
 ### Custom model and timeout
 
 ```bash
@@ -81,9 +114,13 @@ nasde eval path/to/benchmark/jobs/2026-03-16__14-05-58 --with-opik -C path/to/be
 
 ## Token cost heuristic
 
+**Claude Code variants:**
 When using `CLAUDE_CODE_OAUTH_TOKEN` (Claude subscription — no per-token cost):
 - **Run freely**: total estimated time under 30 minutes (sum of tasks × variants)
 - **Ask first**: over 30 minutes, OR when using `ANTHROPIC_API_KEY` (API billing)
+
+**Codex variants:**
+Always billed per-token via `CODEX_API_KEY`. Always ask before running. Codex uses significantly more input tokens than Claude Code (~1M vs ~250K per task).
 
 Task estimated times are in `task.json` → `estimated_time_minutes`. When `--tasks` filters are used, count only selected tasks.
 
@@ -199,6 +236,19 @@ Harbor didn't copy artifacts. Check:
 1. Check trace exists: use the REST API verification script above
 2. If trace exists but no `arch_*` scores: assessment eval didn't run or failed. Check the CLI output for errors.
 3. If no trace at all: Opik tracking wasn't enabled. Verify `.env` has `OPIK_API_KEY` and `OPIK_WORKSPACE`.
+
+### Codex trial fails immediately (reward 0, 0/100)
+
+Check the agent log for errors:
+```bash
+head -20 jobs/<ts>/<trial>/agent/codex.txt
+```
+
+Common causes:
+- **`Incorrect API key provided: ''`** — `CODEX_API_KEY` not set or not exported
+- **`model 'X' does not exist`** — wrong model name. Use `gpt-5-codex`, `gpt-5.3-codex`, `gpt-5.4`, or `gpt-5.4-mini`
+- **`Tool 'web_search_preview' is not supported`** — model doesn't support Codex tools (e.g. `o3-mini`)
+- **`Model metadata for 'X' not found`** — warning only, usually followed by the real error
 
 ### Trial reward is 0 but code looks correct
 

--- a/.claude/skills/nasde-dev/SKILL.md
+++ b/.claude/skills/nasde-dev/SKILL.md
@@ -29,12 +29,19 @@ grep -r "sdlc.eval\|sdlc-eval\|sdlc_eval" src/ docs/ CLAUDE.md README.md .claude
 uv sync
 ```
 
-### 1b. Documentation consistency
+### 1b. Documentation and skills consistency
 
-After any change to the evaluation pipeline, CLI flags, configuration schema, or sandbox/environment handling, update **all** of these:
+After any change to the evaluation pipeline, CLI flags, configuration schema, agent support, or sandbox/environment handling, update **all** of these:
+
+**Documentation:**
 - `ARCHITECTURE.md` — system architecture with mermaid diagrams (end-to-end flow, trial lifecycle, cloud sandbox providers, assessment evaluation)
-- `README.md` — user-facing documentation (CLI options table, nasde.toml example, prerequisites)
+- `README.md` — user-facing documentation (CLI options table, nasde.toml example, prerequisites, authentication)
 - `CLAUDE.md` — agent instructions (CLI reference, nasde.toml example, architecture decisions)
+
+**Skills (update when relevant to the change):**
+- `.claude/skills/nasde-benchmark-runner/SKILL.md` — running benchmarks, supported models/agents, auth, troubleshooting
+- `.claude/skills/nasde-benchmark-creator/SKILL.md` — creating benchmarks, variant structure, task formats, agent conventions
+- `.claude/skills/nasde-dev/SKILL.md` — this file, verification protocol
 
 ### 2. CLI smoke test
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-NASDE evaluates AI coding agents (e.g. Claude Code) on programming tasks. It uses **Harbor** as the execution engine running agents in isolated sandbox environments and **Opik** as the observability platform for tracking results.
+NASDE evaluates AI coding agents (e.g. Claude Code, OpenAI Codex) on programming tasks. It uses **Harbor** as the execution engine running agents in isolated sandbox environments and **Opik** as the observability platform for tracking results.
 
 Key design: evaluation is **two-stage** — Harbor assesses functional correctness (tests pass/fail), then a separate reviewer agent (Claude Code SDK) assesses architectural quality of the generated code.
 
@@ -200,11 +200,16 @@ When `mcp_config` is set, MCP servers are loaded from the JSON file and passed t
 
 ---
 
-## ConfigurableClaude — the only custom agent class
+## Custom agent classes
 
 ```mermaid
 classDiagram
     class ClaudeCode {
+        <<Harbor built-in>>
+        +setup(environment)
+        +solve(task)
+    }
+    class Codex {
         <<Harbor built-in>>
         +setup(environment)
         +solve(task)
@@ -215,12 +220,20 @@ classDiagram
         -_upload_sandbox_files(environment)
         +name() str
     }
+    class ConfigurableCodex {
+        -_sandbox_files: dict~str, str~
+        +setup(environment)
+        -_upload_sandbox_files(environment)
+        +name() str
+    }
     ClaudeCode <|-- ConfigurableClaude
+    Codex <|-- ConfigurableCodex
 
-    note for ConfigurableClaude "Only reason to exist: Harbor has no\nmechanism for injecting files into\nthe sandbox (e.g. CLAUDE.md, MCP config)"
+    note for ConfigurableClaude "Injects CLAUDE.md, .claude/skills/ into sandbox"
+    note for ConfigurableCodex "Injects AGENTS.md, .agents/skills/ into sandbox"
 ```
 
-Harbor natively handles auth, MCP servers, model selection, and timeout. `ConfigurableClaude` adds **one thing**: declarative file mapping from host to the sandbox via `sandbox_files` in `harbor_config.json`.
+Harbor natively handles auth, MCP servers, model selection, and timeout for both agents. `ConfigurableClaude` and `ConfigurableCodex` each add **one thing**: declarative file mapping from host to the sandbox via `sandbox_files` in `harbor_config.json`. The agent type is auto-detected from the variant's instruction file (`CLAUDE.md` → Claude, `AGENTS.md` → Codex).
 
 ---
 
@@ -229,14 +242,15 @@ Harbor natively handles auth, MCP servers, model selection, and timeout. `Config
 Each benchmark defines its **own set of variants** — there are no globally shared variants. A variant represents a specific agent configuration to be compared against other variants on the same set of tasks.
 
 Each variant is a directory under `variants/<variant-name>/` containing:
-- `CLAUDE.md` — project instructions injected into `/app/CLAUDE.md` in the sandbox (required)
-- `skills/` — skill snapshots, each `skills/<name>/SKILL.md` injected into `/app/.claude/skills/<name>/SKILL.md` (optional)
-- `harbor_config.json` — agent import path + `sandbox_files` mapping (auto-generated if absent)
-- `claude_config.json` — MCP server configuration (optional)
+- `variant.toml` — **required**, declares the agent type (`agent = "claude"` or `agent = "codex"`)
+- `CLAUDE.md` — Claude Code instructions injected into `/app/CLAUDE.md` (for Claude variants)
+- `AGENTS.md` — Codex instructions injected into `/app/AGENTS.md` (for Codex variants)
+- `skills/` — Claude skill snapshots, each `skills/<name>/SKILL.md` injected into `/app/.claude/skills/<name>/SKILL.md` (optional)
+- `agents_skills/` — Codex skill snapshots, each `agents_skills/<name>/` injected recursively into `/app/.agents/skills/<name>/` (optional)
+- `harbor_config.json` — agent import path + `sandbox_files` mapping (auto-generated from `variant.toml` if absent)
+- `claude_config.json` — MCP server configuration, Claude only (optional)
 
-This mirrors a real Claude Code project where CLAUDE.md and `.claude/skills/` are separate concerns. Skills in variants are deterministic snapshots — copies of the skill at a specific point in time, not references to external sources.
-
-Variants can differ along many axes: instruction specificity, skill combinations, tool access, constraints, prompting techniques.
+Variants can differ along many axes: agent type, instruction specificity, skill combinations, tool access, constraints, prompting techniques. Cross-agent comparison (e.g. Claude vs Codex on the same tasks) is a key use case.
 
 ---
 
@@ -328,5 +342,6 @@ src/nasde_toolkit/
   docker.py                # Docker environment helpers
   scaffold/                # Project scaffolding templates
   agents/
-    configurable_claude.py # Harbor-compatible agent with sandbox file injection
+    configurable_claude.py # Harbor-compatible Claude Code agent with sandbox file injection
+    configurable_codex.py  # Harbor-compatible Codex agent with sandbox file injection
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,8 @@ src/nasde_toolkit/
     __init__.py            # Project scaffolding templates and file creation
   agents/
     __init__.py
-    configurable_claude.py # Harbor-compatible agent with sandbox file injection
+    configurable_claude.py # Harbor-compatible Claude Code agent with sandbox file injection
+    configurable_codex.py  # Harbor-compatible Codex agent with sandbox file injection
 tests/
 pyproject.toml
 ```
@@ -54,7 +55,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the full system architecture with dia
 - **Configuration**: Two-layer config — `nasde.toml` for project-level settings, `task.json` per task. Both parsed into `@dataclass` models in `config.py`. Task discovery walks `tasks/` (or `.nasde/tasks/`) automatically.
 - **Benchmark runner**: Uses Harbor Python API (`Job`, `JobConfig`) directly instead of subprocess. The runner merges variant config with task registry into a dict, passes it to `JobConfig.model_validate()`, then runs `await job.run()`. Opik tracking via `track_harbor()` (monkey-patches Harbor at runtime).
 - **Evaluator**: Uses Claude Code SDK async API to run a Claude agent that reads trial artifacts and scores them against assessment criteria. Configurable via `[evaluation]` in `nasde.toml` — model, tools, MCP servers, skills, and system prompt can all be customized. Default model is `claude-opus-4-6` (best available for review quality). Monkeypatches SDK's `parse_message` to handle unknown message types (remove when SDK fixes this). Results written to `assessment_eval.json` per trial and optionally uploaded to Opik.
-- **Variant system**: Each variant is a directory under `variants/`. The `CLAUDE.md` inside is injected into `/app/CLAUDE.md` in the Harbor sandbox. An optional `skills/` subdirectory contains skill snapshots — each `skills/<name>/SKILL.md` is injected into `/app/.claude/skills/<name>/SKILL.md`. If no `harbor_config.json` exists, one is auto-generated from discovered files.
+- **Variant system**: Each variant is a directory under `variants/` with a required `variant.toml` declaring the agent type (`agent = "claude"` or `agent = "codex"`). For Claude Code variants, `CLAUDE.md` is injected into `/app/CLAUDE.md`; for Codex variants, `AGENTS.md` is injected into `/app/AGENTS.md`. An optional `skills/` subdirectory contains Claude skill snapshots — each `skills/<name>/SKILL.md` is injected into `/app/.claude/skills/<name>/SKILL.md`. An optional `agents_skills/` subdirectory contains Codex skill snapshots — all files under `agents_skills/<name>/` are injected into `/app/.agents/skills/<name>/`. If no `harbor_config.json` exists, one is auto-generated from `variant.toml`.
 - **All dependencies are core**: `harbor`, `opik`, `claude-code-sdk` are in `[project.dependencies]`. No optional extras — `uv tool install .` gives full functionality. Assessment evaluation is on by default (`--without-eval` to skip).
 - **Pass-through CLI**: `nasde harbor ...` delegates to Harbor's Typer app via `add_typer()`. `nasde opik ...` forwards args to Opik's Click CLI via `ctx.args`.
 - See `docs/adr/` for detailed decision records.
@@ -103,10 +104,15 @@ my-benchmark/
       solution/solve.sh         # Optional reference solution
   variants/
     <variant-name>/
-      CLAUDE.md                 # Project instructions (injected into /app/CLAUDE.md in sandbox)
-      skills/                   # Optional: skill snapshots (injected into /app/.claude/skills/)
+      variant.toml              # Required: agent type declaration (agent = "claude" or "codex")
+      CLAUDE.md                 # Claude Code instructions (injected into /app/CLAUDE.md)
+      AGENTS.md                 # Codex instructions (injected into /app/AGENTS.md)
+      skills/                   # Optional: Claude skill snapshots (injected into /app/.claude/skills/)
         <skill-name>/
           SKILL.md              # Skill content (snapshot for deterministic testing)
+      agents_skills/            # Optional: Codex skill snapshots (injected into /app/.agents/skills/)
+        <skill-name>/
+          SKILL.md              # Skill content with YAML frontmatter (name + description)
       harbor_config.json        # Optional: agent import path + sandbox_files mapping
       claude_config.json        # Optional: MCP server configuration
   evaluator_skills/             # Optional: skills for the evaluator agent
@@ -205,6 +211,7 @@ timeout_sec = 300
 
 ### harbor_config.json (per variant)
 
+Claude Code variant:
 ```json
 {
   "agents": [
@@ -222,8 +229,27 @@ timeout_sec = 300
 }
 ```
 
+Codex variant:
+```json
+{
+  "agents": [
+    {
+      "import_path": "nasde_toolkit.agents.configurable_codex:ConfigurableCodex",
+      "name": "variant-name",
+      "model_name": "o3",
+      "kwargs": {
+        "sandbox_files": {
+          "/app/AGENTS.md": "/absolute/path/to/variants/variant-name/AGENTS.md"
+        },
+        "reasoning_effort": "high"
+      }
+    }
+  ]
+}
+```
+
 Critical: `"name"` field is REQUIRED — without it, Opik tagging breaks.
-If `harbor_config.json` is absent, `nasde` auto-generates one from `CLAUDE.md`.
+If `harbor_config.json` is absent, `nasde` auto-generates one based on the instruction file present (`CLAUDE.md` → Claude, `AGENTS.md` → Codex).
 
 ### tests/test.sh (Harbor verifier)
 

--- a/README.md
+++ b/README.md
@@ -106,23 +106,31 @@ After installation, only `nasde` appears on PATH. Harbor, Opik, and Claude Code 
 ## Quick start
 
 ```bash
-# Set authentication (one of)
+# Set authentication for the agent you want to use:
+
+# Claude Code (one of)
 export ANTHROPIC_API_KEY=sk-ant-...
 export CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...
+
+# OpenAI Codex
+export CODEX_API_KEY=sk-...        # OpenAI API key (from platform.openai.com)
 
 # 1. Scaffold a new evaluation project
 nasde init my-benchmark
 
-# 2. Run benchmark (assessment evaluation runs by default)
+# 2. Run benchmark with Claude Code variant
 nasde run --variant vanilla -C my-benchmark
 
-# 3. Run specific tasks with Opik tracing
+# 3. Run benchmark with Codex variant
+nasde run --variant codex-baseline --model o3 -C my-benchmark
+
+# 4. Run specific tasks with Opik tracing
 nasde run --variant vanilla --tasks my-task -C my-benchmark --with-opik
 
-# 4. Skip assessment evaluation (Harbor only)
+# 5. Skip assessment evaluation (Harbor only)
 nasde run --variant vanilla -C my-benchmark --without-eval
 
-# 5. Re-evaluate an existing job directory
+# 6. Re-evaluate an existing job directory
 nasde eval jobs/2026-03-13__14-30-00 --with-opik -C my-benchmark
 ```
 
@@ -286,15 +294,35 @@ my-benchmark/
       tests/
         test.sh                # Harbor verification script
   variants/
-    vanilla/
-      CLAUDE.md                # Agent system prompt for this variant
-    guided/
+    vanilla/                   # Claude Code variant
+      variant.toml             # agent = "claude"
+      CLAUDE.md                # Agent system prompt (injected to /app/CLAUDE.md)
+    guided/                    # Claude Code variant with skills
+      variant.toml             # agent = "claude"
       CLAUDE.md
+      skills/                  # Claude skills (injected to /app/.claude/skills/)
+        my-skill/
+          SKILL.md
+    codex-baseline/            # Codex variant
+      variant.toml             # agent = "codex"
+      AGENTS.md                # Codex instructions (injected to /app/AGENTS.md)
+    codex-with-skills/         # Codex variant with skills
+      variant.toml             # agent = "codex"
+      AGENTS.md
+      agents_skills/           # Codex skills (injected to /app/.agents/skills/)
+        my-skill/
+          SKILL.md             # Requires YAML frontmatter (name + description)
   evaluator_skills/            # Optional: skills for the evaluator agent
     code-review/
       SKILL.md
   evaluator_mcp.json           # Optional: MCP server config for evaluator
   jobs/                        # Trial output (gitignored)
+```
+
+Each variant must have a `variant.toml` declaring the agent type:
+
+```toml
+agent = "claude"   # or "codex"
 ```
 
 ### `nasde.toml`
@@ -336,6 +364,10 @@ Key design: `nasde` is a **thin integration layer** over Harbor and Opik, not a 
 
 ## Authentication
 
+NASDE auto-detects the required credentials based on the variant's agent type.
+
+### Claude Code
+
 The tool checks for auth tokens in this order:
 1. `ANTHROPIC_API_KEY` environment variable
 2. `CLAUDE_CODE_OAUTH_TOKEN` environment variable
@@ -349,6 +381,22 @@ source scripts/export_oauth_token.sh
 
 This lets you use your Claude Pro/Max subscription instead of an API key.
 
+### OpenAI Codex
+
+Codex variants require an **OpenAI API key**. This is a standard API key from [platform.openai.com](https://platform.openai.com/api-keys) — the same key you'd use for any OpenAI API call (GPT, o3, etc.). It is billed per-token through your OpenAI Platform account.
+
+Set it as `CODEX_API_KEY` (preferred by the Codex CLI):
+
+```bash
+export CODEX_API_KEY=sk-...
+```
+
+`OPENAI_API_KEY` also works, but `CODEX_API_KEY` is recommended to avoid conflicts with other OpenAI tools.
+
+> **Note:** Codex CLI also supports OAuth-based auth via ChatGPT subscriptions (`codex login`), but NASDE currently only supports API key authentication for Codex variants, since agents run in isolated Docker/cloud sandboxes where OAuth sessions from the host are not available.
+
+### Opik tracing
+
 For Opik tracing, set credentials in `.env` (in project dir or parent):
 ```
 OPIK_API_KEY=...
@@ -361,7 +409,10 @@ OPIK_PROJECT_NAME=...
 - **Python 3.12+**
 - **Docker** (default) or a cloud sandbox provider — Harbor runs agents in isolated environments
 - **uv** — Package manager
-- **ANTHROPIC_API_KEY** or **CLAUDE_CODE_OAUTH_TOKEN** — Required for agent and evaluator execution
+- **Agent credentials** (at least one):
+  - Claude Code: `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`
+  - OpenAI Codex: `CODEX_API_KEY` (OpenAI API key from [platform.openai.com](https://platform.openai.com/api-keys))
+- **ANTHROPIC_API_KEY** or **CLAUDE_CODE_OAUTH_TOKEN** — Also required for the assessment evaluator (which always uses Claude Code SDK)
 
 ## Verifying Opik results
 

--- a/examples/ddd-architectural-challenges/variants/codex-guided/AGENTS.md
+++ b/examples/ddd-architectural-challenges/variants/codex-guided/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent Instructions
+
+## Approach
+
+1. Before writing any code, explore the existing codebase to understand its architecture and conventions.
+2. Follow existing architectural patterns exactly — match naming, namespaces, directory structure, and code style.
+3. Write tests that match the style of existing test files.
+
+## Architecture guidelines
+
+- Model domain concepts as Value Objects (immutable, with equality and factory methods) following existing examples in the codebase.
+- Respect layer boundaries and separation of concerns — place code where similar code already lives.
+- Design for extensibility: integrate new concepts into existing discriminated unions or pattern-matching structures so that adding further variants follows the same pattern.
+- Cover edge cases and boundary conditions in tests, including validation of invalid inputs.

--- a/examples/ddd-architectural-challenges/variants/codex-guided/variant.toml
+++ b/examples/ddd-architectural-challenges/variants/codex-guided/variant.toml
@@ -1,0 +1,1 @@
+agent = "codex"

--- a/examples/ddd-architectural-challenges/variants/codex-ntcoding-tactical-ddd/AGENTS.md
+++ b/examples/ddd-architectural-challenges/variants/codex-ntcoding-tactical-ddd/AGENTS.md
@@ -1,0 +1,7 @@
+# Agent Instructions
+
+## Approach
+
+1. Before writing any code, explore the existing codebase to understand its architecture and conventions.
+2. Follow existing architectural patterns exactly — match naming, namespaces, directory structure, and code style.
+3. Write tests that match the style of existing test files.

--- a/examples/ddd-architectural-challenges/variants/codex-ntcoding-tactical-ddd/agents_skills/tactical-ddd/SKILL.md
+++ b/examples/ddd-architectural-challenges/variants/codex-ntcoding-tactical-ddd/agents_skills/tactical-ddd/SKILL.md
@@ -1,0 +1,501 @@
+<!-- Source: ntcoding/claude-skillz -->
+<!-- Snapshot: 2026-03-20 -->
+---
+name: tactical-ddd
+description: "Design, refactor, analyze, and review code by applying the principles and patterns of tactical domain-driven design. Triggers on: domain modeling, aggregate design, 'entity', 'value object', 'repository', 'bounded context', 'domain event', 'domain service', code touching domain/ directories, rich domain model discussions."
+version: 1.0.0
+---
+
+# Tactical DDD
+
+Design, refactor, analyze, and review code by applying the principles and patterns of tactical domain-driven design.
+
+## Principles
+
+1. **Isolate domain logic**
+2. **Use rich domain language**
+3. **Orchestrate with use cases**
+4. **Avoid anemic domain model**
+5. **Separate generic concepts**
+6. **Make the implicit explicit... like your life depends on it**
+7. **Design aggregates around invariants**
+8. **Extract immutable value objects liberally**
+9. **Repositories are for loading and saving full aggregates**
+
+---
+
+## 1. Isolate domain logic
+
+**What:** Domain logic is not mixed with technical code like HTTP and database transactions.
+
+**Why:** Easier to understand the most important part of the code, easier to validate with domain experts, easier to test and evolve, easier to plan and implement new features.
+
+**Test:** Could a domain expert read the code? Can the code be unit tested without mocks or spinning up databases?
+
+```typescript
+// ❌ WRONG - domain polluted with infrastructure
+class Delivery {
+  async dispatch() {
+    this.logger.info('Dispatching delivery', { id: this.id })  // Infrastructure!
+    await this.db.beginTransaction()                           // Infrastructure!
+    if (this.status !== 'ready') throw new Error('Not ready')
+    this.status = 'dispatched'
+    await this.db.save(this)                                   // Infrastructure!
+    await this.db.commit()                                     // Infrastructure!
+    await this.pushNotification.notifyDriver()                 // Infrastructure!
+  }
+}
+
+// ✅ RIGHT - isolated domain logic
+class Delivery {
+  dispatch(): void {
+    if (this.status !== DeliveryStatus.Ready) {
+      throw new DeliveryNotReadyError(this.id)
+    }
+    this.status = DeliveryStatus.Dispatched
+    this.dispatchedAt = new Date()
+  }
+}
+```
+
+---
+
+## 2. Use rich domain language
+
+**What:** Names in code match exactly what domain experts say. No programmer jargon. No generic names.
+
+**Why:** Translation between code-speak and business-speak causes bugs. When a domain expert says "assess a claim" and the code says "processEntity", someone will misunderstand something.
+
+**Test:** Would a domain expert recognize this name? If you'd need to translate it for them, it's wrong.
+
+**Common generic terms to watch for:**
+- `Manager`, `Handler`, `Processor`, `Helper`, `Util`
+- `Data`, `Info`, `Item` (when domain terms exist)
+- `process`, `handle`, `execute` (what does it actually DO?)
+
+```typescript
+// ❌ WRONG - programmer jargon
+class ClaimHandler {
+  processClaimData(claimData: ClaimDTO): ProcessingResult {
+    return this.claimProcessor.handle(claimData)
+  }
+}
+
+// ✅ RIGHT - domain language
+class ClaimAssessor {
+  assessClaim(claim: InsuranceClaim): AssessmentDecision {
+    if (claim.exceedsCoverageLimit()) {
+      return AssessmentDecision.deny(DenialReason.ExceedsCoverage)
+    }
+    return AssessmentDecision.approve()
+  }
+}
+```
+
+---
+
+## 3. Orchestrate with use cases
+
+**What:** A use case is a user goal—something a user would recognize as an action they can perform in your application.
+
+**Why:** Use cases define the entry points to your domain. They answer "what can a user do?" If something isn't a user goal, it's supporting machinery that belongs elsewhere.
+
+**Test (the menu test):** If you described your application's features to a user like a menu, would this be on it?
+
+```
+DELIVERY APP MENU:
+├── Request Delivery     ← Use case: user goal
+├── Track Delivery       ← Use case: user goal
+├── Cancel Delivery      ← Use case: user goal
+├── Calculate ETA        ← NOT a use case: internal machinery
+└── Check Delivery Radius ← NOT a use case: domain rule
+```
+
+```typescript
+// ❌ WRONG - not a user goal, this is internal machinery
+// use-cases/calculate-eta.use-case.ts
+async function calculateETA(deliveryId: DeliveryId) {
+  const delivery = await deliveryRepository.find(deliveryId)
+  const driver = await driverRepository.find(delivery.driverId)
+  return routeService.estimateArrival(driver.location, delivery.destination)
+}
+
+// ✅ RIGHT - actual user goal (appears in menu)
+// use-cases/cancel-delivery.use-case.ts
+async function cancelDelivery(deliveryId: DeliveryId, reason: CancellationReason) {
+  const delivery = await deliveryRepository.find(deliveryId)
+  delivery.cancel(reason)
+  await deliveryRepository.save(delivery)
+}
+```
+
+---
+
+## 4. Avoid anemic domain model
+
+**What:** Domain logic lives in domain objects, not in use cases. Use cases orchestrate; domain objects decide.
+
+**Why:** When business rules leak into use cases, they scatter across the codebase, duplicate, and diverge. The domain becomes a dumb data carrier.
+
+**Test:** Is your use case making business decisions, or just coordinating? If the use case contains if/else business logic, you likely have an anemic model.
+
+```typescript
+// ❌ WRONG - business logic in use case (anemic domain)
+async function confirmDropoff(deliveryId: DeliveryId, photo: ProofPhoto) {
+  const delivery = await deliveryRepository.find(deliveryId)
+
+  // Business rules leaked into use case!
+  if (delivery.status !== 'in_transit') {
+    throw new Error('Delivery not in transit')
+  }
+  if (!photo && delivery.requiresSignature) {
+    throw new Error('Proof of delivery required')
+  }
+
+  delivery.status = 'delivered'
+  delivery.proofPhoto = photo
+  delivery.deliveredAt = new Date()
+  await deliveryRepository.save(delivery)
+}
+
+// ✅ RIGHT - use case orchestrates, domain decides
+async function confirmDropoff(deliveryId: DeliveryId, photo: ProofPhoto) {
+  const delivery = await deliveryRepository.find(deliveryId)
+
+  delivery.confirmDropoff(photo)  // Domain enforces the rules
+
+  await deliveryRepository.save(delivery)
+}
+```
+
+**Signs of anemic model:**
+- Use cases full of if/else business logic
+- Domain objects are just data with getters/setters
+- Business rules duplicated across multiple use cases
+- Validation logic outside the object being validated
+
+---
+
+## 5. Separate generic concepts
+
+**What:** Generic capabilities that aren't specific to your domain live separately from domain-specific logic.
+
+**Why:** A retry mechanism, a caching layer, a validation framework—these aren't YOUR domain. Mixing them with domain logic obscures what's actually specific to your business.
+
+**Test:** Would this code exist in a completely different business domain? If yes, it's generic. If it's specific to YOUR business rules, it's domain.
+
+```typescript
+// ❌ WRONG - generic retry logic mixed with domain
+// domain/driver-locator.ts
+class DriverLocator {
+  // Generic retry logic does not belong in domain!
+  private async withRetry<T>(fn: () => Promise<T>, attempts: number): Promise<T> {
+    for (let i = 0; i < attempts; i++) {
+      try { return await fn() }
+      catch (e) { if (i === attempts - 1) throw e }
+    }
+    throw new Error('Retry failed')
+  }
+
+  async findAvailableDriver(zone: Zone): Promise<Driver> {
+    return this.withRetry(() => this.searchDriversInZone(zone), 3)
+  }
+
+  private async searchDriversInZone(zone: Zone): Promise<Driver> {
+    // domain logic to find nearest available driver
+  }
+}
+
+// ✅ RIGHT - same behavior, properly separated
+// infra/retry.ts (generic, reusable in any project)
+export async function withRetry<T>(fn: () => Promise<T>, attempts: number): Promise<T> {
+  for (let i = 0; i < attempts; i++) {
+    try { return await fn() }
+    catch (e) { if (i === attempts - 1) throw e }
+  }
+  throw new Error('Retry failed')
+}
+
+// domain/driver-locator.ts (pure domain, no infra imports)
+class DriverLocator {
+  async findAvailableDriver(zone: Zone): Promise<Driver> {
+    // domain logic to find nearest available driver
+  }
+}
+
+// use-cases/dispatch-delivery.ts (orchestrates domain + infra)
+async function dispatchDelivery(deliveryId: DeliveryId) {
+  const delivery = await deliveryRepository.find(deliveryId)
+  const driver = await withRetry(
+    () => driverLocator.findAvailableDriver(delivery.zone), 3
+  )
+  delivery.assignDriver(driver)
+  await deliveryRepository.save(delivery)
+}
+```
+
+---
+
+## 6. Make the implicit explicit... like your life depends on it
+
+**What:** Strive for maximum expressiveness. Go as far as possible to identify and name domain concepts in code. Don't settle for "good enough"—push until the code speaks the domain fluently.
+
+**Why:** Maximum alignment optimizes communication between engineers and domain experts. Easier to discuss nuances and avoid misconceptions. Easier to plan and implement features and detect when the design of code is causing unnecessary friction.
+
+**Test:** Could you discuss this code with a domain expert without translation? Are there concepts they use that don't exist in your code?
+
+```typescript
+// This code looks fine - isolated, uses domain terms
+class Delivery {
+  status: DeliveryStatus
+  driver: Driver | null
+  pickupTime: Date | null
+  dropoffTime: Date | null
+  proofOfDelivery: Photo | null
+
+  assignDriver(driver: Driver): void {
+    if (this.status !== DeliveryStatus.Confirmed) throw new Error('...')
+    this.driver = driver
+    this.status = DeliveryStatus.Assigned
+  }
+
+  recordPickup(): void {
+    if (this.status !== DeliveryStatus.Assigned) throw new Error('...')
+    this.pickupTime = new Date()
+    this.status = DeliveryStatus.InTransit
+  }
+
+  recordDropoff(photo: Photo): void {
+    if (this.status !== DeliveryStatus.InTransit) throw new Error('...')
+    this.proofOfDelivery = photo
+    this.dropoffTime = new Date()
+    this.status = DeliveryStatus.Delivered
+  }
+}
+
+// But the TYPES can describe the domain! Each state is a distinct concept.
+// Reading the types alone tells you how deliveries work.
+
+type Delivery =
+  | RequestedDelivery      // Customer placed request
+  | ConfirmedDelivery      // Restaurant accepted
+  | AssignedDelivery       // Driver assigned, heading to restaurant
+  | InTransitDelivery      // Driver picked up, heading to customer
+  | DeliveredDelivery      // Complete with proof
+
+interface RequestedDelivery {
+  kind: 'requested'
+  customer: Customer
+  restaurant: Restaurant
+  items: MenuItem[]
+}
+
+interface ConfirmedDelivery {
+  kind: 'confirmed'
+  customer: Customer
+  restaurant: Restaurant
+  items: MenuItem[]
+  estimatedPrepTime: Duration
+}
+
+interface AssignedDelivery {
+  kind: 'assigned'
+  customer: Customer
+  restaurant: Restaurant
+  items: MenuItem[]
+  driver: Driver              // Now guaranteed to exist
+  estimatedPickup: Time
+}
+
+interface InTransitDelivery {
+  kind: 'in_transit'
+  customer: Customer
+  restaurant: Restaurant
+  items: MenuItem[]
+  driver: Driver
+  pickupTime: Time            // Now guaranteed to exist
+  estimatedDropoff: Time
+}
+
+interface DeliveredDelivery {
+  kind: 'delivered'
+  customer: Customer
+  restaurant: Restaurant
+  items: MenuItem[]
+  driver: Driver
+  pickupTime: Time
+  dropoffTime: Time           // Now guaranteed to exist
+  proofOfDelivery: Photo      // Now guaranteed to exist
+}
+
+// State transitions are explicit functions
+function confirmDelivery(d: RequestedDelivery, prepTime: Duration): ConfirmedDelivery
+function assignDriver(d: ConfirmedDelivery, driver: Driver): AssignedDelivery
+function recordPickup(d: AssignedDelivery): InTransitDelivery
+function recordDropoff(d: InTransitDelivery, photo: Photo): DeliveredDelivery
+```
+
+**Smaller improvements matter too:**
+
+```typescript
+// Extract an if statement to a named method
+if (distance.kilometers > 10 && !driver.hasLongRangeVehicle) { ... }
+if (delivery.exceedsDriverRange(driver)) { ... }
+
+// Name a boolean expression
+const canAssign = driver.isAvailable && driver.isInZone(delivery.zone) && !driver.atCapacity
+const canAssign = driver.canAccept(delivery)
+
+// Rename to use domain language
+const fee = customFee ?? standardFee
+const fee = customFee ?? defaultDeliveryFee
+```
+
+**Ways to increase expressiveness:**
+- Model states as distinct types (Delivery with status → RequestedDelivery, ConfirmedDelivery, etc.)
+- Make optional fields guaranteed at the right state (driver: Driver | null → driver: Driver)
+- Extract conditionals to named methods (complex if → exceedsDriverRange)
+- Rename variables to use domain language (standardFee → defaultDeliveryFee)
+
+---
+
+## 7. Design aggregates around invariants
+
+**What:** An aggregate is a cluster of objects that must be consistent together. The aggregate root enforces the rules. External code cannot violate invariants.
+
+**Why:** Without clear boundaries, inconsistent states creep in. One piece of code updates the delivery, another updates the route, and suddenly the ETA is wrong.
+
+**Test:** What must be true at all times? What rules must never be broken? The objects involved in those rules form an aggregate.
+
+```typescript
+// ❌ WRONG - no aggregate boundary, invariants violated
+class Delivery {
+  stops: DeliveryStop[]  // Exposed!
+  totalDistance: Distance
+}
+
+// External code can break invariants
+delivery.stops.push(new DeliveryStop(location))
+// Oops - totalDistance is now wrong!
+
+// ✅ RIGHT - aggregate protects invariants
+class Delivery {
+  private stops: DeliveryStop[] = []
+  private _totalDistance: Distance = Distance.zero()
+
+  addStop(location: Location): void {
+    if (this.status !== DeliveryStatus.Planning) {
+      throw new DeliveryNotModifiableError(this.id)
+    }
+    const previousStop = this.stops[this.stops.length - 1]
+    const stop = new DeliveryStop(location)
+    this.stops.push(stop)
+    this._totalDistance = this._totalDistance.add(
+      previousStop.distanceTo(location)  // Invariant maintained!
+    )
+  }
+
+  removeStop(stopId: StopId): void {
+    if (this.stops.length <= 2) {
+      throw new MinimumStopsRequiredError(this.id)
+    }
+    // Recalculate total distance after removal
+    this.stops = this.stops.filter(s => !s.id.equals(stopId))
+    this._totalDistance = this.calculateTotalDistance()  // Invariant maintained!
+  }
+
+  get totalDistance(): Distance {
+    return this._totalDistance
+  }
+}
+```
+
+**Aggregate rules:**
+- One root entity per aggregate
+- External code accesses only through the root
+- The root enforces all invariants
+- Reference other aggregates by ID, not object
+- Methods should operate on the same state—if they don't, split the aggregate
+
+---
+
+## 8. Extract immutable value objects liberally
+
+**What:** When something is defined by its attributes (not identity), make it an immutable value object. Do this liberally—more value objects is usually better.
+
+**Why:** Value objects are simple. They can't change unexpectedly. They're easy to test. They make domain concepts explicit. They're also a good way to extract logic from aggregates and entities that can easily get large—keep entities focused by pulling cohesive concepts into value objects.
+
+**Test:** Does this need a unique ID to track it over time? No? It's probably a value object.
+
+```typescript
+// Entity with primitives that should be a value object
+class Delivery {
+  id: DeliveryId
+  feeAmount: number
+  feeCurrency: string
+}
+
+// Extract the value object
+class Delivery {
+  id: DeliveryId
+  fee: Money
+}
+
+class Money {
+  constructor(
+    readonly amount: number,
+    readonly currency: Currency
+  ) {}
+
+  add(other: Money): Money {
+    if (this.currency !== other.currency) {
+      throw new CurrencyMismatchError(this.currency, other.currency)
+    }
+    return new Money(this.amount + other.amount, this.currency)
+  }
+
+  equals(other: Money): boolean {
+    return this.amount === other.amount && this.currency === other.currency
+  }
+}
+```
+
+**Good candidates for value objects:**
+- Money, Currency, Percentage
+- DateRange, TimeSlot, Duration
+- Address, Coordinates, Distance
+- EmailAddress, PhoneNumber, URL
+- Quantity, Weight, Temperature
+- PersonName, CompanyName
+
+---
+
+## 9. Repositories are for loading and saving full aggregates
+
+The job of a repository is to load and save entire aggregates - not partial aggregates or nested entities inside an aggregate. The `load` method takes an ID and returns the full aggregate.
+
+A repository should not exist for a domain object that is not an aggregate. Entity that is part of an aggreate -> does not have a repository. It is loaded via the aggregate root's repository.
+
+The `hydrate` method is used ONLY for constructing an aggregate from it's persisted state. It should not be abused for other use cases like creating new instances. Each creation flow should have a dedicated factory method, e.g. `Order.fromExisting()`, `Order.new()`, `Order.draft()`.
+
+The `save` method of a repository should take the full aggregate.
+
+If you just want to query information to display without modifying state and applying business rules, create a separate read model object and don't use a repository.
+
+---
+
+## Mandatory Checklist
+
+When designing, refactoring, analyzing, or reviewing code:
+
+1. [ ] Verify domain is isolated from infrastructure (no DB/HTTP/logging in domain; generic utilities in infra; domain doesn't import infra)
+2. [ ] Verify names are from YOUR domain, not generic developer jargon
+3. [ ] Verify use cases are intentions of users, human or automated (apply the menu test)
+4. [ ] Verify business logic lives in domain objects, use cases only orchestrate
+5. [ ] Verify states are modeled as distinct types where appropriate
+6. [ ] Verify hidden domain concepts are extracted and named explicitly
+7. [ ] Verify aggregates are designed around invariants, not naive mapping of domain nouns
+8. [ ] Verify values are extracted into value objects expressing a domain concept
+9. [ ] Veirfy no abuse of hydrate methods for creation scenarios. Each creation scenario must have dedicated factory method
+
+Do not proceed until all checks pass.

--- a/examples/ddd-architectural-challenges/variants/codex-ntcoding-tactical-ddd/variant.toml
+++ b/examples/ddd-architectural-challenges/variants/codex-ntcoding-tactical-ddd/variant.toml
@@ -1,0 +1,1 @@
+agent = "codex"

--- a/examples/ddd-architectural-challenges/variants/codex-vanilla/AGENTS.md
+++ b/examples/ddd-architectural-challenges/variants/codex-vanilla/AGENTS.md
@@ -1,0 +1,1 @@
+You are a coding assistant. Work in /app.

--- a/examples/ddd-architectural-challenges/variants/codex-vanilla/variant.toml
+++ b/examples/ddd-architectural-challenges/variants/codex-vanilla/variant.toml
@@ -1,0 +1,1 @@
+agent = "codex"

--- a/examples/ddd-architectural-challenges/variants/guided/variant.toml
+++ b/examples/ddd-architectural-challenges/variants/guided/variant.toml
@@ -1,0 +1,1 @@
+agent = "claude"

--- a/examples/ddd-architectural-challenges/variants/ntcoding-tactical-ddd/variant.toml
+++ b/examples/ddd-architectural-challenges/variants/ntcoding-tactical-ddd/variant.toml
@@ -1,0 +1,1 @@
+agent = "claude"

--- a/examples/ddd-architectural-challenges/variants/vanilla/variant.toml
+++ b/examples/ddd-architectural-challenges/variants/vanilla/variant.toml
@@ -1,0 +1,1 @@
+agent = "claude"

--- a/examples/refactoring-skill/variants/codex-vanilla/AGENTS.md
+++ b/examples/refactoring-skill/variants/codex-vanilla/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Instructions
+
+You are a coding assistant. Work in /app.
+
+1. Follow existing patterns in the codebase.
+2. Write tests that match the style of existing test files.

--- a/examples/refactoring-skill/variants/codex-vanilla/variant.toml
+++ b/examples/refactoring-skill/variants/codex-vanilla/variant.toml
@@ -1,0 +1,1 @@
+agent = "codex"

--- a/examples/refactoring-skill/variants/refactoring-skill/variant.toml
+++ b/examples/refactoring-skill/variants/refactoring-skill/variant.toml
@@ -1,0 +1,1 @@
+agent = "claude"

--- a/examples/refactoring-skill/variants/vanilla/variant.toml
+++ b/examples/refactoring-skill/variants/vanilla/variant.toml
@@ -1,0 +1,1 @@
+agent = "claude"

--- a/src/nasde_toolkit/agents/configurable_codex.py
+++ b/src/nasde_toolkit/agents/configurable_codex.py
@@ -1,0 +1,111 @@
+"""Configurable Codex agent for Harbor evaluations.
+
+Harbor's built-in Codex agent handles CLI installation, command construction,
+and token/trajectory parsing natively.  However, it has no mechanism to inject
+arbitrary files (e.g. AGENTS.md) into the sandbox before the agent starts.
+
+ConfigurableCodex fills that single gap: it accepts a sandbox_files mapping
+via AgentConfig.kwargs and uploads each file into the container during setup().
+Everything else (auth, model selection, reasoning effort) stays in Harbor.
+
+Usage in harbor_config.json::
+
+    {
+      "agents": [{
+        "import_path": "nasde_toolkit.agents.configurable_codex:ConfigurableCodex",
+        "model_name": "o3",
+        "kwargs": {
+          "sandbox_files": {
+            "/app/AGENTS.md": "path/to/AGENTS.md"
+          }
+        }
+      }]
+    }
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from harbor.agents.installed.base import ExecInput
+from harbor.agents.installed.codex import Codex
+from harbor.environments.base import BaseEnvironment
+
+logger = logging.getLogger(__name__)
+
+_DNS_FIX_COMMAND = (
+    "timeout 5 getent hosts api.openai.com >/dev/null 2>&1"
+    " || printf 'nameserver 8.8.8.8\\nnameserver 1.1.1.1\\n' > /etc/resolv.conf"
+)
+
+
+class ConfigurableCodex(Codex):
+    """Codex with declarative file injection into the sandbox.
+
+    Args:
+        sandbox_files: Mapping of container paths to host-relative file paths.
+            Each entry is uploaded into the sandbox during setup() before
+            the agent starts. Paths are resolved relative to CWD.
+    """
+
+    def __init__(
+        self,
+        sandbox_files: dict[str, str] | None = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._sandbox_files = sandbox_files or {}
+
+    @staticmethod
+    def name() -> str:
+        return "configurable-codex"
+
+    async def setup(self, environment: BaseEnvironment) -> None:
+        """Fix cloud DNS, run base setup, then upload configured files."""
+        await self._ensure_dns_resolution(environment)
+        await super().setup(environment)
+        await self._upload_sandbox_files(environment)
+
+    async def _ensure_dns_resolution(self, environment: BaseEnvironment) -> None:
+        """Prepend public DNS resolvers if cloud sandbox cannot reach OpenAI.
+
+        Cloud sandboxes (Daytona, Modal, etc.) may land on runners whose DNS
+        resolvers cannot reach whitelisted domains.  Prepending Google/Cloudflare
+        public resolvers fixes this without affecting local Docker environments.
+        """
+        result = await environment.exec(command=_DNS_FIX_COMMAND)
+        if result.return_code == 0:
+            logger.debug("DNS resolution fix applied")
+        else:
+            logger.warning("DNS resolution fix failed: %s", result.stderr)
+
+    def create_run_agent_commands(self, instruction: str) -> list[ExecInput]:
+        """Resolve CODEX_API_KEY before delegating to parent.
+
+        Harbor's built-in Codex agent reads only OPENAI_API_KEY.
+        Users may set CODEX_API_KEY instead (recommended by OpenAI).
+        Bridge the gap by copying CODEX_API_KEY → OPENAI_API_KEY when
+        the latter is absent.
+        """
+        if not os.environ.get("OPENAI_API_KEY") and os.environ.get("CODEX_API_KEY"):
+            os.environ["OPENAI_API_KEY"] = os.environ["CODEX_API_KEY"]
+        return super().create_run_agent_commands(instruction)
+
+    async def _upload_sandbox_files(self, environment: BaseEnvironment) -> None:
+        for target_path, source_path in self._sandbox_files.items():
+            resolved = Path(source_path).resolve()
+            if not resolved.is_file():
+                raise FileNotFoundError(
+                    f"sandbox_files: source '{source_path}' "
+                    f"(resolved to '{resolved}') does not exist"
+                )
+            parent_dir = str(Path(target_path).parent)
+            await environment.exec(command=f"mkdir -p {parent_dir}")
+            await environment.upload_file(
+                source_path=resolved,
+                target_path=target_path,
+            )

--- a/src/nasde_toolkit/cli.py
+++ b/src/nasde_toolkit/cli.py
@@ -178,6 +178,11 @@ def run(
         ))
     else:
         resolved_variant = variant
+        from nasde_toolkit.runner import load_variant_agent_type, resolve_variant_dir
+
+        variant_dir = resolve_variant_dir(config.project_dir, resolved_variant)
+        agent_type = load_variant_agent_type(variant_dir)
+
         _print_run_header(
             variant=resolved_variant,
             model=resolved_model,
@@ -187,6 +192,7 @@ def run(
             with_eval=not without_eval,
             harbor_env=resolved_harbor_env,
             attempts=attempts,
+            agent_type=agent_type,
         )
 
         asyncio.run(run_benchmark(
@@ -289,13 +295,16 @@ def _print_run_header(
     with_eval: bool,
     harbor_env: str | None = None,
     attempts: int = 1,
+    agent_type: str = "claude",
 ) -> None:
     tasks_str = ", ".join(tasks_filter) if tasks_filter else "all"
     eval_str = "enabled" if with_eval else "[yellow]disabled[/yellow]"
     env_str = harbor_env or "docker"
     attempts_str = f"{attempts}" if attempts > 1 else "1"
+    agent_label = "Codex (OpenAI)" if agent_type == "codex" else "Claude Code"
     console.print(Panel(
         f"[bold]Benchmark Runner[/bold]\n"
+        f"Agent: {agent_label}\n"
         f"Variant: {variant}\n"
         f"Model: {model}\n"
         f"Timeout: {timeout}s\n"

--- a/src/nasde_toolkit/runner.py
+++ b/src/nasde_toolkit/runner.py
@@ -55,14 +55,15 @@ async def run_benchmark(
 ) -> None:
     """Run a benchmark variant against configured tasks via Harbor."""
     _load_env_file(config.project_dir)
-    _ensure_auth()
 
-    variant_dir = _resolve_variant_dir(config.project_dir, variant)
+    variant_dir = resolve_variant_dir(config.project_dir, variant)
     harbor_config_path = variant_dir / "harbor_config.json"
 
     if not harbor_config_path.exists():
         _generate_harbor_config(variant_dir, variant)
         harbor_config_path = variant_dir / "harbor_config.json"
+
+    _ensure_auth(_read_agent_import_path(harbor_config_path))
 
     merged_config = _build_merged_config(
         config=config,
@@ -101,7 +102,19 @@ async def run_benchmark(
 # ---------------------------------------------------------------------------
 
 
-def _ensure_auth() -> None:
+def _ensure_auth(agent_import_path: str | None = None) -> None:
+    if _is_codex_agent(agent_import_path):
+        if (
+            os.environ.get("CODEX_API_KEY")
+            or os.environ.get("OPENAI_API_KEY")
+            or Path.home().joinpath(".codex", "auth.json").exists()
+        ):
+            return
+        console.print(
+            "[red]ERROR: Set CODEX_API_KEY, OPENAI_API_KEY, "
+            "or run 'codex login' for OAuth[/red]"
+        )
+        raise SystemExit(1)
     if os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"):
         return
     console.print("[red]ERROR: Set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN[/red]")
@@ -130,7 +143,7 @@ def _parse_env_file(env_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _resolve_variant_dir(project_dir: Path, variant: str) -> Path:
+def resolve_variant_dir(project_dir: Path, variant: str) -> Path:
     for base in [project_dir / ".nasde", project_dir]:
         variant_dir = base / "variants" / variant
         if variant_dir.exists():
@@ -155,23 +168,104 @@ def _collect_sandbox_files(variant_dir: Path) -> dict[str, str]:
     claude_md = variant_dir / "CLAUDE.md"
     if claude_md.exists():
         sandbox_files["/app/CLAUDE.md"] = str(claude_md)
-    skills_dir = variant_dir / "skills"
-    if skills_dir.is_dir():
-        for skill_dir in sorted(skills_dir.iterdir()):
-            skill_md = skill_dir / "SKILL.md"
-            if skill_dir.is_dir() and skill_md.exists():
-                target = f"/app/.claude/skills/{skill_dir.name}/SKILL.md"
-                sandbox_files[target] = str(skill_md)
+    agents_md = variant_dir / "AGENTS.md"
+    if agents_md.exists():
+        sandbox_files["/app/AGENTS.md"] = str(agents_md)
+    _collect_claude_skills(variant_dir, sandbox_files)
+    _collect_codex_skills(variant_dir, sandbox_files)
     return sandbox_files
+
+
+def _collect_claude_skills(variant_dir: Path, sandbox_files: dict[str, str]) -> None:
+    skills_dir = variant_dir / "skills"
+    if not skills_dir.is_dir():
+        return
+    for skill_dir in sorted(skills_dir.iterdir()):
+        skill_md = skill_dir / "SKILL.md"
+        if skill_dir.is_dir() and skill_md.exists():
+            target = f"/app/.claude/skills/{skill_dir.name}/SKILL.md"
+            sandbox_files[target] = str(skill_md)
+
+
+def _collect_codex_skills(variant_dir: Path, sandbox_files: dict[str, str]) -> None:
+    agents_skills_dir = variant_dir / "agents_skills"
+    if not agents_skills_dir.is_dir():
+        return
+    for skill_dir in sorted(agents_skills_dir.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        for file_path in skill_dir.rglob("*"):
+            if file_path.is_file():
+                relative = file_path.relative_to(agents_skills_dir)
+                target = f"/app/.agents/skills/{relative}"
+                sandbox_files[target] = str(file_path)
+
+
+_VALID_AGENT_TYPES = {"claude", "codex"}
+
+
+def load_variant_agent_type(variant_dir: Path) -> str:
+    """Read the agent type from variant.toml.
+
+    Every variant directory must contain a ``variant.toml`` with an
+    ``agent`` field set to ``"claude"`` or ``"codex"``.
+    """
+    variant_toml = variant_dir / "variant.toml"
+    if not variant_toml.exists():
+        console.print(
+            f"[red]ERROR: {variant_toml} not found. "
+            f"Every variant must have a variant.toml with 'agent' field.[/red]"
+        )
+        raise SystemExit(1)
+
+    import tomllib
+
+    with open(variant_toml, "rb") as f:
+        data = tomllib.load(f)
+
+    agent_type = data.get("agent")
+    if agent_type not in _VALID_AGENT_TYPES:
+        console.print(
+            f"[red]ERROR: variant.toml 'agent' must be one of "
+            f"{_VALID_AGENT_TYPES}, got: {agent_type!r}[/red]"
+        )
+        raise SystemExit(1)
+
+    return agent_type
+
+
+def _agent_import_path(agent_type: str) -> str:
+    if agent_type == "codex":
+        return "nasde_toolkit.agents.configurable_codex:ConfigurableCodex"
+    return "nasde_toolkit.agents.configurable_claude:ConfigurableClaude"
+
+
+def _is_codex_agent(agent_import_path: str | None) -> bool:
+    return bool(agent_import_path and "codex" in agent_import_path.lower())
+
+
+def _read_agent_import_path(harbor_config_path: Path) -> str | None:
+    """Extract the first agent's import_path from a harbor_config.json."""
+    try:
+        with open(harbor_config_path) as f:
+            data = json.load(f)
+        agents = data.get("agents", [])
+        if agents:
+            return agents[0].get("import_path")
+    except (json.JSONDecodeError, OSError):
+        pass
+    return None
 
 
 def _generate_harbor_config(variant_dir: Path, variant: str) -> None:
     sandbox_files = _collect_sandbox_files(variant_dir)
+    agent_type = load_variant_agent_type(variant_dir)
+    import_path = _agent_import_path(agent_type)
 
     config = {
         "agents": [
             {
-                "import_path": "nasde_toolkit.agents.configurable_claude:ConfigurableClaude",
+                "import_path": import_path,
                 "name": variant,
                 "kwargs": {
                     "sandbox_files": sandbox_files,

--- a/tests/test_configurable_codex.py
+++ b/tests/test_configurable_codex.py
@@ -1,0 +1,71 @@
+"""Tests for ConfigurableCodex agent."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nasde_toolkit.agents.configurable_codex import ConfigurableCodex
+
+
+def test_name_returns_configurable_codex() -> None:
+    assert ConfigurableCodex.name() == "configurable-codex"
+
+
+def test_constructor_stores_sandbox_files() -> None:
+    files = {"/app/AGENTS.md": "/tmp/AGENTS.md"}
+    agent = ConfigurableCodex(
+        sandbox_files=files,
+        logs_dir=Path("/tmp/logs"),
+        model_name="o3",
+    )
+    assert agent._sandbox_files == files
+
+
+def test_constructor_defaults_to_empty_sandbox_files() -> None:
+    agent = ConfigurableCodex(
+        logs_dir=Path("/tmp/logs"),
+        model_name="o3",
+    )
+    assert agent._sandbox_files == {}
+
+
+def test_setup_calls_dns_fix_then_parent_then_upload() -> None:
+    agent = ConfigurableCodex(
+        sandbox_files={"/app/AGENTS.md": __file__},
+        logs_dir=Path("/tmp/logs"),
+        model_name="o3",
+    )
+
+    env = AsyncMock()
+    env.exec.return_value = MagicMock(return_code=0, stderr="")
+
+    with patch.object(
+        ConfigurableCodex.__bases__[0], "setup", new_callable=AsyncMock
+    ) as mock_parent_setup:
+        asyncio.run(agent.setup(env))
+
+    dns_call = env.exec.call_args_list[0]
+    assert "api.openai.com" in dns_call.kwargs.get("command", dns_call.args[0] if dns_call.args else "")
+    mock_parent_setup.assert_awaited_once_with(env)
+    assert env.upload_file.await_count == 1
+
+
+def test_upload_raises_on_missing_source() -> None:
+    agent = ConfigurableCodex(
+        sandbox_files={"/app/AGENTS.md": "/nonexistent/path.md"},
+        logs_dir=Path("/tmp/logs"),
+        model_name="o3",
+    )
+
+    env = AsyncMock()
+    env.exec.return_value = MagicMock(return_code=0, stderr="")
+
+    with patch.object(
+        ConfigurableCodex.__bases__[0], "setup", new_callable=AsyncMock
+    ):
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            asyncio.run(agent.setup(env))

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -16,7 +16,14 @@ from nasde_toolkit.config import (
     SourceConfig,
     TaskConfig,
 )
-from nasde_toolkit.runner import _build_merged_config, collect_available_variants
+from nasde_toolkit.runner import (
+    _build_merged_config,
+    _ensure_auth,
+    _generate_harbor_config,
+    _is_codex_agent,
+    collect_available_variants,
+    load_variant_agent_type,
+)
 
 
 @pytest.fixture()
@@ -143,3 +150,145 @@ def test_collect_available_variants_ignores_files(tmp_path: Path) -> None:
     (tmp_path / "variants" / "vanilla").mkdir()
     (tmp_path / "variants" / "README.md").write_text("docs")
     assert collect_available_variants(tmp_path) == ["vanilla"]
+
+
+# ---------------------------------------------------------------------------
+# load_variant_agent_type
+# ---------------------------------------------------------------------------
+
+
+def test_load_variant_agent_type_claude(tmp_path: Path) -> None:
+    (tmp_path / "variant.toml").write_text('agent = "claude"')
+    assert load_variant_agent_type(tmp_path) == "claude"
+
+
+def test_load_variant_agent_type_codex(tmp_path: Path) -> None:
+    (tmp_path / "variant.toml").write_text('agent = "codex"')
+    assert load_variant_agent_type(tmp_path) == "codex"
+
+
+def test_load_variant_agent_type_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit):
+        load_variant_agent_type(tmp_path)
+
+
+def test_load_variant_agent_type_invalid_value_raises(tmp_path: Path) -> None:
+    (tmp_path / "variant.toml").write_text('agent = "gpt"')
+    with pytest.raises(SystemExit):
+        load_variant_agent_type(tmp_path)
+
+
+def test_load_variant_agent_type_missing_field_raises(tmp_path: Path) -> None:
+    (tmp_path / "variant.toml").write_text('model = "o3"')
+    with pytest.raises(SystemExit):
+        load_variant_agent_type(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# _is_codex_agent
+# ---------------------------------------------------------------------------
+
+
+def test_is_codex_agent_with_codex_import_path() -> None:
+    assert _is_codex_agent("nasde_toolkit.agents.configurable_codex:ConfigurableCodex")
+
+
+def test_is_codex_agent_with_harbor_codex() -> None:
+    assert _is_codex_agent("harbor.agents.installed.codex:Codex")
+
+
+def test_is_codex_agent_with_claude_import_path() -> None:
+    assert not _is_codex_agent("nasde_toolkit.agents.configurable_claude:ConfigurableClaude")
+
+
+def test_is_codex_agent_with_none() -> None:
+    assert not _is_codex_agent(None)
+
+
+# ---------------------------------------------------------------------------
+# _generate_harbor_config — agent type detection
+# ---------------------------------------------------------------------------
+
+
+def test_generate_harbor_config_claude_variant(tmp_path: Path) -> None:
+    variant_dir = tmp_path / "variants" / "vanilla"
+    variant_dir.mkdir(parents=True)
+    (variant_dir / "CLAUDE.md").write_text("# Claude")
+    (variant_dir / "variant.toml").write_text('agent = "claude"')
+
+    _generate_harbor_config(variant_dir, "vanilla")
+
+    config = json.loads((variant_dir / "harbor_config.json").read_text())
+    assert "configurable_claude" in config["agents"][0]["import_path"]
+
+
+def test_generate_harbor_config_codex_variant(tmp_path: Path) -> None:
+    variant_dir = tmp_path / "variants" / "codex-baseline"
+    variant_dir.mkdir(parents=True)
+    (variant_dir / "AGENTS.md").write_text("# Codex")
+    (variant_dir / "variant.toml").write_text('agent = "codex"')
+
+    _generate_harbor_config(variant_dir, "codex-baseline")
+
+    config = json.loads((variant_dir / "harbor_config.json").read_text())
+    assert "configurable_codex" in config["agents"][0]["import_path"]
+    assert config["agents"][0]["name"] == "codex-baseline"
+    assert "/app/AGENTS.md" in config["agents"][0]["kwargs"]["sandbox_files"]
+
+
+# ---------------------------------------------------------------------------
+# _ensure_auth — multi-provider
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_auth_claude_with_anthropic_key() -> None:
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-ant-test"}, clear=True):
+        _ensure_auth()
+
+
+def test_ensure_auth_claude_with_oauth_token() -> None:
+    with patch.dict("os.environ", {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-test"}, clear=True):
+        _ensure_auth()
+
+
+def test_ensure_auth_claude_missing_raises() -> None:
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(SystemExit):
+            _ensure_auth()
+
+
+def test_ensure_auth_codex_with_codex_api_key() -> None:
+    codex_path = "nasde_toolkit.agents.configurable_codex:ConfigurableCodex"
+    with patch.dict("os.environ", {"CODEX_API_KEY": "sk-test"}, clear=True):
+        _ensure_auth(codex_path)
+
+
+def test_ensure_auth_codex_with_openai_api_key() -> None:
+    codex_path = "nasde_toolkit.agents.configurable_codex:ConfigurableCodex"
+    with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}, clear=True):
+        _ensure_auth(codex_path)
+
+
+def test_ensure_auth_codex_with_oauth_file(tmp_path: Path) -> None:
+    codex_path = "nasde_toolkit.agents.configurable_codex:ConfigurableCodex"
+    auth_file = tmp_path / ".codex" / "auth.json"
+    auth_file.parent.mkdir(parents=True)
+    auth_file.write_text('{"token": "test"}')
+
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch("pathlib.Path.home", return_value=tmp_path),
+    ):
+        _ensure_auth(codex_path)
+
+
+def test_ensure_auth_codex_missing_raises() -> None:
+    codex_path = "nasde_toolkit.agents.configurable_codex:ConfigurableCodex"
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch("nasde_toolkit.runner.Path") as mock_path_cls,
+    ):
+        mock_home = mock_path_cls.home.return_value
+        mock_home.joinpath.return_value.exists.return_value = False
+        with pytest.raises(SystemExit):
+            _ensure_auth(codex_path)


### PR DESCRIPTION
## Summary

Add OpenAI Codex agent support to nasde-toolkit, enabling cross-agent benchmarking (Claude Code vs Codex on the same tasks).

### New agent
- **`ConfigurableCodex`** — subclass of Harbor's built-in `Codex` agent with sandbox file injection (`AGENTS.md`, Codex skills)
- Bridge `CODEX_API_KEY` → `OPENAI_API_KEY` (Harbor reads only `OPENAI_API_KEY`, but OpenAI recommends `CODEX_API_KEY`)
- DNS fix for cloud sandboxes (same pattern as `ConfigurableClaude`)

### Explicit variant configuration via `variant.toml`
- Every variant must declare its agent type in `variant.toml`: `agent = "claude"` or `agent = "codex"`
- Missing or invalid `variant.toml` is a hard error — no guessing, no auto-detection
- `harbor_config.json` is auto-generated from `variant.toml` if absent

### Multi-agent variant system
- `_collect_codex_skills()` — collects `agents_skills/<name>/` and injects into `/app/.agents/skills/<name>/` (Codex's skill directory convention)
- `_collect_claude_skills()` — refactored from inline code, collects `skills/<name>/SKILL.md` → `/app/.claude/skills/`

### Multi-provider auth
- `_ensure_auth()` checks `CODEX_API_KEY` / `OPENAI_API_KEY` for Codex variants, Anthropic keys for Claude variants
- Auth check deferred until after variant config is loaded (so agent type is known)

### CLI
- Display agent type (Claude Code / Codex) in run header panel

### Example benchmarks — Codex variants added
- **DDD benchmark**: 3 Codex variants mirroring Claude variants (`codex-vanilla`, `codex-guided`, `codex-ntcoding-tactical-ddd`)
- **Refactoring-skill benchmark**: `codex-vanilla` variant added
- All variants in both examples have `variant.toml`

### Skills updated
- **nasde-benchmark-runner** — Codex docs: supported models, cross-agent comparison, token cost heuristic, troubleshooting
- **nasde-benchmark-creator** — variant.toml requirement, Claude/Codex variant structure, cross-agent design pattern
- **nasde-dev** — skills added to documentation consistency checklist

### Documentation
- **README.md** — Quick start with Codex example, Authentication section (API key from platform.openai.com), Prerequisites, Project structure with `variant.toml`
- **CLAUDE.md** — Package structure, variant conventions, harbor_config.json examples for both agents
- **ARCHITECTURE.md** — Multi-agent class diagram, variant docs with `variant.toml`

### Tests — 21 new tests (43 total)
- `test_configurable_codex.py` — constructor, name, setup orchestration, missing file error
- `test_runner.py` — `load_variant_agent_type()` (valid/missing/invalid), `_is_codex_agent()`, `_generate_harbor_config()` for both agents, `_ensure_auth()` multi-provider

## Verified end-to-end

### DDD benchmark (`ddd-threshold-discount`)

| Variant | Agent | Model | Reward | Score |
|---|---|---|---|---|
| vanilla | Claude Code | claude-sonnet-4-6 | 1.0 | **82/100** |
| guided | Claude Code | claude-sonnet-4-6 | 1.0 | **86/100** |
| codex-vanilla | Codex | gpt-5-codex | 1.0 | **82/100** |
| codex-ntcoding-tactical-ddd | Codex | gpt-5-codex | 1.0 | **82/100** |

### Refactoring benchmark (`python-gilded-rose-polymorphism`)

| Variant | Agent | Model | Reward | Score |
|---|---|---|---|---|
| vanilla | Claude Code | claude-sonnet-4-6 | 1.0 | **73/100** |
| codex-vanilla | Codex | gpt-5-codex | 1.0 | **70/100** |

All Opik traces verified with complete feedback scores.

**Note on Codex models:** Only `gpt-5-codex`, `gpt-5.3-codex`, `gpt-5.4`, `gpt-5.4-mini` work via API key. Models like `codex-mini-latest` are subscription-only; `o3-mini` doesn't support required Codex tools.

## Test plan

- [x] All 43 tests pass (`uv run pytest -v`)
- [x] Codex variant with `gpt-5-codex` completes tasks on 2 benchmarks
- [x] Codex variant with skill (`codex-ntcoding-tactical-ddd`) works end-to-end
- [x] Missing `variant.toml` produces clear error
- [x] `_ensure_auth()` validates `CODEX_API_KEY` for Codex agents
- [x] Opik traces have complete feedback scores for both agent types
- [x] Rebase on main clean, no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)