### PR TITLE
fix: regenerate docker-compose.yaml for local sources & litellm workaround

### DIFF
--- a/examples/nasde-dev-skill/nasde.toml
+++ b/examples/nasde-dev-skill/nasde.toml
@@ -9,9 +9,14 @@ timeout_sec = 1800
 
 [docker]
 base_image = "python:3.12-slim"
+# TEMPORARY WORKAROUND: litellm is quarantined on PyPI (March 2026 supply chain attack —
+# versions 1.82.7-1.82.8 contained infostealer malware). PyPI blocked ALL versions pending
+# review. We install a safe version (v1.82.3) from GitHub as a uv override.
+# Remove override lines once litellm is restored on PyPI.
 build_commands = [
   "pip install uv",
-  "uv tool install .",
+  "echo 'litellm @ https://github.com/BerriAI/litellm/archive/refs/tags/v1.82.3.tar.gz' > /tmp/litellm-override.txt",
+  "uv tool install . --override /tmp/litellm-override.txt",
   "nasde --version",
 ]
 

--- a/examples/nasde-dev-skill/tasks/add-multi-attempt-support/tests/test.sh
+++ b/examples/nasde-dev-skill/tasks/add-multi-attempt-support/tests/test.sh
@@ -8,7 +8,10 @@ echo ""
 cd /app
 
 # Reinstall from source so agent edits are picked up
-uv tool install . --force 2>/dev/null
+# TEMPORARY WORKAROUND: litellm quarantined on PyPI (March 2026 supply chain attack).
+# Safe version installed from GitHub via uv override. Remove once PyPI restores litellm.
+echo 'litellm @ https://github.com/BerriAI/litellm/archive/refs/tags/v1.82.3.tar.gz' > /tmp/litellm-override.txt
+uv tool install . --force --override /tmp/litellm-override.txt 2>/dev/null
 
 echo "Step 1: CLI flag exists with correct help text..."
 echo "--------------------------------------"

--- a/src/nasde_toolkit/docker.py
+++ b/src/nasde_toolkit/docker.py
@@ -38,14 +38,12 @@ def ensure_task_environment(
     current working tree which may contain later changes.
     """
     env_dir = task_dir / "environment"
-    if (env_dir / "Dockerfile").exists():
-        return
 
-    env_dir.mkdir(parents=True, exist_ok=True)
-
-    dockerfile_content = generate_dockerfile(source, docker)
-    (env_dir / "Dockerfile").write_text(dockerfile_content)
-    console.print(f"  [dim]Generated Dockerfile in {env_dir}[/dim]")
+    if not (env_dir / "Dockerfile").exists():
+        env_dir.mkdir(parents=True, exist_ok=True)
+        dockerfile_content = generate_dockerfile(source, docker)
+        (env_dir / "Dockerfile").write_text(dockerfile_content)
+        console.print(f"  [dim]Generated Dockerfile in {env_dir}[/dim]")
 
     if _is_local_path(source.git):
         build_context_dir = _resolve_local_build_context(task_dir, source)

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -209,3 +209,44 @@ def test_ensure_task_environment_creates_worktree_for_local_with_ref(
         assert not (worktree_dir / "new_file.txt").exists()
     finally:
         cleanup_worktrees()
+
+
+def test_ensure_task_environment_regenerates_compose_when_dockerfile_exists(
+    tmp_path: Path,
+    default_docker: DockerConfig,
+) -> None:
+    """docker-compose.yaml must be regenerated even when Dockerfile already exists.
+
+    Local sources with a ref create a temp worktree whose path changes every run.
+    A stale docker-compose.yaml from a previous run points to a cleaned-up path.
+    """
+    repo_dir = tmp_path / "my-repo"
+    repo_dir.mkdir()
+    commit_hash = _init_git_repo(repo_dir)
+
+    task_dir = tmp_path / "project" / "tasks" / "my-task"
+    env_dir = task_dir / "environment"
+    env_dir.mkdir(parents=True)
+
+    (env_dir / "Dockerfile").write_text("FROM python:3.12-slim\nCOPY . /app\n")
+    (env_dir / "docker-compose.yaml").write_text(
+        "services:\n  main:\n    build:\n      context: /tmp/nasde-build-STALE\n"
+    )
+
+    source = SourceConfig(git=str(repo_dir), ref=commit_hash)
+
+    try:
+        ensure_task_environment(task_dir, source, default_docker)
+
+        assert (env_dir / "Dockerfile").read_text() == "FROM python:3.12-slim\nCOPY . /app\n"
+
+        compose = (env_dir / "docker-compose.yaml").read_text()
+        assert "/tmp/nasde-build-STALE" not in compose
+
+        context_line = [line.strip() for line in compose.splitlines() if "context:" in line][0]
+        relative_context = context_line.split("context:")[1].strip()
+        worktree_dir = (env_dir / relative_context).resolve()
+        assert worktree_dir.exists()
+        assert (worktree_dir / "hello.txt").exists()
+    finally:
+        cleanup_worktrees()


### PR DESCRIPTION
## Summary

- **docker-compose.yaml stale path fix**: `ensure_task_environment()` now always regenerates `docker-compose.yaml` for local repo sources, even when the Dockerfile already exists. Previously both were guarded by a single `Dockerfile.exists()` check, causing Docker build failures on subsequent runs because the compose file pointed to a cleaned-up temp worktree.
- **litellm PyPI workaround**: Adds temporary override to install litellm v1.82.3 from GitHub in the nasde-dev-skill benchmark. litellm is quarantined on PyPI after a supply chain attack (versions 1.82.7-1.82.8 contained infostealer malware). v1.82.3 from GitHub is verified safe.

## Test plan
- [x] All 57 unit tests pass (`uv run pytest`)
- [x] Regression test added for stale docker-compose.yaml scenario
- [x] End-to-end: `nasde run --variant claude-vanilla --tasks add-multi-attempt-support` completes with reward 1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)