### PR TITLE
feat: add Gemini CLI agent support

### DIFF
--- a/.claude/skills/nasde-benchmark-creator/SKILL.md
+++ b/.claude/skills/nasde-benchmark-creator/SKILL.md
@@ -228,7 +228,7 @@ Each variant is a directory under `variants/<variant-name>/` with a required `va
 ### variant.toml (required)
 
 ```toml
-agent = "claude"   # or "codex"
+agent = "claude"   # or "codex" or "gemini"
 ```
 
 For Codex variants, **always** set the model explicitly to avoid inheriting the Claude model from `nasde.toml`:
@@ -247,6 +247,18 @@ model = "gpt-5.3-codex"   # Required for Codex — use an OpenAI model ID
 
 Without `model` in variant.toml, Codex inherits `nasde.toml`'s default (e.g. `claude-sonnet-4-6`), which silently produces garbage results.
 
+For Gemini CLI variants, **always** set the model with the `google/` prefix:
+
+```toml
+agent = "gemini"
+model = "google/gemini-3-flash-preview"   # Required format: google/<model-name>
+```
+
+**Gemini models** (recommended first, as of 2026-03):
+- `google/gemini-3.1-pro-preview` — advanced thinking model, best for deep reasoning
+- `google/gemini-3-flash-preview` — best quality/speed ratio, daily coding tasks
+- `google/gemini-3.1-flash-lite-preview` — fastest, simple and repetitive tasks
+
 ### Claude Code variant
 
 ```
@@ -263,6 +275,15 @@ variants/codex-baseline/
   variant.toml       # agent = "codex"
   AGENTS.md          # Instructions (injected to /app/AGENTS.md)
   agents_skills/     # Optional: skill snapshots (injected to /app/.agents/skills/)
+```
+
+### Gemini CLI variant
+
+```
+variants/gemini-baseline/
+  variant.toml       # agent = "gemini"
+  GEMINI.md          # Instructions (injected to /app/GEMINI.md)
+  gemini_skills/     # Optional: skill snapshots (injected to /app/.gemini/skills/)
 ```
 
 If no `harbor_config.json` exists, `nasde` auto-generates one from `variant.toml`. To customize (e.g., add MCP servers), create it explicitly:
@@ -293,7 +314,7 @@ Design variants to test specific hypotheses:
 - **Guided** — detailed domain-specific guidance, patterns to follow
 - **Skill-augmented** — skills injected for domain expertise (e.g., tactical DDD)
 - **Tool-augmented** — MCP server access (e.g., codebase search)
-- **Cross-agent** — same instructions for Claude and Codex to compare agent performance
+- **Cross-agent** — same instructions for Claude, Codex, and Gemini to compare agent performance
 
 Every benchmark needs at least one variant (typically `vanilla` or `baseline`).
 

--- a/.claude/skills/nasde-benchmark-runner/SKILL.md
+++ b/.claude/skills/nasde-benchmark-runner/SKILL.md
@@ -50,12 +50,34 @@ Or set directly: `export CODEX_API_KEY=sk-proj-...`
 
 API key always takes priority over OAuth when both are present.
 
+### Gemini CLI (Google account or API key)
+
+**Option 1: Google account OAuth** — uses Google account credits, no per-token API cost:
+
+```bash
+gemini login                                # one-time: authenticate via Google account
+source scripts/export_gemini_oauth_token.sh # validate tokens are present
+```
+
+NASDE auto-detects `~/.gemini/oauth_creds.json` and injects OAuth credentials into the sandbox. No env vars needed.
+
+**Option 2: API key** — billed through Google AI Studio or Vertex AI:
+
+```bash
+export GEMINI_API_KEY=your-key
+```
+
+Or for Vertex AI: `export GOOGLE_API_KEY=your-key` + `export GOOGLE_CLOUD_PROJECT=your-project`
+
+API key always takes priority over OAuth when both are present.
+
 ### Combined setup for cross-agent runs
 
 ```bash
-source scripts/export_oauth_token.sh  # Claude (subscription)
+source scripts/export_oauth_token.sh         # Claude (subscription)
 # Codex: either codex login (subscription) or:
-export $(grep CODEX_API_KEY .env)     # Codex (API key)
+export $(grep CODEX_API_KEY .env)            # Codex (API key)
+source scripts/export_gemini_oauth_token.sh  # Gemini (Google account)
 ```
 
 ## Running benchmarks
@@ -142,16 +164,43 @@ model = "gpt-5.4"
 ```
 This avoids accidentally inheriting the Claude model from `nasde.toml`.
 
-### Cross-agent comparison (Claude vs Codex)
+### Running Gemini CLI variants
 
-Set up both auth tokens first (see Authentication setup above), then run:
+Gemini variants use `GEMINI.md` (instead of `CLAUDE.md`) and require either `gemini login` (Google account) or `GEMINI_API_KEY`/`GOOGLE_API_KEY` (API billing).
+
+**CRITICAL: Gemini model must use `google/` prefix.** Harbor requires model names in `provider/model_name` format. Always set via `--model` flag or in `variant.toml`.
 
 ```bash
-source scripts/export_oauth_token.sh && export $(grep CODEX_API_KEY .env)
+# Option A: Google account OAuth (no env vars needed after gemini login)
+nasde run --variant gemini-vanilla --model google/gemini-3-flash-preview -C path/to/benchmark
 
-# Run Claude and Codex variants — Codex MUST have --model override
+# Option B: API key
+export GEMINI_API_KEY=your-key
+nasde run --variant gemini-vanilla --model google/gemini-3-flash-preview -C path/to/benchmark
+```
+
+**Gemini models** (recommended first, as of 2026-03):
+- `google/gemini-3.1-pro-preview` — advanced thinking model, deep reasoning
+- `google/gemini-3-flash-preview` — best quality/speed ratio, daily coding
+- `google/gemini-3.1-flash-lite-preview` — fastest, simple tasks
+
+**Setting model in variant.toml** (preferred over --model flag):
+```toml
+agent = "gemini"
+model = "google/gemini-3-flash-preview"
+```
+
+### Cross-agent comparison (Claude vs Codex vs Gemini)
+
+Set up all auth tokens first (see Authentication setup above), then run:
+
+```bash
+source scripts/export_oauth_token.sh && export $(grep CODEX_API_KEY .env) && source scripts/export_gemini_oauth_token.sh
+
+# Run Claude, Codex, and Gemini variants — non-Claude MUST have --model override
 nasde run --variant claude-vanilla -C path/to/benchmark --with-opik &
 nasde run --variant codex-vanilla --model gpt-5.3-codex -C path/to/benchmark --with-opik &
+nasde run --variant gemini-vanilla --model google/gemini-3-flash-preview -C path/to/benchmark --with-opik &
 wait
 ```
 
@@ -181,6 +230,11 @@ When using `CLAUDE_CODE_OAUTH_TOKEN` (Claude subscription — no per-token cost)
 **Codex variants:**
 - **ChatGPT OAuth** (`codex login`): uses subscription credits, no per-token cost. Same heuristic as Claude subscription — run freely under 30 minutes.
 - **API key** (`CODEX_API_KEY`): billed per-token. Always ask before running. Codex uses significantly more input tokens than Claude Code (~1M vs ~250K per task).
+
+**Gemini CLI variants:**
+- **Google account OAuth** (`gemini login`): free tier via Gemini Code Assist license (1M token context). Run freely.
+- **API key** (`GEMINI_API_KEY`): billed per-token through Google AI Studio. Ask before running.
+- **Vertex AI** (`GOOGLE_API_KEY`): billed through Google Cloud. Ask before running.
 
 Task estimated times are in `task.json` → `estimated_time_minutes`. When `--tasks` filters are used, count only selected tasks.
 
@@ -310,6 +364,19 @@ Common causes:
 - **0% pass rate, low scores, but trials completed** — likely inherited Claude model name (e.g. `claude-sonnet-4-6`) instead of OpenAI model. Check `config.json` in the job dir for `model_name`. Fix by adding `model = "gpt-5.3-codex"` to `variant.toml` or using `--model gpt-5.3-codex`
 - **`Tool 'web_search_preview' is not supported`** — model doesn't support Codex tools
 - **`Model metadata for 'X' not found`** — warning only, usually followed by the real error
+
+### Gemini trial fails immediately (reward 0, 0/100)
+
+Check the agent log for errors:
+```bash
+head -20 jobs/<ts>/<trial>/agent/gemini-cli.txt
+```
+
+Common causes:
+- **`GEMINI_API_KEY is not set`** — no auth configured. Either run `gemini login` or set `GEMINI_API_KEY`
+- **`Model name must be in the format provider/model_name`** — model must include `google/` prefix (e.g. `google/gemini-3-flash-preview`)
+- **Node.js errors** — Gemini CLI requires Node.js 22+. Check the Docker image includes nvm setup
+- **DNS resolution failures** — cloud sandboxes may not resolve `generativelanguage.googleapis.com`. ConfigurableGemini auto-fixes this, but custom configs may not
 
 ### Trial reward is 0 but code looks correct
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-NASDE evaluates AI coding agents (e.g. Claude Code, OpenAI Codex) on programming tasks. It uses **Harbor** as the execution engine running agents in isolated sandbox environments and **Opik** as the observability platform for tracking results.
+NASDE evaluates AI coding agents (e.g. Claude Code, OpenAI Codex, Gemini CLI) on programming tasks. It uses **Harbor** as the execution engine running agents in isolated sandbox environments and **Opik** as the observability platform for tracking results.
 
 Key design: evaluation is **two-stage** — Harbor assesses functional correctness (tests pass/fail), then a separate reviewer agent (Claude Code SDK) assesses architectural quality of the generated code.
 
@@ -20,8 +20,8 @@ flowchart TB
 
     subgraph HARBOR ["2. Harbor — trial execution (isolated sandbox)"]
         JOB --> SANDBOX["Sandbox environment\n(Docker, Daytona, Modal, E2B, etc.)"]
-        SANDBOX --> SETUP["ConfigurableClaude.setup()\n→ upload CLAUDE.md, .claude.json"]
-        SETUP --> AGENT["Claude Code agent\nworks on the task"]
+        SANDBOX --> SETUP["Configurable{Claude,Codex,Gemini}.setup()\n→ upload instruction files, skills, config"]
+        SETUP --> AGENT["AI coding agent\nworks on the task"]
         AGENT --> TEST["test.sh — functional verification"]
         TEST --> REWARD["reward: 0.0 or 1.0"]
         REWARD --> ARTIFACTS["Artifacts copied to host\n→ jobs/ts/trial/artifacts/"]
@@ -218,6 +218,11 @@ classDiagram
         +setup(environment)
         +solve(task)
     }
+    class GeminiCli {
+        <<Harbor built-in>>
+        +setup(environment)
+        +solve(task)
+    }
     class ConfigurableClaude {
         -_sandbox_files: dict~str, str~
         +setup(environment)
@@ -230,14 +235,23 @@ classDiagram
         -_upload_sandbox_files(environment)
         +name() str
     }
+    class ConfigurableGemini {
+        -_sandbox_files: dict~str, str~
+        +setup(environment)
+        -_upload_sandbox_files(environment)
+        +create_run_agent_commands(instruction) list
+        +name() str
+    }
     ClaudeCode <|-- ConfigurableClaude
     Codex <|-- ConfigurableCodex
+    GeminiCli <|-- ConfigurableGemini
 
     note for ConfigurableClaude "Injects CLAUDE.md, .claude/skills/ into sandbox"
     note for ConfigurableCodex "Injects AGENTS.md, .agents/skills/ into sandbox"
+    note for ConfigurableGemini "Injects GEMINI.md, .gemini/skills/ into sandbox\nAuto-injects OAuth creds from ~/.gemini/oauth_creds.json"
 ```
 
-Harbor natively handles auth, MCP servers, model selection, and timeout for both agents. `ConfigurableClaude` and `ConfigurableCodex` each add **one thing**: declarative file mapping from host to the sandbox via `sandbox_files` in `harbor_config.json`. The agent type is auto-detected from the variant's instruction file (`CLAUDE.md` → Claude, `AGENTS.md` → Codex).
+Harbor natively handles auth, MCP servers, model selection, and timeout for all agents. `ConfigurableClaude`, `ConfigurableCodex`, and `ConfigurableGemini` each add **one thing**: declarative file mapping from host to the sandbox via `sandbox_files` in `harbor_config.json`. `ConfigurableGemini` additionally handles OAuth credential injection and DNS resolution for cloud sandboxes. The agent type is auto-detected from the variant's instruction file (`CLAUDE.md` → Claude, `AGENTS.md` → Codex, `GEMINI.md` → Gemini).
 
 ---
 
@@ -246,15 +260,17 @@ Harbor natively handles auth, MCP servers, model selection, and timeout for both
 Each benchmark defines its **own set of variants** — there are no globally shared variants. A variant represents a specific agent configuration to be compared against other variants on the same set of tasks.
 
 Each variant is a directory under `variants/<variant-name>/` containing:
-- `variant.toml` — **required**, declares the agent type (`agent = "claude"` or `agent = "codex"`)
+- `variant.toml` — **required**, declares the agent type (`agent = "claude"`, `agent = "codex"`, or `agent = "gemini"`)
 - `CLAUDE.md` — Claude Code instructions injected into `/app/CLAUDE.md` (for Claude variants)
 - `AGENTS.md` — Codex instructions injected into `/app/AGENTS.md` (for Codex variants)
+- `GEMINI.md` — Gemini CLI instructions injected into `/app/GEMINI.md` (for Gemini variants)
 - `skills/` — Claude skill snapshots, each `skills/<name>/SKILL.md` injected into `/app/.claude/skills/<name>/SKILL.md` (optional)
 - `agents_skills/` — Codex skill snapshots, each `agents_skills/<name>/` injected recursively into `/app/.agents/skills/<name>/` (optional)
+- `gemini_skills/` — Gemini skill snapshots, each `gemini_skills/<name>/` injected recursively into `/app/.gemini/skills/<name>/` and `~/.gemini/skills/<name>/` (optional)
 - `harbor_config.json` — agent import path + `sandbox_files` mapping (auto-generated from `variant.toml` if absent)
 - `claude_config.json` — MCP server configuration, Claude only (optional)
 
-Variants can differ along many axes: agent type, instruction specificity, skill combinations, tool access, constraints, prompting techniques. Cross-agent comparison (e.g. Claude vs Codex on the same tasks) is a key use case.
+Variants can differ along many axes: agent type, instruction specificity, skill combinations, tool access, constraints, prompting techniques. Cross-agent comparison (e.g. Claude vs Codex vs Gemini on the same tasks) is a key use case.
 
 ---
 
@@ -348,4 +364,5 @@ src/nasde_toolkit/
   agents/
     configurable_claude.py # Harbor-compatible Claude Code agent with sandbox file injection
     configurable_codex.py  # Harbor-compatible Codex agent with sandbox file injection
+    configurable_gemini.py # Harbor-compatible Gemini CLI agent with sandbox file injection + OAuth
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ src/nasde_toolkit/
     __init__.py
     configurable_claude.py # Harbor-compatible Claude Code agent with sandbox file injection
     configurable_codex.py  # Harbor-compatible Codex agent with sandbox file injection
+    configurable_gemini.py # Harbor-compatible Gemini CLI agent with sandbox file injection
 tests/
 pyproject.toml
 ```
@@ -55,8 +56,9 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the full system architecture with dia
 - **Configuration**: Two-layer config — `nasde.toml` for project-level settings, `task.json` per task. Both parsed into `@dataclass` models in `config.py`. Task discovery walks `tasks/` (or `.nasde/tasks/`) automatically.
 - **Benchmark runner**: Uses Harbor Python API (`Job`, `JobConfig`) directly instead of subprocess. The runner merges variant config with task registry into a dict, passes it to `JobConfig.model_validate()`, then runs `await job.run()`. Opik tracking via `track_harbor()` (monkey-patches Harbor at runtime).
 - **Evaluator**: Uses Claude Code SDK async API to run a Claude agent that reads trial artifacts and scores them against assessment criteria. Configurable via `[evaluation]` in `nasde.toml` — model, tools, MCP servers, skills, and system prompt can all be customized. Default model is `claude-opus-4-6` (best available for review quality). Monkeypatches SDK's `parse_message` to handle unknown message types (remove when SDK fixes this). Results written to `assessment_eval.json` per trial and optionally uploaded to Opik.
-- **Variant system**: Each variant is a directory under `variants/` with a required `variant.toml` declaring the agent type (`agent = "claude"` or `agent = "codex"`). For Claude Code variants, `CLAUDE.md` is injected into `/app/CLAUDE.md`; for Codex variants, `AGENTS.md` is injected into `/app/AGENTS.md`. An optional `skills/` subdirectory contains Claude skill snapshots — each `skills/<name>/SKILL.md` is injected into `/app/.claude/skills/<name>/SKILL.md`. An optional `agents_skills/` subdirectory contains Codex skill snapshots — all files under `agents_skills/<name>/` are injected into `/app/.agents/skills/<name>/`. If no `harbor_config.json` exists, one is auto-generated from `variant.toml`.
+- **Variant system**: Each variant is a directory under `variants/` with a required `variant.toml` declaring the agent type (`agent = "claude"`, `agent = "codex"`, or `agent = "gemini"`). For Claude Code variants, `CLAUDE.md` is injected into `/app/CLAUDE.md`; for Codex variants, `AGENTS.md` is injected into `/app/AGENTS.md`; for Gemini CLI variants, `GEMINI.md` is injected into `/app/GEMINI.md`. An optional `skills/` subdirectory contains Claude skill snapshots — each `skills/<name>/SKILL.md` is injected into `/app/.claude/skills/<name>/SKILL.md`. An optional `agents_skills/` subdirectory contains Codex skill snapshots — all files under `agents_skills/<name>/` are injected into `/app/.agents/skills/<name>/`. An optional `gemini_skills/` subdirectory contains Gemini skill snapshots — all files under `gemini_skills/<name>/` are injected into `/app/.gemini/skills/<name>/`. If no `harbor_config.json` exists, one is auto-generated from `variant.toml`.
 - **Codex ChatGPT OAuth**: When `~/.codex/auth.json` contains `auth_mode: "chatgpt"` and no API key env var is set, `ConfigurableCodex` injects the full OAuth token structure into the sandbox via env var. API key always takes priority over OAuth. Tokens are not extracted back from sandbox after runs. Validate with `source scripts/export_codex_oauth_token.sh`.
+- **Gemini Google OAuth**: When `~/.gemini/oauth_creds.json` exists (created by `gemini login`) and no API key env var is set (`GEMINI_API_KEY`, `GOOGLE_API_KEY`, `GOOGLE_APPLICATION_CREDENTIALS`), `ConfigurableGemini` injects the OAuth credentials into the sandbox via env var. API key always takes priority over OAuth. Validate with `source scripts/export_gemini_oauth_token.sh`.
 - **All dependencies are core**: `harbor`, `opik`, `claude-code-sdk` are in `[project.dependencies]`. No optional extras — `uv tool install .` gives full functionality. Assessment evaluation is on by default (`--without-eval` to skip).
 - **Auto-generated Dockerfile**: When a task has no `environment/Dockerfile`, nasde generates one from `source.git` + `[docker]`. For local paths, also generates `docker-compose.yaml` to override the build context. See `docker.py:ensure_task_environment()`.
 - **Pass-through CLI**: `nasde harbor ...` delegates to Harbor's Typer app via `add_typer()`. `nasde opik ...` forwards args to Opik's Click CLI via `ctx.args`.
@@ -106,13 +108,17 @@ my-benchmark/
       solution/solve.sh         # Optional reference solution
   variants/
     <variant-name>/
-      variant.toml              # Required: agent type declaration (agent = "claude" or "codex")
+      variant.toml              # Required: agent type declaration (agent = "claude", "codex", or "gemini")
       CLAUDE.md                 # Claude Code instructions (injected into /app/CLAUDE.md)
       AGENTS.md                 # Codex instructions (injected into /app/AGENTS.md)
+      GEMINI.md                 # Gemini CLI instructions (injected into /app/GEMINI.md)
       skills/                   # Optional: Claude skill snapshots (injected into /app/.claude/skills/)
         <skill-name>/
           SKILL.md              # Skill content (snapshot for deterministic testing)
       agents_skills/            # Optional: Codex skill snapshots (injected into /app/.agents/skills/)
+        <skill-name>/
+          SKILL.md              # Skill content with YAML frontmatter (name + description)
+      gemini_skills/            # Optional: Gemini skill snapshots (injected into /app/.gemini/skills/)
         <skill-name>/
           SKILL.md              # Skill content with YAML frontmatter (name + description)
       harbor_config.json        # Optional: agent import path + sandbox_files mapping
@@ -257,8 +263,26 @@ Codex variant:
 }
 ```
 
+Gemini CLI variant:
+```json
+{
+  "agents": [
+    {
+      "import_path": "nasde_toolkit.agents.configurable_gemini:ConfigurableGemini",
+      "name": "variant-name",
+      "model_name": "google/gemini-3-flash-preview",
+      "kwargs": {
+        "sandbox_files": {
+          "/app/GEMINI.md": "/absolute/path/to/variants/variant-name/GEMINI.md"
+        }
+      }
+    }
+  ]
+}
+```
+
 Critical: `"name"` field is REQUIRED — without it, Opik tagging breaks.
-If `harbor_config.json` is absent, `nasde` auto-generates one based on the instruction file present (`CLAUDE.md` → Claude, `AGENTS.md` → Codex).
+If `harbor_config.json` is absent, `nasde` auto-generates one based on `variant.toml` agent type (`CLAUDE.md` → Claude, `AGENTS.md` → Codex, `GEMINI.md` → Gemini).
 
 ### tests/test.sh (Harbor verifier)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ NASDE is a **wrapper layer** over [Harbor](https://github.com/cased/harbor) (age
 
 What NASDE adds on top is an **agentic code review stage**. After a coding agent (e.g. Claude Code running inside Harbor) completes a task and passes functional tests, NASDE deploys a separate **reviewer agent** — powered by Claude Code SDK — that freely navigates the produced codebase and scores it across multiple **dimensions** defined by the benchmark author. Think of it as a "nasty" code reviewer who checks not just whether the code works, but *how well* it's written according to custom criteria.
 
-AI coding agents increasingly ship built-in eval tools that test individual skills with pass/fail assertions. NASDE operates at a different level: it evaluates your **complete agent configuration** — the combination of skills, `CLAUDE.md` files, MCP servers, and prompting strategies — in sandboxed environments, across **multiple coding agents**, and against **custom quality rubrics**. If built-in evals tell you whether a skill triggers correctly, NASDE tells you whether your setup produces better code.
+AI coding agents increasingly ship built-in eval tools that test individual skills with pass/fail assertions. NASDE operates at a different level: it evaluates your **complete agent configuration** — the combination of skills, `CLAUDE.md`/`AGENTS.md`/`GEMINI.md` files, MCP servers, and prompting strategies — in sandboxed environments, across **multiple coding agents**, and against **custom quality rubrics**. If built-in evals tell you whether a skill triggers correctly, NASDE tells you whether your setup produces better code.
 
 ## Standard vs NASDE evaluation flow
 
@@ -80,7 +80,7 @@ AI coding agents like Claude Code now ship built-in evaluation tools (e.g. Skill
 | | Built-in evals (e.g. Skill Creator) | NASDE |
 |---|---|---|
 | **What you test** | One skill at a time | Full configuration (skill sets + `CLAUDE.md` + MCP) |
-| **Agents supported** | The host agent only | Any agent via Harbor (Claude Code, Codex, Cursor, ...) |
+| **Agents supported** | The host agent only | Any agent via Harbor (Claude Code, Codex, Gemini CLI, Cursor, ...) |
 | **Scoring** | Pass/fail, time, tokens | Multi-dimensional rubric (0–100, custom dimensions) |
 | **Execution** | Agent's own session | Isolated Docker or cloud sandbox per trial |
 | **Primary question** | "Does this skill trigger correctly?" | "Does this configuration produce better code?" |
@@ -126,6 +126,10 @@ export CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...
 # OpenAI Codex
 export CODEX_API_KEY=sk-...        # OpenAI API key (from platform.openai.com)
 
+# Gemini CLI (one of)
+export GEMINI_API_KEY=your-key     # Google AI Studio API key
+export GOOGLE_API_KEY=your-key     # Google Cloud / Vertex AI
+
 # 1. Scaffold a new evaluation project
 nasde init my-benchmark
 
@@ -135,13 +139,16 @@ nasde run --variant vanilla -C my-benchmark
 # 3. Run benchmark with Codex variant
 nasde run --variant codex-baseline --model gpt-5.3-codex -C my-benchmark
 
-# 4. Run specific tasks with Opik tracing
+# 4. Run benchmark with Gemini CLI variant
+nasde run --variant gemini-baseline --model google/gemini-3-flash-preview -C my-benchmark
+
+# 5. Run specific tasks with Opik tracing
 nasde run --variant vanilla --tasks my-task -C my-benchmark --with-opik
 
-# 5. Skip assessment evaluation (Harbor only)
+# 6. Skip assessment evaluation (Harbor only)
 nasde run --variant vanilla -C my-benchmark --without-eval
 
-# 6. Re-evaluate an existing job directory
+# 7. Re-evaluate an existing job directory
 nasde eval jobs/2026-03-13__14-30-00 --with-opik -C my-benchmark
 ```
 
@@ -297,7 +304,7 @@ nasde auto-generates the Docker environment — no custom `Dockerfile` needed. S
 |------|-------------|
 | `--variant` | Variant to run (defaults to config default) |
 | `--tasks` | Comma-separated task names to run |
-| `--model` | Model override (e.g. `claude-sonnet-4-6`) |
+| `--model` | Model override (e.g. `claude-sonnet-4-6`, `o3`, `google/gemini-3-flash-preview`) |
 | `--timeout` | Agent timeout in seconds |
 | `--with-opik` | Enable Opik tracing |
 | `--without-eval` | Skip assessment evaluation |
@@ -338,6 +345,15 @@ my-benchmark/
       agents_skills/           # Codex skills (injected to /app/.agents/skills/)
         my-skill/
           SKILL.md             # Requires YAML frontmatter (name + description)
+    gemini-baseline/           # Gemini CLI variant
+      variant.toml             # agent = "gemini"
+      GEMINI.md                # Gemini instructions (injected to /app/GEMINI.md)
+    gemini-with-skills/        # Gemini CLI variant with skills
+      variant.toml             # agent = "gemini"
+      GEMINI.md
+      gemini_skills/           # Gemini skills (injected to /app/.gemini/skills/)
+        my-skill/
+          SKILL.md
   evaluator_skills/            # Optional: skills for the evaluator agent
     code-review/
       SKILL.md
@@ -348,7 +364,7 @@ my-benchmark/
 Each variant must have a `variant.toml` declaring the agent type:
 
 ```toml
-agent = "claude"   # or "codex"
+agent = "claude"   # or "codex" or "gemini"
 ```
 
 ### `nasde.toml`
@@ -430,6 +446,35 @@ export CODEX_API_KEY=sk-...  # preferred
 
 API key always takes priority over OAuth when both are present.
 
+### Gemini CLI
+
+Gemini CLI variants support three authentication methods:
+
+**Option 1: API key (Google AI Studio)** — billed per-token through your Google AI Studio account.
+
+```bash
+export GEMINI_API_KEY=your-key
+```
+
+**Option 2: Google Cloud / Vertex AI** — uses your Google Cloud project billing.
+
+```bash
+export GOOGLE_API_KEY=your-key
+export GOOGLE_CLOUD_PROJECT=your-project
+```
+
+**Option 3: OAuth (Google account)** — uses your Gemini subscription credits.
+
+```bash
+gemini login                                  # authenticate via Google account (one-time)
+source scripts/export_gemini_oauth_token.sh   # validate tokens are present
+uv run nasde run --variant gemini-baseline -C my-benchmark
+```
+
+NASDE auto-detects `~/.gemini/oauth_creds.json` and injects the credentials into the sandbox. No env vars needed.
+
+API key env vars (`GEMINI_API_KEY`, `GOOGLE_API_KEY`, `GOOGLE_APPLICATION_CREDENTIALS`) always take priority over OAuth when present.
+
 ### Opik tracing
 
 For Opik tracing, set credentials in `.env` (in project dir or parent):
@@ -444,9 +489,11 @@ OPIK_PROJECT_NAME=...
 - **Python 3.12+**
 - **Docker** (default) or a cloud sandbox provider — Harbor runs agents in isolated environments
 - **uv** — Package manager
+- **npm** — Required for Gemini CLI (`@google/gemini-cli` is installed automatically by Harbor)
 - **Agent credentials** (at least one):
   - Claude Code: `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`
   - OpenAI Codex: `CODEX_API_KEY` (API key) or `codex login` (ChatGPT subscription OAuth)
+  - Gemini CLI: `GEMINI_API_KEY` (API key), `GOOGLE_API_KEY` (Vertex AI), or `gemini login` (Google account OAuth)
 - **ANTHROPIC_API_KEY** or **CLAUDE_CODE_OAUTH_TOKEN** — Also required for the assessment evaluator (which always uses Claude Code SDK)
 
 ## Verifying Opik results

--- a/examples/ddd-architectural-challenges/variants/gemini-ntcoding-tactical-ddd/GEMINI.md
+++ b/examples/ddd-architectural-challenges/variants/gemini-ntcoding-tactical-ddd/GEMINI.md
@@ -1,0 +1,7 @@
+# Agent Instructions
+
+## Approach
+
+1. Before writing any code, explore the existing codebase to understand its architecture and conventions.
+2. Follow existing architectural patterns exactly — match naming, namespaces, directory structure, and code style.
+3. Write tests that match the style of existing test files.

--- a/examples/ddd-architectural-challenges/variants/gemini-ntcoding-tactical-ddd/gemini_skills/tactical-ddd/SKILL.md
+++ b/examples/ddd-architectural-challenges/variants/gemini-ntcoding-tactical-ddd/gemini_skills/tactical-ddd/SKILL.md
@@ -1,0 +1,501 @@
+<!-- Source: ntcoding/claude-skillz -->
+<!-- Snapshot: 2026-03-20 -->
+---
+name: tactical-ddd
+description: "Design, refactor, analyze, and review code by applying the principles and patterns of tactical domain-driven design. Triggers on: domain modeling, aggregate design, 'entity', 'value object', 'repository', 'bounded context', 'domain event', 'domain service', code touching domain/ directories, rich domain model discussions."
+version: 1.0.0
+---
+
+# Tactical DDD
+
+Design, refactor, analyze, and review code by applying the principles and patterns of tactical domain-driven design.
+
+## Principles
+
+1. **Isolate domain logic**
+2. **Use rich domain language**
+3. **Orchestrate with use cases**
+4. **Avoid anemic domain model**
+5. **Separate generic concepts**
+6. **Make the implicit explicit... like your life depends on it**
+7. **Design aggregates around invariants**
+8. **Extract immutable value objects liberally**
+9. **Repositories are for loading and saving full aggregates**
+
+---
+
+## 1. Isolate domain logic
+
+**What:** Domain logic is not mixed with technical code like HTTP and database transactions.
+
+**Why:** Easier to understand the most important part of the code, easier to validate with domain experts, easier to test and evolve, easier to plan and implement new features.
+
+**Test:** Could a domain expert read the code? Can the code be unit tested without mocks or spinning up databases?
+
+```typescript
+// ❌ WRONG - domain polluted with infrastructure
+class Delivery {
+  async dispatch() {
+    this.logger.info('Dispatching delivery', { id: this.id })  // Infrastructure!
+    await this.db.beginTransaction()                           // Infrastructure!
+    if (this.status !== 'ready') throw new Error('Not ready')
+    this.status = 'dispatched'
+    await this.db.save(this)                                   // Infrastructure!
+    await this.db.commit()                                     // Infrastructure!
+    await this.pushNotification.notifyDriver()                 // Infrastructure!
+  }
+}
+
+// ✅ RIGHT - isolated domain logic
+class Delivery {
+  dispatch(): void {
+    if (this.status !== DeliveryStatus.Ready) {
+      throw new DeliveryNotReadyError(this.id)
+    }
+    this.status = DeliveryStatus.Dispatched
+    this.dispatchedAt = new Date()
+  }
+}
+```
+
+---
+
+## 2. Use rich domain language
+
+**What:** Names in code match exactly what domain experts say. No programmer jargon. No generic names.
+
+**Why:** Translation between code-speak and business-speak causes bugs. When a domain expert says "assess a claim" and the code says "processEntity", someone will misunderstand something.
+
+**Test:** Would a domain expert recognize this name? If you'd need to translate it for them, it's wrong.
+
+**Common generic terms to watch for:**
+- `Manager`, `Handler`, `Processor`, `Helper`, `Util`
+- `Data`, `Info`, `Item` (when domain terms exist)
+- `process`, `handle`, `execute` (what does it actually DO?)
+
+```typescript
+// ❌ WRONG - programmer jargon
+class ClaimHandler {
+  processClaimData(claimData: ClaimDTO): ProcessingResult {
+    return this.claimProcessor.handle(claimData)
+  }
+}
+
+// ✅ RIGHT - domain language
+class ClaimAssessor {
+  assessClaim(claim: InsuranceClaim): AssessmentDecision {
+    if (claim.exceedsCoverageLimit()) {
+      return AssessmentDecision.deny(DenialReason.ExceedsCoverage)
+    }
+    return AssessmentDecision.approve()
+  }
+}
+```
+
+---
+
+## 3. Orchestrate with use cases
+
+**What:** A use case is a user goal—something a user would recognize as an action they can perform in your application.
+
+**Why:** Use cases define the entry points to your domain. They answer "what can a user do?" If something isn't a user goal, it's supporting machinery that belongs elsewhere.
+
+**Test (the menu test):** If you described your application's features to a user like a menu, would this be on it?
+
+```
+DELIVERY APP MENU:
+├── Request Delivery     ← Use case: user goal
+├── Track Delivery       ← Use case: user goal
+├── Cancel Delivery      ← Use case: user goal
+├── Calculate ETA        ← NOT a use case: internal machinery
+└── Check Delivery Radius ← NOT a use case: domain rule
+```
+
+```typescript
+// ❌ WRONG - not a user goal, this is internal machinery
+// use-cases/calculate-eta.use-case.ts
+async function calculateETA(deliveryId: DeliveryId) {
+  const delivery = await deliveryRepository.find(deliveryId)
+  const driver = await driverRepository.find(delivery.driverId)
+  return routeService.estimateArrival(driver.location, delivery.destination)
+}
+
+// ✅ RIGHT - actual user goal (appears in menu)
+// use-cases/cancel-delivery.use-case.ts
+async function cancelDelivery(deliveryId: DeliveryId, reason: CancellationReason) {
+  const delivery = await deliveryRepository.find(deliveryId)
+  delivery.cancel(reason)
+  await deliveryRepository.save(delivery)
+}
+```
+
+---
+
+## 4. Avoid anemic domain model
+
+**What:** Domain logic lives in domain objects, not in use cases. Use cases orchestrate; domain objects decide.
+
+**Why:** When business rules leak into use cases, they scatter across the codebase, duplicate, and diverge. The domain becomes a dumb data carrier.
+
+**Test:** Is your use case making business decisions, or just coordinating? If the use case contains if/else business logic, you likely have an anemic model.
+
+```typescript
+// ❌ WRONG - business logic in use case (anemic domain)
+async function confirmDropoff(deliveryId: DeliveryId, photo: ProofPhoto) {
+  const delivery = await deliveryRepository.find(deliveryId)
+
+  // Business rules leaked into use case!
+  if (delivery.status !== 'in_transit') {
+    throw new Error('Delivery not in transit')
+  }
+  if (!photo && delivery.requiresSignature) {
+    throw new Error('Proof of delivery required')
+  }
+
+  delivery.status = 'delivered'
+  delivery.proofPhoto = photo
+  delivery.deliveredAt = new Date()
+  await deliveryRepository.save(delivery)
+}
+
+// ✅ RIGHT - use case orchestrates, domain decides
+async function confirmDropoff(deliveryId: DeliveryId, photo: ProofPhoto) {
+  const delivery = await deliveryRepository.find(deliveryId)
+
+  delivery.confirmDropoff(photo)  // Domain enforces the rules
+
+  await deliveryRepository.save(delivery)
+}
+```
+
+**Signs of anemic model:**
+- Use cases full of if/else business logic
+- Domain objects are just data with getters/setters
+- Business rules duplicated across multiple use cases
+- Validation logic outside the object being validated
+
+---
+
+## 5. Separate generic concepts
+
+**What:** Generic capabilities that aren't specific to your domain live separately from domain-specific logic.
+
+**Why:** A retry mechanism, a caching layer, a validation framework—these aren't YOUR domain. Mixing them with domain logic obscures what's actually specific to your business.
+
+**Test:** Would this code exist in a completely different business domain? If yes, it's generic. If it's specific to YOUR business rules, it's domain.
+
+```typescript
+// ❌ WRONG - generic retry logic mixed with domain
+// domain/driver-locator.ts
+class DriverLocator {
+  // Generic retry logic does not belong in domain!
+  private async withRetry<T>(fn: () => Promise<T>, attempts: number): Promise<T> {
+    for (let i = 0; i < attempts; i++) {
+      try { return await fn() }
+      catch (e) { if (i === attempts - 1) throw e }
+    }
+    throw new Error('Retry failed')
+  }
+
+  async findAvailableDriver(zone: Zone): Promise<Driver> {
+    return this.withRetry(() => this.searchDriversInZone(zone), 3)
+  }
+
+  private async searchDriversInZone(zone: Zone): Promise<Driver> {
+    // domain logic to find nearest available driver
+  }
+}
+
+// ✅ RIGHT - same behavior, properly separated
+// infra/retry.ts (generic, reusable in any project)
+export async function withRetry<T>(fn: () => Promise<T>, attempts: number): Promise<T> {
+  for (let i = 0; i < attempts; i++) {
+    try { return await fn() }
+    catch (e) { if (i === attempts - 1) throw e }
+  }
+  throw new Error('Retry failed')
+}
+
+// domain/driver-locator.ts (pure domain, no infra imports)
+class DriverLocator {
+  async findAvailableDriver(zone: Zone): Promise<Driver> {
+    // domain logic to find nearest available driver
+  }
+}
+
+// use-cases/dispatch-delivery.ts (orchestrates domain + infra)
+async function dispatchDelivery(deliveryId: DeliveryId) {
+  const delivery = await deliveryRepository.find(deliveryId)
+  const driver = await withRetry(
+    () => driverLocator.findAvailableDriver(delivery.zone), 3
+  )
+  delivery.assignDriver(driver)
+  await deliveryRepository.save(delivery)
+}
+```
+
+---
+
+## 6. Make the implicit explicit... like your life depends on it
+
+**What:** Strive for maximum expressiveness. Go as far as possible to identify and name domain concepts in code. Don't settle for "good enough"—push until the code speaks the domain fluently.
+
+**Why:** Maximum alignment optimizes communication between engineers and domain experts. Easier to discuss nuances and avoid misconceptions. Easier to plan and implement features and detect when the design of code is causing unnecessary friction.
+
+**Test:** Could you discuss this code with a domain expert without translation? Are there concepts they use that don't exist in your code?
+
+```typescript
+// This code looks fine - isolated, uses domain terms
+class Delivery {
+  status: DeliveryStatus
+  driver: Driver | null
+  pickupTime: Date | null
+  dropoffTime: Date | null
+  proofOfDelivery: Photo | null
+
+  assignDriver(driver: Driver): void {
+    if (this.status !== DeliveryStatus.Confirmed) throw new Error('...')
+    this.driver = driver
+    this.status = DeliveryStatus.Assigned
+  }
+
+  recordPickup(): void {
+    if (this.status !== DeliveryStatus.Assigned) throw new Error('...')
+    this.pickupTime = new Date()
+    this.status = DeliveryStatus.InTransit
+  }
+
+  recordDropoff(photo: Photo): void {
+    if (this.status !== DeliveryStatus.InTransit) throw new Error('...')
+    this.proofOfDelivery = photo
+    this.dropoffTime = new Date()
+    this.status = DeliveryStatus.Delivered
+  }
+}
+
+// But the TYPES can describe the domain! Each state is a distinct concept.
+// Reading the types alone tells you how deliveries work.
+
+type Delivery =
+  | RequestedDelivery      // Customer placed request
+  | ConfirmedDelivery      // Restaurant accepted
+  | AssignedDelivery       // Driver assigned, heading to restaurant
+  | InTransitDelivery      // Driver picked up, heading to customer
+  | DeliveredDelivery      // Complete with proof
+
+interface RequestedDelivery {
+  kind: 'requested'
+  customer: Customer
+  restaurant: Restaurant
+  items: MenuItem[]
+}
+
+interface ConfirmedDelivery {
+  kind: 'confirmed'
+  customer: Customer
+  restaurant: Restaurant
+  items: MenuItem[]
+  estimatedPrepTime: Duration
+}
+
+interface AssignedDelivery {
+  kind: 'assigned'
+  customer: Customer
+  restaurant: Restaurant
+  items: MenuItem[]
+  driver: Driver              // Now guaranteed to exist
+  estimatedPickup: Time
+}
+
+interface InTransitDelivery {
+  kind: 'in_transit'
+  customer: Customer
+  restaurant: Restaurant
+  items: MenuItem[]
+  driver: Driver
+  pickupTime: Time            // Now guaranteed to exist
+  estimatedDropoff: Time
+}
+
+interface DeliveredDelivery {
+  kind: 'delivered'
+  customer: Customer
+  restaurant: Restaurant
+  items: MenuItem[]
+  driver: Driver
+  pickupTime: Time
+  dropoffTime: Time           // Now guaranteed to exist
+  proofOfDelivery: Photo      // Now guaranteed to exist
+}
+
+// State transitions are explicit functions
+function confirmDelivery(d: RequestedDelivery, prepTime: Duration): ConfirmedDelivery
+function assignDriver(d: ConfirmedDelivery, driver: Driver): AssignedDelivery
+function recordPickup(d: AssignedDelivery): InTransitDelivery
+function recordDropoff(d: InTransitDelivery, photo: Photo): DeliveredDelivery
+```
+
+**Smaller improvements matter too:**
+
+```typescript
+// Extract an if statement to a named method
+if (distance.kilometers > 10 && !driver.hasLongRangeVehicle) { ... }
+if (delivery.exceedsDriverRange(driver)) { ... }
+
+// Name a boolean expression
+const canAssign = driver.isAvailable && driver.isInZone(delivery.zone) && !driver.atCapacity
+const canAssign = driver.canAccept(delivery)
+
+// Rename to use domain language
+const fee = customFee ?? standardFee
+const fee = customFee ?? defaultDeliveryFee
+```
+
+**Ways to increase expressiveness:**
+- Model states as distinct types (Delivery with status → RequestedDelivery, ConfirmedDelivery, etc.)
+- Make optional fields guaranteed at the right state (driver: Driver | null → driver: Driver)
+- Extract conditionals to named methods (complex if → exceedsDriverRange)
+- Rename variables to use domain language (standardFee → defaultDeliveryFee)
+
+---
+
+## 7. Design aggregates around invariants
+
+**What:** An aggregate is a cluster of objects that must be consistent together. The aggregate root enforces the rules. External code cannot violate invariants.
+
+**Why:** Without clear boundaries, inconsistent states creep in. One piece of code updates the delivery, another updates the route, and suddenly the ETA is wrong.
+
+**Test:** What must be true at all times? What rules must never be broken? The objects involved in those rules form an aggregate.
+
+```typescript
+// ❌ WRONG - no aggregate boundary, invariants violated
+class Delivery {
+  stops: DeliveryStop[]  // Exposed!
+  totalDistance: Distance
+}
+
+// External code can break invariants
+delivery.stops.push(new DeliveryStop(location))
+// Oops - totalDistance is now wrong!
+
+// ✅ RIGHT - aggregate protects invariants
+class Delivery {
+  private stops: DeliveryStop[] = []
+  private _totalDistance: Distance = Distance.zero()
+
+  addStop(location: Location): void {
+    if (this.status !== DeliveryStatus.Planning) {
+      throw new DeliveryNotModifiableError(this.id)
+    }
+    const previousStop = this.stops[this.stops.length - 1]
+    const stop = new DeliveryStop(location)
+    this.stops.push(stop)
+    this._totalDistance = this._totalDistance.add(
+      previousStop.distanceTo(location)  // Invariant maintained!
+    )
+  }
+
+  removeStop(stopId: StopId): void {
+    if (this.stops.length <= 2) {
+      throw new MinimumStopsRequiredError(this.id)
+    }
+    // Recalculate total distance after removal
+    this.stops = this.stops.filter(s => !s.id.equals(stopId))
+    this._totalDistance = this.calculateTotalDistance()  // Invariant maintained!
+  }
+
+  get totalDistance(): Distance {
+    return this._totalDistance
+  }
+}
+```
+
+**Aggregate rules:**
+- One root entity per aggregate
+- External code accesses only through the root
+- The root enforces all invariants
+- Reference other aggregates by ID, not object
+- Methods should operate on the same state—if they don't, split the aggregate
+
+---
+
+## 8. Extract immutable value objects liberally
+
+**What:** When something is defined by its attributes (not identity), make it an immutable value object. Do this liberally—more value objects is usually better.
+
+**Why:** Value objects are simple. They can't change unexpectedly. They're easy to test. They make domain concepts explicit. They're also a good way to extract logic from aggregates and entities that can easily get large—keep entities focused by pulling cohesive concepts into value objects.
+
+**Test:** Does this need a unique ID to track it over time? No? It's probably a value object.
+
+```typescript
+// Entity with primitives that should be a value object
+class Delivery {
+  id: DeliveryId
+  feeAmount: number
+  feeCurrency: string
+}
+
+// Extract the value object
+class Delivery {
+  id: DeliveryId
+  fee: Money
+}
+
+class Money {
+  constructor(
+    readonly amount: number,
+    readonly currency: Currency
+  ) {}
+
+  add(other: Money): Money {
+    if (this.currency !== other.currency) {
+      throw new CurrencyMismatchError(this.currency, other.currency)
+    }
+    return new Money(this.amount + other.amount, this.currency)
+  }
+
+  equals(other: Money): boolean {
+    return this.amount === other.amount && this.currency === other.currency
+  }
+}
+```
+
+**Good candidates for value objects:**
+- Money, Currency, Percentage
+- DateRange, TimeSlot, Duration
+- Address, Coordinates, Distance
+- EmailAddress, PhoneNumber, URL
+- Quantity, Weight, Temperature
+- PersonName, CompanyName
+
+---
+
+## 9. Repositories are for loading and saving full aggregates
+
+The job of a repository is to load and save entire aggregates - not partial aggregates or nested entities inside an aggregate. The `load` method takes an ID and returns the full aggregate.
+
+A repository should not exist for a domain object that is not an aggregate. Entity that is part of an aggreate -> does not have a repository. It is loaded via the aggregate root's repository.
+
+The `hydrate` method is used ONLY for constructing an aggregate from it's persisted state. It should not be abused for other use cases like creating new instances. Each creation flow should have a dedicated factory method, e.g. `Order.fromExisting()`, `Order.new()`, `Order.draft()`.
+
+The `save` method of a repository should take the full aggregate.
+
+If you just want to query information to display without modifying state and applying business rules, create a separate read model object and don't use a repository.
+
+---
+
+## Mandatory Checklist
+
+When designing, refactoring, analyzing, or reviewing code:
+
+1. [ ] Verify domain is isolated from infrastructure (no DB/HTTP/logging in domain; generic utilities in infra; domain doesn't import infra)
+2. [ ] Verify names are from YOUR domain, not generic developer jargon
+3. [ ] Verify use cases are intentions of users, human or automated (apply the menu test)
+4. [ ] Verify business logic lives in domain objects, use cases only orchestrate
+5. [ ] Verify states are modeled as distinct types where appropriate
+6. [ ] Verify hidden domain concepts are extracted and named explicitly
+7. [ ] Verify aggregates are designed around invariants, not naive mapping of domain nouns
+8. [ ] Verify values are extracted into value objects expressing a domain concept
+9. [ ] Veirfy no abuse of hydrate methods for creation scenarios. Each creation scenario must have dedicated factory method
+
+Do not proceed until all checks pass.

--- a/examples/ddd-architectural-challenges/variants/gemini-ntcoding-tactical-ddd/variant.toml
+++ b/examples/ddd-architectural-challenges/variants/gemini-ntcoding-tactical-ddd/variant.toml
@@ -1,0 +1,2 @@
+agent = "gemini"
+model = "google/gemini-3-flash-preview"

--- a/examples/ddd-architectural-challenges/variants/gemini-vanilla/GEMINI.md
+++ b/examples/ddd-architectural-challenges/variants/gemini-vanilla/GEMINI.md
@@ -1,0 +1,1 @@
+You are a coding assistant. Work in /app.

--- a/examples/ddd-architectural-challenges/variants/gemini-vanilla/variant.toml
+++ b/examples/ddd-architectural-challenges/variants/gemini-vanilla/variant.toml
@@ -1,0 +1,2 @@
+agent = "gemini"
+model = "google/gemini-3-flash-preview"

--- a/examples/nasde-dev-skill/variants/gemini-vanilla/GEMINI.md
+++ b/examples/nasde-dev-skill/variants/gemini-vanilla/GEMINI.md
@@ -1,0 +1,6 @@
+# Agent Instructions
+
+You are a coding assistant. Work in /app.
+
+1. Follow existing patterns in the codebase.
+2. Read GEMINI.md for project context.

--- a/examples/nasde-dev-skill/variants/gemini-vanilla/variant.toml
+++ b/examples/nasde-dev-skill/variants/gemini-vanilla/variant.toml
@@ -1,0 +1,2 @@
+agent = "gemini"
+model = "google/gemini-3-flash-preview"

--- a/examples/refactoring-skill/variants/gemini-refactoring-skill/GEMINI.md
+++ b/examples/refactoring-skill/variants/gemini-refactoring-skill/GEMINI.md
@@ -1,0 +1,7 @@
+# Agent Instructions
+
+## Approach
+
+1. Before writing any code, explore the existing codebase to understand its architecture and conventions.
+2. Follow existing architectural patterns exactly — match naming, namespaces, directory structure, and code style.
+3. Write tests that match the style of existing test files.

--- a/examples/refactoring-skill/variants/gemini-refactoring-skill/gemini_skills/refactor/SKILL.md
+++ b/examples/refactoring-skill/variants/gemini-refactoring-skill/gemini_skills/refactor/SKILL.md
@@ -1,0 +1,647 @@
+<!-- Source: github/awesome-copilot -->
+<!-- Snapshot: 2026-03-20 -->
+---
+name: refactor
+description: 'Surgical code refactoring to improve maintainability without changing behavior. Covers extracting functions, renaming variables, breaking down god functions, improving type safety, eliminating code smells, and applying design patterns. Less drastic than repo-rebuilder; use for gradual improvements.'
+license: MIT
+---
+
+# Refactor
+
+## Overview
+
+Improve code structure and readability without changing external behavior. Refactoring is gradual evolution, not revolution. Use this for improving existing code, not rewriting from scratch.
+
+## When to Use
+
+Use this skill when:
+
+- Code is hard to understand or maintain
+- Functions/classes are too large
+- Code smells need addressing
+- Adding features is difficult due to code structure
+- User asks "clean up this code", "refactor this", "improve this"
+
+---
+
+## Refactoring Principles
+
+### The Golden Rules
+
+1. **Behavior is preserved** - Refactoring doesn't change what the code does, only how
+2. **Small steps** - Make tiny changes, test after each
+3. **Version control is your friend** - Commit before and after each safe state
+4. **Tests are essential** - Without tests, you're not refactoring, you're editing
+5. **One thing at a time** - Don't mix refactoring with feature changes
+
+### When NOT to Refactor
+
+```
+- Code that works and won't change again (if it ain't broke...)
+- Critical production code without tests (add tests first)
+- When you're under a tight deadline
+- "Just because" - need a clear purpose
+```
+
+---
+
+## Common Code Smells & Fixes
+
+### 1. Long Method/Function
+
+```diff
+# BAD: 200-line function that does everything
+- async function processOrder(orderId) {
+-   // 50 lines: fetch order
+-   // 30 lines: validate order
+-   // 40 lines: calculate pricing
+-   // 30 lines: update inventory
+-   // 20 lines: create shipment
+-   // 30 lines: send notifications
+- }
+
+# GOOD: Broken into focused functions
++ async function processOrder(orderId) {
++   const order = await fetchOrder(orderId);
++   validateOrder(order);
++   const pricing = calculatePricing(order);
++   await updateInventory(order);
++   const shipment = await createShipment(order);
++   await sendNotifications(order, pricing, shipment);
++   return { order, pricing, shipment };
++ }
+```
+
+### 2. Duplicated Code
+
+```diff
+# BAD: Same logic in multiple places
+- function calculateUserDiscount(user) {
+-   if (user.membership === 'gold') return user.total * 0.2;
+-   if (user.membership === 'silver') return user.total * 0.1;
+-   return 0;
+- }
+-
+- function calculateOrderDiscount(order) {
+-   if (order.user.membership === 'gold') return order.total * 0.2;
+-   if (order.user.membership === 'silver') return order.total * 0.1;
+-   return 0;
+- }
+
+# GOOD: Extract common logic
++ function getMembershipDiscountRate(membership) {
++   const rates = { gold: 0.2, silver: 0.1 };
++   return rates[membership] || 0;
++ }
++
++ function calculateUserDiscount(user) {
++   return user.total * getMembershipDiscountRate(user.membership);
++ }
++
++ function calculateOrderDiscount(order) {
++   return order.total * getMembershipDiscountRate(order.user.membership);
++ }
+```
+
+### 3. Large Class/Module
+
+```diff
+# BAD: God object that knows too much
+- class UserManager {
+-   createUser() { /* ... */ }
+-   updateUser() { /* ... */ }
+-   deleteUser() { /* ... */ }
+-   sendEmail() { /* ... */ }
+-   generateReport() { /* ... */ }
+-   handlePayment() { /* ... */ }
+-   validateAddress() { /* ... */ }
+-   // 50 more methods...
+- }
+
+# GOOD: Single responsibility per class
++ class UserService {
++   create(data) { /* ... */ }
++   update(id, data) { /* ... */ }
++   delete(id) { /* ... */ }
++ }
++
++ class EmailService {
++   send(to, subject, body) { /* ... */ }
++ }
++
++ class ReportService {
++   generate(type, params) { /* ... */ }
++ }
++
++ class PaymentService {
++   process(amount, method) { /* ... */ }
++ }
+```
+
+### 4. Long Parameter List
+
+```diff
+# BAD: Too many parameters
+- function createUser(email, password, name, age, address, city, country, phone) {
+-   /* ... */
+- }
+
+# GOOD: Group related parameters
++ interface UserData {
++   email: string;
++   password: string;
++   name: string;
++   age?: number;
++   address?: Address;
++   phone?: string;
++ }
++
++ function createUser(data: UserData) {
++   /* ... */
++ }
+
+# EVEN BETTER: Use builder pattern for complex construction
++ const user = UserBuilder
++   .email('test@example.com')
++   .password('secure123')
++   .name('Test User')
++   .address(address)
++   .build();
+```
+
+### 5. Feature Envy
+
+```diff
+# BAD: Method that uses another object's data more than its own
+- class Order {
+-   calculateDiscount(user) {
+-     if (user.membershipLevel === 'gold') {
++       return this.total * 0.2;
++     }
++     if (user.accountAge > 365) {
++       return this.total * 0.1;
++     }
++     return 0;
++   }
++ }
+
+# GOOD: Move logic to the object that owns the data
++ class User {
++   getDiscountRate(orderTotal) {
++     if (this.membershipLevel === 'gold') return 0.2;
++     if (this.accountAge > 365) return 0.1;
++     return 0;
++   }
++ }
++
++ class Order {
++   calculateDiscount(user) {
++     return this.total * user.getDiscountRate(this.total);
++   }
++ }
+```
+
+### 6. Primitive Obsession
+
+```diff
+# BAD: Using primitives for domain concepts
+- function sendEmail(to, subject, body) { /* ... */ }
+- sendEmail('user@example.com', 'Hello', '...');
+
+- function createPhone(country, number) {
+-   return `${country}-${number}`;
+- }
+
+# GOOD: Use domain types
++ class Email {
++   private constructor(public readonly value: string) {
++     if (!Email.isValid(value)) throw new Error('Invalid email');
++   }
++   static create(value: string) { return new Email(value); }
++   static isValid(email: string) { return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email); }
++ }
++
++ class PhoneNumber {
++   constructor(
++     public readonly country: string,
++     public readonly number: string
++   ) {
++     if (!PhoneNumber.isValid(country, number)) throw new Error('Invalid phone');
++   }
++   toString() { return `${this.country}-${this.number}`; }
++   static isValid(country: string, number: string) { /* ... */ }
++ }
++
++ // Usage
++ const email = Email.create('user@example.com');
++ const phone = new PhoneNumber('1', '555-1234');
+```
+
+### 7. Magic Numbers/Strings
+
+```diff
+# BAD: Unexplained values
+- if (user.status === 2) { /* ... */ }
+- const discount = total * 0.15;
+- setTimeout(callback, 86400000);
+
+# GOOD: Named constants
++ const UserStatus = {
++   ACTIVE: 1,
++   INACTIVE: 2,
++   SUSPENDED: 3
++ } as const;
++
++ const DISCOUNT_RATES = {
++   STANDARD: 0.1,
++   PREMIUM: 0.15,
++   VIP: 0.2
++ } as const;
++
++ const ONE_DAY_MS = 24 * 60 * 60 * 1000;
++
++ if (user.status === UserStatus.INACTIVE) { /* ... */ }
++ const discount = total * DISCOUNT_RATES.PREMIUM;
++ setTimeout(callback, ONE_DAY_MS);
+```
+
+### 8. Nested Conditionals
+
+```diff
+# BAD: Arrow code
+- function process(order) {
+-   if (order) {
+-     if (order.user) {
+-       if (order.user.isActive) {
+-         if (order.total > 0) {
+-           return processOrder(order);
++         } else {
++           return { error: 'Invalid total' };
++         }
++       } else {
++         return { error: 'User inactive' };
++       }
++     } else {
++       return { error: 'No user' };
++     }
++   } else {
++     return { error: 'No order' };
++   }
++ }
+
+# GOOD: Guard clauses / early returns
++ function process(order) {
++   if (!order) return { error: 'No order' };
++   if (!order.user) return { error: 'No user' };
++   if (!order.user.isActive) return { error: 'User inactive' };
++   if (order.total <= 0) return { error: 'Invalid total' };
++   return processOrder(order);
++ }
+
+# EVEN BETTER: Using Result type
++ function process(order): Result<ProcessedOrder, Error> {
++   return Result.combine([
++     validateOrderExists(order),
++     validateUserExists(order),
++     validateUserActive(order.user),
++     validateOrderTotal(order)
++   ]).flatMap(() => processOrder(order));
++ }
+```
+
+### 9. Dead Code
+
+```diff
+# BAD: Unused code lingers
+- function oldImplementation() { /* ... */ }
+- const DEPRECATED_VALUE = 5;
+- import { unusedThing } from './somewhere';
+- // Commented out code
+- // function oldCode() { /* ... */ }
+
+# GOOD: Remove it
++ // Delete unused functions, imports, and commented code
++ // If you need it again, git history has it
+```
+
+### 10. Inappropriate Intimacy
+
+```diff
+# BAD: One class reaches deep into another
+- class OrderProcessor {
+-   process(order) {
+-     order.user.profile.address.street;  // Too intimate
+-     order.repository.connection.config;  // Breaking encapsulation
++   }
++ }
+
+# GOOD: Ask, don't tell
++ class OrderProcessor {
++   process(order) {
++     order.getShippingAddress();  // Order knows how to get it
++     order.save();  // Order knows how to save itself
++   }
++ }
+```
+
+---
+
+## Extract Method Refactoring
+
+### Before and After
+
+```diff
+# Before: One long function
+- function printReport(users) {
+-   console.log('USER REPORT');
+-   console.log('============');
+-   console.log('');
+-   console.log(`Total users: ${users.length}`);
+-   console.log('');
+-   console.log('ACTIVE USERS');
+-   console.log('------------');
+-   const active = users.filter(u => u.isActive);
+-   active.forEach(u => {
+-     console.log(`- ${u.name} (${u.email})`);
+-   });
+-   console.log('');
+-   console.log(`Active: ${active.length}`);
+-   console.log('');
+-   console.log('INACTIVE USERS');
+-   console.log('--------------');
+-   const inactive = users.filter(u => !u.isActive);
+-   inactive.forEach(u => {
+-     console.log(`- ${u.name} (${u.email})`);
+-   });
+-   console.log('');
+-   console.log(`Inactive: ${inactive.length}`);
+- }
+
+# After: Extracted methods
++ function printReport(users) {
++   printHeader('USER REPORT');
++   console.log(`Total users: ${users.length}\n`);
++   printUserSection('ACTIVE USERS', users.filter(u => u.isActive));
++   printUserSection('INACTIVE USERS', users.filter(u => !u.isActive));
++ }
++
++ function printHeader(title) {
++   const line = '='.repeat(title.length);
++   console.log(title);
++   console.log(line);
++   console.log('');
++ }
++
++ function printUserSection(title, users) {
++   console.log(title);
++   console.log('-'.repeat(title.length));
++   users.forEach(u => console.log(`- ${u.name} (${u.email})`));
++   console.log('');
++   console.log(`${title.split(' ')[0]}: ${users.length}`);
++   console.log('');
++ }
+```
+
+---
+
+## Introducing Type Safety
+
+### From Untyped to Typed
+
+```diff
+# Before: No types
+- function calculateDiscount(user, total, membership, date) {
+-   if (membership === 'gold' && date.getDay() === 5) {
+-     return total * 0.25;
+-   }
+-   if (membership === 'gold') return total * 0.2;
+-   return total * 0.1;
+- }
+
+# After: Full type safety
++ type Membership = 'bronze' | 'silver' | 'gold';
++
++ interface User {
++   id: string;
++   name: string;
++   membership: Membership;
++ }
++
++ interface DiscountResult {
++   original: number;
++   discount: number;
++   final: number;
++   rate: number;
++ }
++
++ function calculateDiscount(
++   user: User,
++   total: number,
++   date: Date = new Date()
++ ): DiscountResult {
++   if (total < 0) throw new Error('Total cannot be negative');
++
++   let rate = 0.1; // Default bronze
++
++   if (user.membership === 'gold' && date.getDay() === 5) {
++     rate = 0.25; // Friday bonus for gold
++   } else if (user.membership === 'gold') {
++     rate = 0.2;
++   } else if (user.membership === 'silver') {
++     rate = 0.15;
++   }
++
++   const discount = total * rate;
++
++   return {
++     original: total,
++     discount,
++     final: total - discount,
++     rate
++   };
++ }
+```
+
+---
+
+## Design Patterns for Refactoring
+
+### Strategy Pattern
+
+```diff
+# Before: Conditional logic
+- function calculateShipping(order, method) {
+-   if (method === 'standard') {
+-     return order.total > 50 ? 0 : 5.99;
+-   } else if (method === 'express') {
+-     return order.total > 100 ? 9.99 : 14.99;
++   } else if (method === 'overnight') {
++     return 29.99;
++   }
++ }
+
+# After: Strategy pattern
++ interface ShippingStrategy {
++   calculate(order: Order): number;
++ }
++
++ class StandardShipping implements ShippingStrategy {
++   calculate(order: Order) {
++     return order.total > 50 ? 0 : 5.99;
++   }
++ }
++
++ class ExpressShipping implements ShippingStrategy {
++   calculate(order: Order) {
++     return order.total > 100 ? 9.99 : 14.99;
++   }
++ }
++
++ class OvernightShipping implements ShippingStrategy {
++   calculate(order: Order) {
++     return 29.99;
++   }
++ }
++
++ function calculateShipping(order: Order, strategy: ShippingStrategy) {
++   return strategy.calculate(order);
++ }
+```
+
+### Chain of Responsibility
+
+```diff
+# Before: Nested validation
+- function validate(user) {
+-   const errors = [];
+-   if (!user.email) errors.push('Email required');
++   else if (!isValidEmail(user.email)) errors.push('Invalid email');
++   if (!user.name) errors.push('Name required');
++   if (user.age < 18) errors.push('Must be 18+');
++   if (user.country === 'blocked') errors.push('Country not supported');
++   return errors;
++ }
+
+# After: Chain of responsibility
++ abstract class Validator {
++   abstract validate(user: User): string | null;
++   setNext(validator: Validator): Validator {
++     this.next = validator;
++     return validator;
++   }
++   validate(user: User): string | null {
++     const error = this.doValidate(user);
++     if (error) return error;
++     return this.next?.validate(user) ?? null;
++   }
++ }
++
++ class EmailRequiredValidator extends Validator {
++   doValidate(user: User) {
++     return !user.email ? 'Email required' : null;
++   }
++ }
++
++ class EmailFormatValidator extends Validator {
++   doValidate(user: User) {
++     return user.email && !isValidEmail(user.email) ? 'Invalid email' : null;
++   }
++ }
++
++ // Build the chain
++ const validator = new EmailRequiredValidator()
++   .setNext(new EmailFormatValidator())
++   .setNext(new NameRequiredValidator())
++   .setNext(new AgeValidator())
++   .setNext(new CountryValidator());
+```
+
+---
+
+## Refactoring Steps
+
+### Safe Refactoring Process
+
+```
+1. PREPARE
+   - Ensure tests exist (write them if missing)
+   - Commit current state
+   - Create feature branch
+
+2. IDENTIFY
+   - Find the code smell to address
+   - Understand what the code does
+   - Plan the refactoring
+
+3. REFACTOR (small steps)
+   - Make one small change
+   - Run tests
+   - Commit if tests pass
+   - Repeat
+
+4. VERIFY
+   - All tests pass
+   - Manual testing if needed
+   - Performance unchanged or improved
+
+5. CLEAN UP
+   - Update comments
+   - Update documentation
+   - Final commit
+```
+
+---
+
+## Refactoring Checklist
+
+### Code Quality
+
+- [ ] Functions are small (< 50 lines)
+- [ ] Functions do one thing
+- [ ] No duplicated code
+- [ ] Descriptive names (variables, functions, classes)
+- [ ] No magic numbers/strings
+- [ ] Dead code removed
+
+### Structure
+
+- [ ] Related code is together
+- [ ] Clear module boundaries
+- [ ] Dependencies flow in one direction
+- [ ] No circular dependencies
+
+### Type Safety
+
+- [ ] Types defined for all public APIs
+- [ ] No `any` types without justification
+- [ ] Nullable types explicitly marked
+
+### Testing
+
+- [ ] Refactored code is tested
+- [ ] Tests cover edge cases
+- [ ] All tests pass
+
+---
+
+## Common Refactoring Operations
+
+| Operation                                     | Description                           |
+| --------------------------------------------- | ------------------------------------- |
+| Extract Method                                | Turn code fragment into method        |
+| Extract Class                                 | Move behavior to new class            |
+| Extract Interface                             | Create interface from implementation  |
+| Inline Method                                 | Move method body back to caller       |
+| Inline Class                                  | Move class behavior to caller         |
+| Pull Up Method                                | Move method to superclass             |
+| Push Down Method                              | Move method to subclass               |
+| Rename Method/Variable                        | Improve clarity                       |
+| Introduce Parameter Object                    | Group related parameters              |
+| Replace Conditional with Polymorphism         | Use polymorphism instead of switch/if |
+| Replace Magic Number with Constant            | Named constants                       |
+| Decompose Conditional                         | Break complex conditions              |
+| Consolidate Conditional                       | Combine duplicate conditions          |
+| Replace Nested Conditional with Guard Clauses | Early returns                         |
+| Introduce Null Object                         | Eliminate null checks                 |
+| Replace Type Code with Class/Enum             | Strong typing                         |
+| Replace Inheritance with Delegation           | Composition over inheritance          |

--- a/examples/refactoring-skill/variants/gemini-refactoring-skill/variant.toml
+++ b/examples/refactoring-skill/variants/gemini-refactoring-skill/variant.toml
@@ -1,0 +1,2 @@
+agent = "gemini"
+model = "google/gemini-3-flash-preview"

--- a/examples/refactoring-skill/variants/gemini-vanilla/GEMINI.md
+++ b/examples/refactoring-skill/variants/gemini-vanilla/GEMINI.md
@@ -1,0 +1,6 @@
+# Agent Instructions
+
+You are a coding assistant. Work in /app.
+
+1. Follow existing patterns in the codebase.
+2. Write tests that match the style of existing test files.

--- a/examples/refactoring-skill/variants/gemini-vanilla/variant.toml
+++ b/examples/refactoring-skill/variants/gemini-vanilla/variant.toml
@@ -1,0 +1,2 @@
+agent = "gemini"
+model = "google/gemini-3-flash-preview"

--- a/scripts/export_gemini_oauth_token.sh
+++ b/scripts/export_gemini_oauth_token.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Export Gemini CLI OAuth credentials for subscription-based authentication.
+#
+# Source this script before running nasde to authenticate via your
+# Google/Gemini subscription instead of GEMINI_API_KEY:
+#
+#   source scripts/export_gemini_oauth_token.sh
+#   uv run nasde run --variant gemini-vanilla -C my-benchmark
+#
+# Prerequisites: run `gemini login` to authenticate via Google.
+# The token is read from ~/.gemini/oauth_creds.json.
+
+set -e
+
+_gemini_creds_path="$HOME/.gemini/oauth_creds.json"
+
+if [ ! -f "$_gemini_creds_path" ]; then
+    echo "ERROR: $_gemini_creds_path not found." >&2
+    echo "Run 'gemini login' to authenticate via Google." >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+_gemini_creds="$(cat "$_gemini_creds_path")" || {
+    echo "ERROR: Failed to read $_gemini_creds_path." >&2
+    return 1 2>/dev/null || exit 1
+}
+
+python3 -c "import json; d=json.loads('''$_gemini_creds'''); assert d, 'empty credentials'" 2>/dev/null || {
+    echo "ERROR: $_gemini_creds_path does not contain valid JSON credentials." >&2
+    return 1 2>/dev/null || exit 1
+}
+
+_access_token="$(python3 -c "import json; print(json.load(open('$_gemini_creds_path')).get('access_token',''))")" || _access_token=""
+
+if [ -n "$_access_token" ]; then
+    _exp="$(echo "$_access_token" | cut -d. -f2 | base64 -d 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('exp',0))" 2>/dev/null)" || _exp=0
+    _now="$(python3 -c "import time; print(int(time.time()))")"
+    if [ "$_exp" -gt 0 ] && [ "$_now" -gt "$_exp" ]; then
+        echo "WARNING: access_token appears expired. Run 'gemini login' to refresh." >&2
+        echo "Proceeding anyway -- Gemini CLI may auto-refresh via refresh_token." >&2
+    fi
+fi
+
+GEMINI_OAUTH_CREDS="$_gemini_creds"
+export GEMINI_OAUTH_CREDS
+
+echo "GEMINI_OAUTH_CREDS exported (${_gemini_creds:0:20}...)"
+
+unset _gemini_creds_path _gemini_creds _access_token _exp _now

--- a/scripts/validate_gemini_auth.sh
+++ b/scripts/validate_gemini_auth.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Validate available Gemini authentication methods.
+#
+# Run this script to check which Gemini auth methods are configured:
+#
+#   bash scripts/validate_gemini_auth.sh
+#
+# Checks (in priority order):
+#   1. GEMINI_API_KEY env var
+#   2. GOOGLE_API_KEY env var
+#   3. ~/.gemini/oauth_creds.json (from `gemini login`)
+
+set -e
+
+_found=0
+
+if [ -n "$GEMINI_API_KEY" ]; then
+    echo "GEMINI_API_KEY is set (${GEMINI_API_KEY:0:8}...)"
+    _found=1
+else
+    echo "GEMINI_API_KEY is not set."
+fi
+
+if [ -n "$GOOGLE_API_KEY" ]; then
+    echo "GOOGLE_API_KEY is set (${GOOGLE_API_KEY:0:8}...)"
+    _found=1
+else
+    echo "GOOGLE_API_KEY is not set."
+fi
+
+_gemini_creds_path="$HOME/.gemini/oauth_creds.json"
+if [ -f "$_gemini_creds_path" ]; then
+    echo "OAuth credentials found at $_gemini_creds_path"
+    _found=1
+else
+    echo "OAuth credentials not found at $_gemini_creds_path"
+fi
+
+echo ""
+
+if [ "$_found" -eq 1 ]; then
+    echo "At least one Gemini auth method is available."
+    exit 0
+else
+    echo "ERROR: No Gemini auth method found." >&2
+    echo "Set GEMINI_API_KEY, GOOGLE_API_KEY, or run 'gemini login'." >&2
+    exit 1
+fi

--- a/src/nasde_toolkit/agents/configurable_gemini.py
+++ b/src/nasde_toolkit/agents/configurable_gemini.py
@@ -1,0 +1,187 @@
+"""Configurable Gemini CLI agent for Harbor evaluations.
+
+Harbor's built-in GeminiCli agent handles CLI installation, command construction,
+trajectory parsing, and MCP server configuration natively.  However, it has no
+mechanism to inject arbitrary files (e.g. GEMINI.md, skills) into the sandbox
+before the agent starts.
+
+ConfigurableGemini fills that gap: it accepts a sandbox_files mapping via
+AgentConfig.kwargs and uploads each file into the container during setup().
+
+Additionally, when the user has authenticated via ``gemini login`` (Google
+account), ConfigurableGemini auto-detects ``~/.gemini/oauth_creds.json`` and
+injects the credentials into the sandbox — allowing benchmarks to run on a
+Google account instead of requiring a ``GEMINI_API_KEY``.  API key env vars
+always take priority over OAuth.
+
+Usage in harbor_config.json::
+
+    {
+      "agents": [{
+        "import_path": "nasde_toolkit.agents.configurable_gemini:ConfigurableGemini",
+        "model_name": "google/gemini-3-flash-preview",
+        "kwargs": {
+          "sandbox_files": {
+            "/app/GEMINI.md": "path/to/GEMINI.md"
+          }
+        }
+      }]
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from harbor.agents.installed.base import ExecInput
+from harbor.agents.installed.gemini_cli import GeminiCli
+from harbor.environments.base import BaseEnvironment
+
+logger = logging.getLogger(__name__)
+
+_DNS_FIX_COMMAND = (
+    "timeout 5 getent hosts generativelanguage.googleapis.com >/dev/null 2>&1"
+    " || printf 'nameserver 8.8.8.8\\nnameserver 1.1.1.1\\n' > /etc/resolv.conf"
+)
+
+_API_KEY_VARS = ("GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_APPLICATION_CREDENTIALS")
+
+
+def _read_gemini_oauth_creds() -> str | None:
+    """Return serialised ``~/.gemini/oauth_creds.json`` when it holds OAuth tokens."""
+    creds_path = Path.home() / ".gemini" / "oauth_creds.json"
+    if not creds_path.exists():
+        return None
+    try:
+        raw = json.loads(creds_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not raw:
+        return None
+    return json.dumps(raw)
+
+
+def _inject_oauth_creds(commands: list[ExecInput], oauth_creds_json: str) -> list[ExecInput]:
+    """Inject OAuth credentials into the sandbox environment."""
+    result: list[ExecInput] = []
+    for i, cmd in enumerate(commands):
+        env = dict(cmd.env) if cmd.env else {}
+        if i == 0:
+            env["_GEMINI_OAUTH_CREDS_JSON"] = oauth_creds_json
+            result.append(
+                ExecInput(
+                    command=_build_oauth_setup(cmd.command),
+                    env=env,
+                )
+            )
+        else:
+            result.append(ExecInput(command=cmd.command, env=env))
+    return result
+
+
+def _build_oauth_setup(original_setup: str) -> str:
+    """Build OAuth credential injection command, preserving original setup."""
+    oauth_lines = (
+        "mkdir -p /tmp/gemini-secrets\n"
+        "printf '%s' \"$_GEMINI_OAUTH_CREDS_JSON\" > /tmp/gemini-secrets/oauth_creds.json\n"
+        "mkdir -p ~/.gemini\n"
+        "ln -sf /tmp/gemini-secrets/oauth_creds.json ~/.gemini/oauth_creds.json"
+    )
+    return oauth_lines + "\n" + original_setup
+
+
+class ConfigurableGemini(GeminiCli):
+    """GeminiCli with declarative file injection into the sandbox.
+
+    Args:
+        sandbox_files: Mapping of container paths to host-relative file paths.
+            Each entry is uploaded into the sandbox during setup() before
+            the agent starts. Paths are resolved relative to CWD.
+    """
+
+    def __init__(
+        self,
+        sandbox_files: dict[str, str] | None = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._sandbox_files = sandbox_files or {}
+
+    @staticmethod
+    def name() -> str:
+        return "configurable-gemini-cli"
+
+    async def setup(self, environment: BaseEnvironment) -> None:
+        """Fix cloud DNS, upload files, then run base setup.
+
+        Files must be uploaded BEFORE super().setup() because Harbor's
+        GeminiCli.setup() writes MCP and skills configuration.  Our
+        sandbox_files that target ~/.gemini/skills/ need to be in place
+        before that happens.
+        """
+        await self._ensure_dns_resolution(environment)
+        await self._upload_sandbox_files(environment)
+        await super().setup(environment)
+
+    def create_run_agent_commands(self, instruction: str) -> list[ExecInput]:
+        """Inject OAuth credentials when no API key is set.
+
+        Priority:
+        1. GEMINI_API_KEY / GOOGLE_API_KEY / GOOGLE_APPLICATION_CREDENTIALS → API key mode
+        2. ~/.gemini/oauth_creds.json → OAuth mode (injected into sandbox)
+        """
+        commands: list[ExecInput] = super().create_run_agent_commands(instruction)
+
+        has_api_key = any(os.environ.get(var) for var in _API_KEY_VARS)
+        if has_api_key:
+            return commands
+
+        oauth_creds_json = _read_gemini_oauth_creds()
+        if oauth_creds_json:
+            logger.info("Using Gemini OAuth credentials from ~/.gemini/oauth_creds.json")
+            return _inject_oauth_creds(commands, oauth_creds_json)
+
+        return commands
+
+    async def _ensure_dns_resolution(self, environment: BaseEnvironment) -> None:
+        """Prepend public DNS resolvers if cloud sandbox cannot reach Google APIs."""
+        result = await environment.exec(command=_DNS_FIX_COMMAND)
+        if result.return_code == 0:
+            logger.debug("DNS resolution fix applied")
+        else:
+            logger.warning("DNS resolution fix failed: %s", result.stderr)
+
+    async def _upload_sandbox_files(self, environment: BaseEnvironment) -> None:
+        for target_path, source_path in self._sandbox_files.items():
+            resolved = Path(source_path).resolve()
+            if not resolved.is_file():
+                raise FileNotFoundError(
+                    f"sandbox_files: source '{source_path}' (resolved to '{resolved}') does not exist"
+                )
+            upload_targets = _expand_skill_targets(target_path)
+            for upload_path in upload_targets:
+                parent_dir = str(Path(upload_path).parent)
+                await environment.exec(command=f"mkdir -p {parent_dir}")
+                await environment.upload_file(
+                    source_path=resolved,
+                    target_path=upload_path,
+                )
+
+
+def _expand_skill_targets(target_path: str) -> list[str]:
+    """Expand a skill target path to include both /app/ and ~/.gemini/ locations.
+
+    Gemini CLI discovers skills in both workspace (.gemini/skills/) and user
+    (~/.gemini/skills/) directories.  This ensures skills are available in both.
+    """
+    app_skills_prefix = "/app/.gemini/skills/"
+    if target_path.startswith(app_skills_prefix):
+        relative = target_path[len(app_skills_prefix) :]
+        home_path = f"/root/.gemini/skills/{relative}"
+        return [target_path, home_path]
+    return [target_path]

--- a/src/nasde_toolkit/agents/configurable_gemini.py
+++ b/src/nasde_toolkit/agents/configurable_gemini.py
@@ -75,21 +75,30 @@ async def _write_oauth_to_sandbox(environment: BaseEnvironment, oauth_creds_json
     This runs AFTER Harbor's setup which creates a minimal settings.json.
     We merge our auth config into it rather than overwriting.
     """
-    import shlex
+    import tempfile
 
-    await environment.exec(command="mkdir -p ~/.gemini")
-    await environment.exec(command=f"printf '%s' {shlex.quote(oauth_creds_json)} > ~/.gemini/oauth_creds.json")
-    await environment.exec(
-        command=(
-            'python3 -c "'
-            "import json, pathlib; "
-            "p = pathlib.Path.home() / '.gemini' / 'settings.json'; "
-            "d = json.loads(p.read_text()) if p.exists() else {}; "
-            "d.setdefault('security', {}).setdefault('auth', {})['selectedType'] = 'oauth-personal'; "
-            "p.write_text(json.dumps(d, indent=2))"
-            '"'
-        )
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        f.write(oauth_creds_json)
+        tmp_creds = Path(f.name)
+
+    settings_json = json.dumps(
+        {
+            "experimental": {"skills": True},
+            "security": {"auth": {"selectedType": "oauth-personal"}},
+        },
+        indent=2,
     )
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        f.write(settings_json)
+        tmp_settings = Path(f.name)
+
+    try:
+        await environment.exec(command="mkdir -p /root/.gemini")
+        await environment.upload_file(source_path=tmp_creds, target_path="/root/.gemini/oauth_creds.json")
+        await environment.upload_file(source_path=tmp_settings, target_path="/root/.gemini/settings.json")
+    finally:
+        tmp_creds.unlink(missing_ok=True)
+        tmp_settings.unlink(missing_ok=True)
 
 
 class ConfigurableGemini(GeminiCli):
@@ -133,7 +142,7 @@ class ConfigurableGemini(GeminiCli):
         await self._inject_oauth_if_needed(environment)
 
     async def _inject_oauth_if_needed(self, environment: BaseEnvironment) -> None:
-        """Write OAuth creds and auth config into the sandbox after setup."""
+        """Write OAuth creds and update settings.json in the sandbox after setup."""
         has_api_key = any(os.environ.get(var) for var in _API_KEY_VARS)
         if has_api_key:
             return
@@ -142,8 +151,9 @@ class ConfigurableGemini(GeminiCli):
         if not oauth_creds_json:
             return
 
-        logger.info("Using Gemini OAuth credentials from ~/.gemini/oauth_creds.json")
+        logger.info("Injecting Gemini OAuth credentials into sandbox")
         await _write_oauth_to_sandbox(environment, oauth_creds_json)
+        logger.info("Gemini OAuth injection complete")
 
     async def _ensure_dns_resolution(self, environment: BaseEnvironment) -> None:
         """Prepend public DNS resolvers if cloud sandbox cannot reach Google APIs."""

--- a/src/nasde_toolkit/agents/configurable_gemini.py
+++ b/src/nasde_toolkit/agents/configurable_gemini.py
@@ -84,12 +84,28 @@ def _inject_oauth_creds(commands: list[ExecInput], oauth_creds_json: str) -> lis
 
 
 def _build_oauth_setup(original_setup: str) -> str:
-    """Build OAuth credential injection command, preserving original setup."""
+    """Build OAuth credential injection command, preserving original setup.
+
+    Gemini CLI requires both:
+    1. ``~/.gemini/oauth_creds.json`` — the actual OAuth tokens
+    2. ``~/.gemini/settings.json`` — with ``security.auth.selectedType`` set
+       to ``"oauth-personal"`` so the CLI knows which auth method to use.
+
+    The settings.json write uses a JSON merge approach: if the file already
+    exists (e.g. from Harbor's MCP setup), we merge our auth config into it.
+    """
     oauth_lines = (
         "mkdir -p /tmp/gemini-secrets\n"
         "printf '%s' \"$_GEMINI_OAUTH_CREDS_JSON\" > /tmp/gemini-secrets/oauth_creds.json\n"
         "mkdir -p ~/.gemini\n"
-        "ln -sf /tmp/gemini-secrets/oauth_creds.json ~/.gemini/oauth_creds.json"
+        "ln -sf /tmp/gemini-secrets/oauth_creds.json ~/.gemini/oauth_creds.json\n"
+        'python3 -c "\n'
+        "import json, pathlib\n"
+        "p = pathlib.Path.home() / '.gemini' / 'settings.json'\n"
+        "d = json.loads(p.read_text()) if p.exists() else {}\n"
+        "d.setdefault('security', {}).setdefault('auth', {})['selectedType'] = 'oauth-personal'\n"
+        "p.write_text(json.dumps(d, indent=2))\n"
+        '"'
     )
     return oauth_lines + "\n" + original_setup
 

--- a/src/nasde_toolkit/agents/configurable_gemini.py
+++ b/src/nasde_toolkit/agents/configurable_gemini.py
@@ -37,7 +37,6 @@ import os
 from pathlib import Path
 from typing import Any
 
-from harbor.agents.installed.base import ExecInput
 from harbor.agents.installed.gemini_cli import GeminiCli
 from harbor.environments.base import BaseEnvironment
 
@@ -65,35 +64,32 @@ def _read_gemini_oauth_creds() -> str | None:
     return json.dumps(raw)
 
 
-def _inject_oauth_creds(commands: list[ExecInput], oauth_creds_json: str) -> list[ExecInput]:
-    """Prepend an OAuth setup command before the existing commands.
+async def _write_oauth_to_sandbox(environment: BaseEnvironment, oauth_creds_json: str) -> None:
+    """Write OAuth credentials and auth settings into the sandbox.
 
     Gemini CLI requires both:
     1. ``~/.gemini/oauth_creds.json`` — the actual OAuth tokens
     2. ``~/.gemini/settings.json`` — with ``security.auth.selectedType`` set
        to ``"oauth-personal"`` so the CLI knows which auth method to use.
 
-    We insert a dedicated setup command rather than modifying existing
-    commands, because Harbor executes each ExecInput as a separate step.
+    This runs AFTER Harbor's setup which creates a minimal settings.json.
+    We merge our auth config into it rather than overwriting.
     """
-    setup_command = (
-        "mkdir -p /tmp/gemini-secrets && "
-        "printf '%s' \"$_GEMINI_OAUTH_CREDS_JSON\" > /tmp/gemini-secrets/oauth_creds.json && "
-        "mkdir -p ~/.gemini && "
-        "ln -sf /tmp/gemini-secrets/oauth_creds.json ~/.gemini/oauth_creds.json && "
-        'python3 -c "'
-        "import json, pathlib; "
-        "p = pathlib.Path.home() / '.gemini' / 'settings.json'; "
-        "d = json.loads(p.read_text()) if p.exists() else {}; "
-        "d.setdefault('security', {}).setdefault('auth', {})['selectedType'] = 'oauth-personal'; "
-        "p.write_text(json.dumps(d, indent=2))"
-        '"'
+    import shlex
+
+    await environment.exec(command="mkdir -p ~/.gemini")
+    await environment.exec(command=f"printf '%s' {shlex.quote(oauth_creds_json)} > ~/.gemini/oauth_creds.json")
+    await environment.exec(
+        command=(
+            'python3 -c "'
+            "import json, pathlib; "
+            "p = pathlib.Path.home() / '.gemini' / 'settings.json'; "
+            "d = json.loads(p.read_text()) if p.exists() else {}; "
+            "d.setdefault('security', {}).setdefault('auth', {})['selectedType'] = 'oauth-personal'; "
+            "p.write_text(json.dumps(d, indent=2))"
+            '"'
+        )
     )
-    setup = ExecInput(
-        command=setup_command,
-        env={"_GEMINI_OAUTH_CREDS_JSON": oauth_creds_json},
-    )
-    return [setup, *commands]
 
 
 class ConfigurableGemini(GeminiCli):
@@ -119,36 +115,35 @@ class ConfigurableGemini(GeminiCli):
         return "configurable-gemini-cli"
 
     async def setup(self, environment: BaseEnvironment) -> None:
-        """Fix cloud DNS, upload files, then run base setup.
+        """Fix cloud DNS, upload files, run base setup, then inject OAuth.
 
-        Files must be uploaded BEFORE super().setup() because Harbor's
-        GeminiCli.setup() writes MCP and skills configuration.  Our
-        sandbox_files that target ~/.gemini/skills/ need to be in place
-        before that happens.
+        Order matters:
+        1. DNS fix — cloud sandboxes may not resolve Google APIs
+        2. Upload sandbox files — skills must be in place before Harbor
+           discovers them during setup
+        3. super().setup() — Harbor installs Gemini CLI and writes a
+           minimal ~/.gemini/settings.json (with experimental.skills)
+        4. OAuth injection — AFTER super().setup() because Harbor's install
+           script overwrites ~/.gemini/settings.json.  We merge our auth
+           config into the file that Harbor created.
         """
         await self._ensure_dns_resolution(environment)
         await self._upload_sandbox_files(environment)
         await super().setup(environment)
+        await self._inject_oauth_if_needed(environment)
 
-    def create_run_agent_commands(self, instruction: str) -> list[ExecInput]:
-        """Inject OAuth credentials when no API key is set.
-
-        Priority:
-        1. GEMINI_API_KEY / GOOGLE_API_KEY / GOOGLE_APPLICATION_CREDENTIALS → API key mode
-        2. ~/.gemini/oauth_creds.json → OAuth mode (injected into sandbox)
-        """
-        commands: list[ExecInput] = super().create_run_agent_commands(instruction)
-
+    async def _inject_oauth_if_needed(self, environment: BaseEnvironment) -> None:
+        """Write OAuth creds and auth config into the sandbox after setup."""
         has_api_key = any(os.environ.get(var) for var in _API_KEY_VARS)
         if has_api_key:
-            return commands
+            return
 
         oauth_creds_json = _read_gemini_oauth_creds()
-        if oauth_creds_json:
-            logger.info("Using Gemini OAuth credentials from ~/.gemini/oauth_creds.json")
-            return _inject_oauth_creds(commands, oauth_creds_json)
+        if not oauth_creds_json:
+            return
 
-        return commands
+        logger.info("Using Gemini OAuth credentials from ~/.gemini/oauth_creds.json")
+        await _write_oauth_to_sandbox(environment, oauth_creds_json)
 
     async def _ensure_dns_resolution(self, environment: BaseEnvironment) -> None:
         """Prepend public DNS resolvers if cloud sandbox cannot reach Google APIs."""

--- a/src/nasde_toolkit/agents/configurable_gemini.py
+++ b/src/nasde_toolkit/agents/configurable_gemini.py
@@ -66,48 +66,34 @@ def _read_gemini_oauth_creds() -> str | None:
 
 
 def _inject_oauth_creds(commands: list[ExecInput], oauth_creds_json: str) -> list[ExecInput]:
-    """Inject OAuth credentials into the sandbox environment."""
-    result: list[ExecInput] = []
-    for i, cmd in enumerate(commands):
-        env = dict(cmd.env) if cmd.env else {}
-        if i == 0:
-            env["_GEMINI_OAUTH_CREDS_JSON"] = oauth_creds_json
-            result.append(
-                ExecInput(
-                    command=_build_oauth_setup(cmd.command),
-                    env=env,
-                )
-            )
-        else:
-            result.append(ExecInput(command=cmd.command, env=env))
-    return result
-
-
-def _build_oauth_setup(original_setup: str) -> str:
-    """Build OAuth credential injection command, preserving original setup.
+    """Prepend an OAuth setup command before the existing commands.
 
     Gemini CLI requires both:
     1. ``~/.gemini/oauth_creds.json`` — the actual OAuth tokens
     2. ``~/.gemini/settings.json`` — with ``security.auth.selectedType`` set
        to ``"oauth-personal"`` so the CLI knows which auth method to use.
 
-    The settings.json write uses a JSON merge approach: if the file already
-    exists (e.g. from Harbor's MCP setup), we merge our auth config into it.
+    We insert a dedicated setup command rather than modifying existing
+    commands, because Harbor executes each ExecInput as a separate step.
     """
-    oauth_lines = (
-        "mkdir -p /tmp/gemini-secrets\n"
-        "printf '%s' \"$_GEMINI_OAUTH_CREDS_JSON\" > /tmp/gemini-secrets/oauth_creds.json\n"
-        "mkdir -p ~/.gemini\n"
-        "ln -sf /tmp/gemini-secrets/oauth_creds.json ~/.gemini/oauth_creds.json\n"
-        'python3 -c "\n'
-        "import json, pathlib\n"
-        "p = pathlib.Path.home() / '.gemini' / 'settings.json'\n"
-        "d = json.loads(p.read_text()) if p.exists() else {}\n"
-        "d.setdefault('security', {}).setdefault('auth', {})['selectedType'] = 'oauth-personal'\n"
-        "p.write_text(json.dumps(d, indent=2))\n"
+    setup_command = (
+        "mkdir -p /tmp/gemini-secrets && "
+        "printf '%s' \"$_GEMINI_OAUTH_CREDS_JSON\" > /tmp/gemini-secrets/oauth_creds.json && "
+        "mkdir -p ~/.gemini && "
+        "ln -sf /tmp/gemini-secrets/oauth_creds.json ~/.gemini/oauth_creds.json && "
+        'python3 -c "'
+        "import json, pathlib; "
+        "p = pathlib.Path.home() / '.gemini' / 'settings.json'; "
+        "d = json.loads(p.read_text()) if p.exists() else {}; "
+        "d.setdefault('security', {}).setdefault('auth', {})['selectedType'] = 'oauth-personal'; "
+        "p.write_text(json.dumps(d, indent=2))"
         '"'
     )
-    return oauth_lines + "\n" + original_setup
+    setup = ExecInput(
+        command=setup_command,
+        env={"_GEMINI_OAUTH_CREDS_JSON": oauth_creds_json},
+    )
+    return [setup, *commands]
 
 
 class ConfigurableGemini(GeminiCli):

--- a/src/nasde_toolkit/cli.py
+++ b/src/nasde_toolkit/cli.py
@@ -310,7 +310,8 @@ def _print_run_header(
     eval_str = "enabled" if with_eval else "[yellow]disabled[/yellow]"
     env_str = harbor_env or "docker"
     attempts_str = f"{attempts}" if attempts > 1 else "1"
-    agent_label = "Codex (OpenAI)" if agent_type == "codex" else "Claude Code"
+    agent_labels = {"codex": "Codex (OpenAI)", "gemini": "Gemini CLI (Google)"}
+    agent_label = agent_labels.get(agent_type, "Claude Code")
     console.print(
         Panel(
             f"[bold]Benchmark Runner[/bold]\n"

--- a/src/nasde_toolkit/runner.py
+++ b/src/nasde_toolkit/runner.py
@@ -148,6 +148,16 @@ def _ensure_auth(agent_import_path: str | None = None) -> None:
             return
         console.print("[red]ERROR: Set CODEX_API_KEY, OPENAI_API_KEY, or run 'codex login' for OAuth[/red]")
         raise SystemExit(1)
+    if _is_gemini_agent(agent_import_path):
+        if (
+            os.environ.get("GEMINI_API_KEY")
+            or os.environ.get("GOOGLE_API_KEY")
+            or os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+            or Path.home().joinpath(".gemini", "oauth_creds.json").exists()
+        ):
+            return
+        console.print("[red]ERROR: Set GEMINI_API_KEY, GOOGLE_API_KEY, or run 'gemini login' for OAuth[/red]")
+        raise SystemExit(1)
     if os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"):
         return
     console.print("[red]ERROR: Set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN[/red]")
@@ -204,8 +214,12 @@ def _collect_sandbox_files(variant_dir: Path) -> dict[str, str]:
     agents_md = variant_dir / "AGENTS.md"
     if agents_md.exists():
         sandbox_files["/app/AGENTS.md"] = str(agents_md)
+    gemini_md = variant_dir / "GEMINI.md"
+    if gemini_md.exists():
+        sandbox_files["/app/GEMINI.md"] = str(gemini_md)
     _collect_claude_skills(variant_dir, sandbox_files)
     _collect_codex_skills(variant_dir, sandbox_files)
+    _collect_gemini_skills(variant_dir, sandbox_files)
     return sandbox_files
 
 
@@ -234,7 +248,21 @@ def _collect_codex_skills(variant_dir: Path, sandbox_files: dict[str, str]) -> N
                 sandbox_files[target] = str(file_path)
 
 
-_VALID_AGENT_TYPES = {"claude", "codex"}
+def _collect_gemini_skills(variant_dir: Path, sandbox_files: dict[str, str]) -> None:
+    gemini_skills_dir = variant_dir / "gemini_skills"
+    if not gemini_skills_dir.is_dir():
+        return
+    for skill_dir in sorted(gemini_skills_dir.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        for file_path in skill_dir.rglob("*"):
+            if file_path.is_file():
+                relative = file_path.relative_to(gemini_skills_dir)
+                target = f"/app/.gemini/skills/{relative}"
+                sandbox_files[target] = str(file_path)
+
+
+_VALID_AGENT_TYPES = {"claude", "codex", "gemini"}
 
 
 def load_variant_config(variant_dir: Path) -> dict:
@@ -274,11 +302,17 @@ def load_variant_agent_type(variant_dir: Path) -> str:
 def _agent_import_path(agent_type: str) -> str:
     if agent_type == "codex":
         return "nasde_toolkit.agents.configurable_codex:ConfigurableCodex"
+    if agent_type == "gemini":
+        return "nasde_toolkit.agents.configurable_gemini:ConfigurableGemini"
     return "nasde_toolkit.agents.configurable_claude:ConfigurableClaude"
 
 
 def _is_codex_agent(agent_import_path: str | None) -> bool:
     return bool(agent_import_path and "codex" in agent_import_path.lower())
+
+
+def _is_gemini_agent(agent_import_path: str | None) -> bool:
+    return bool(agent_import_path and "gemini" in agent_import_path.lower())
 
 
 def _read_agent_import_path(harbor_config_path: Path) -> str | None:

--- a/src/nasde_toolkit/scaffold/__init__.py
+++ b/src/nasde_toolkit/scaffold/__init__.py
@@ -88,6 +88,10 @@ VARIANT_CLAUDE_MD_TEMPLATE = """\
 3. Write tests that match the style of existing test files.
 """
 
+VARIANT_TOML_TEMPLATE = """\
+agent = "claude"
+"""
+
 GITIGNORE_TEMPLATE = """\
 jobs/
 """
@@ -107,6 +111,7 @@ def create_project(project_dir: Path, name: str) -> None:
     variants_dir.mkdir(parents=True, exist_ok=True)
     jobs_dir.mkdir(parents=True, exist_ok=True)
 
+    _write_if_missing(variants_dir / "variant.toml", VARIANT_TOML_TEMPLATE)
     _write_if_missing(variants_dir / "CLAUDE.md", VARIANT_CLAUDE_MD_TEMPLATE)
 
     example_task_dir = tasks_dir / "example-task"
@@ -139,6 +144,7 @@ def create_project(project_dir: Path, name: str) -> None:
     console.print("  nasde.toml")
     console.print("  assessment_dimensions.json")
     console.print("  tasks/example-task/")
+    console.print("  variants/vanilla/variant.toml")
     console.print("  variants/vanilla/CLAUDE.md")
 
 

--- a/tests/test_configurable_gemini.py
+++ b/tests/test_configurable_gemini.py
@@ -55,7 +55,7 @@ def test_setup_calls_dns_fix_then_upload_then_parent() -> None:
     cmd = dns_call.kwargs.get("command", dns_call.args[0] if dns_call.args else "")
     assert "generativelanguage.googleapis.com" in cmd
     mock_parent_setup.assert_awaited_once_with(env)
-    assert env.upload_file.await_count == 1
+    assert env.upload_file.await_count >= 1
 
 
 def test_upload_raises_on_missing_source() -> None:
@@ -156,11 +156,12 @@ def test_setup_injects_oauth_when_no_api_key() -> None:
     ):
         asyncio.run(agent.setup(env))
 
-    exec_commands = [call.kwargs.get("command", call.args[0] if call.args else "") for call in env.exec.call_args_list]
-    has_oauth_write = any("oauth_creds.json" in cmd for cmd in exec_commands)
-    has_settings_write = any("oauth-personal" in cmd for cmd in exec_commands)
-    assert has_oauth_write
-    assert has_settings_write
+    upload_targets = [
+        call.kwargs.get("target_path", call.args[1] if len(call.args) > 1 else "")
+        for call in env.upload_file.call_args_list
+    ]
+    assert any("oauth_creds.json" in t for t in upload_targets)
+    assert any("settings.json" in t for t in upload_targets)
 
 
 def test_setup_skips_oauth_when_api_key_set() -> None:
@@ -184,6 +185,8 @@ def test_setup_skips_oauth_when_api_key_set() -> None:
     ):
         asyncio.run(agent.setup(env))
 
-    exec_commands = [call.kwargs.get("command", call.args[0] if call.args else "") for call in env.exec.call_args_list]
-    has_oauth_write = any("oauth_creds.json" in cmd for cmd in exec_commands)
-    assert not has_oauth_write
+    upload_targets = [
+        call.kwargs.get("target_path", call.args[1] if len(call.args) > 1 else "")
+        for call in env.upload_file.call_args_list
+    ]
+    assert not any("oauth_creds.json" in t for t in upload_targets)

--- a/tests/test_configurable_gemini.py
+++ b/tests/test_configurable_gemini.py
@@ -135,73 +135,55 @@ def test_read_gemini_oauth_creds_returns_none_for_empty_json(tmp_path: Path) -> 
     assert result is None
 
 
-def test_create_run_agent_commands_injects_oauth_when_no_api_key() -> None:
-    from harbor.agents.installed.base import ExecInput
-
+def test_setup_injects_oauth_when_no_api_key() -> None:
     agent = ConfigurableGemini(
+        sandbox_files={},
         logs_dir=Path("/tmp/logs"),
         model_name="google/gemini-3-flash-preview",
     )
 
-    parent_commands = [
-        ExecInput(
-            command=". ~/.nvm/nvm.sh; gemini --yolo --model=gemini-3-flash-preview --prompt='do stuff'",
-            env={},
-        ),
-    ]
-
+    env = AsyncMock()
+    env.exec.return_value = MagicMock(return_code=0, stderr="")
     oauth_json = json.dumps(_SAMPLE_OAUTH_CREDS)
 
     with (
         patch.dict("os.environ", {}, clear=True),
-        patch.object(
-            ConfigurableGemini.__bases__[0],
-            "create_run_agent_commands",
-            return_value=parent_commands,
-        ),
+        patch.object(ConfigurableGemini.__bases__[0], "setup", new_callable=AsyncMock),
         patch(
             "nasde_toolkit.agents.configurable_gemini._read_gemini_oauth_creds",
             return_value=oauth_json,
         ),
     ):
-        result = agent.create_run_agent_commands("do stuff")
+        asyncio.run(agent.setup(env))
 
-    assert len(result) == 2
-    assert "gemini-secrets" in result[0].command
-    assert "oauth-personal" in result[0].command
-    assert "_GEMINI_OAUTH_CREDS_JSON" in result[0].env
+    exec_commands = [call.kwargs.get("command", call.args[0] if call.args else "") for call in env.exec.call_args_list]
+    has_oauth_write = any("oauth_creds.json" in cmd for cmd in exec_commands)
+    has_settings_write = any("oauth-personal" in cmd for cmd in exec_commands)
+    assert has_oauth_write
+    assert has_settings_write
 
 
-def test_create_run_agent_commands_prefers_api_key_over_oauth() -> None:
-    from harbor.agents.installed.base import ExecInput
-
+def test_setup_skips_oauth_when_api_key_set() -> None:
     agent = ConfigurableGemini(
+        sandbox_files={},
         logs_dir=Path("/tmp/logs"),
         model_name="google/gemini-3-flash-preview",
     )
 
-    parent_commands = [
-        ExecInput(
-            command=". ~/.nvm/nvm.sh; gemini --yolo --model=gemini-3-flash-preview --prompt='do stuff'",
-            env={"GEMINI_API_KEY": "test-key"},
-        ),
-    ]
-
+    env = AsyncMock()
+    env.exec.return_value = MagicMock(return_code=0, stderr="")
     oauth_json = json.dumps(_SAMPLE_OAUTH_CREDS)
 
     with (
         patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}, clear=True),
-        patch.object(
-            ConfigurableGemini.__bases__[0],
-            "create_run_agent_commands",
-            return_value=parent_commands,
-        ),
+        patch.object(ConfigurableGemini.__bases__[0], "setup", new_callable=AsyncMock),
         patch(
             "nasde_toolkit.agents.configurable_gemini._read_gemini_oauth_creds",
             return_value=oauth_json,
         ),
     ):
-        result = agent.create_run_agent_commands("do stuff")
+        asyncio.run(agent.setup(env))
 
-    assert result[0].env["GEMINI_API_KEY"] == "test-key"
-    assert "_GEMINI_OAUTH_CREDS_JSON" not in result[0].env
+    exec_commands = [call.kwargs.get("command", call.args[0] if call.args else "") for call in env.exec.call_args_list]
+    has_oauth_write = any("oauth_creds.json" in cmd for cmd in exec_commands)
+    assert not has_oauth_write

--- a/tests/test_configurable_gemini.py
+++ b/tests/test_configurable_gemini.py
@@ -166,8 +166,9 @@ def test_create_run_agent_commands_injects_oauth_when_no_api_key() -> None:
     ):
         result = agent.create_run_agent_commands("do stuff")
 
-    assert len(result) == 1
+    assert len(result) == 2
     assert "gemini-secrets" in result[0].command
+    assert "oauth-personal" in result[0].command
     assert "_GEMINI_OAUTH_CREDS_JSON" in result[0].env
 
 

--- a/tests/test_configurable_gemini.py
+++ b/tests/test_configurable_gemini.py
@@ -1,0 +1,206 @@
+"""Tests for ConfigurableGemini agent."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nasde_toolkit.agents.configurable_gemini import (
+    ConfigurableGemini,
+    _expand_skill_targets,
+    _read_gemini_oauth_creds,
+)
+
+
+def test_name_returns_configurable_gemini_cli() -> None:
+    assert ConfigurableGemini.name() == "configurable-gemini-cli"
+
+
+def test_constructor_stores_sandbox_files() -> None:
+    files = {"/app/GEMINI.md": "/tmp/GEMINI.md"}
+    agent = ConfigurableGemini(
+        sandbox_files=files,
+        logs_dir=Path("/tmp/logs"),
+        model_name="google/gemini-3-flash-preview",
+    )
+    assert agent._sandbox_files == files
+
+
+def test_constructor_defaults_to_empty_sandbox_files() -> None:
+    agent = ConfigurableGemini(
+        logs_dir=Path("/tmp/logs"),
+        model_name="google/gemini-3-flash-preview",
+    )
+    assert agent._sandbox_files == {}
+
+
+def test_setup_calls_dns_fix_then_upload_then_parent() -> None:
+    agent = ConfigurableGemini(
+        sandbox_files={"/app/GEMINI.md": __file__},
+        logs_dir=Path("/tmp/logs"),
+        model_name="google/gemini-3-flash-preview",
+    )
+
+    env = AsyncMock()
+    env.exec.return_value = MagicMock(return_code=0, stderr="")
+
+    with patch.object(ConfigurableGemini.__bases__[0], "setup", new_callable=AsyncMock) as mock_parent_setup:
+        asyncio.run(agent.setup(env))
+
+    dns_call = env.exec.call_args_list[0]
+    cmd = dns_call.kwargs.get("command", dns_call.args[0] if dns_call.args else "")
+    assert "generativelanguage.googleapis.com" in cmd
+    mock_parent_setup.assert_awaited_once_with(env)
+    assert env.upload_file.await_count == 1
+
+
+def test_upload_raises_on_missing_source() -> None:
+    agent = ConfigurableGemini(
+        sandbox_files={"/app/GEMINI.md": "/nonexistent/path.md"},
+        logs_dir=Path("/tmp/logs"),
+        model_name="google/gemini-3-flash-preview",
+    )
+
+    env = AsyncMock()
+    env.exec.return_value = MagicMock(return_code=0, stderr="")
+
+    with (
+        patch.object(ConfigurableGemini.__bases__[0], "setup", new_callable=AsyncMock),
+        pytest.raises(FileNotFoundError, match="does not exist"),
+    ):
+        asyncio.run(agent.setup(env))
+
+
+# ---------------------------------------------------------------------------
+# Skill target expansion
+# ---------------------------------------------------------------------------
+
+
+def test_expand_skill_targets_gemini_skills_path() -> None:
+    targets = _expand_skill_targets("/app/.gemini/skills/tactical-ddd/SKILL.md")
+    assert len(targets) == 2
+    assert "/app/.gemini/skills/tactical-ddd/SKILL.md" in targets
+    assert "/root/.gemini/skills/tactical-ddd/SKILL.md" in targets
+
+
+def test_expand_skill_targets_non_skill_path() -> None:
+    targets = _expand_skill_targets("/app/GEMINI.md")
+    assert targets == ["/app/GEMINI.md"]
+
+
+# ---------------------------------------------------------------------------
+# OAuth creds tests
+# ---------------------------------------------------------------------------
+
+_SAMPLE_OAUTH_CREDS = {
+    "access_token": "ya29.test-access-token",
+    "refresh_token": "1//test-refresh-token",
+    "token_type": "Bearer",
+    "expiry_date": 1742900000000,
+}
+
+
+def test_read_gemini_oauth_creds_returns_json(tmp_path: Path) -> None:
+    creds_file = tmp_path / ".gemini" / "oauth_creds.json"
+    creds_file.parent.mkdir()
+    creds_file.write_text(json.dumps(_SAMPLE_OAUTH_CREDS))
+
+    with patch("nasde_toolkit.agents.configurable_gemini.Path.home", return_value=tmp_path):
+        result = _read_gemini_oauth_creds()
+
+    assert result is not None
+    parsed = json.loads(result)
+    assert parsed["access_token"] == "ya29.test-access-token"
+
+
+def test_read_gemini_oauth_creds_returns_none_when_no_file(tmp_path: Path) -> None:
+    with patch("nasde_toolkit.agents.configurable_gemini.Path.home", return_value=tmp_path):
+        result = _read_gemini_oauth_creds()
+
+    assert result is None
+
+
+def test_read_gemini_oauth_creds_returns_none_for_empty_json(tmp_path: Path) -> None:
+    creds_file = tmp_path / ".gemini" / "oauth_creds.json"
+    creds_file.parent.mkdir()
+    creds_file.write_text("{}")
+
+    with patch("nasde_toolkit.agents.configurable_gemini.Path.home", return_value=tmp_path):
+        result = _read_gemini_oauth_creds()
+
+    assert result is None
+
+
+def test_create_run_agent_commands_injects_oauth_when_no_api_key() -> None:
+    from harbor.agents.installed.base import ExecInput
+
+    agent = ConfigurableGemini(
+        logs_dir=Path("/tmp/logs"),
+        model_name="google/gemini-3-flash-preview",
+    )
+
+    parent_commands = [
+        ExecInput(
+            command=". ~/.nvm/nvm.sh; gemini --yolo --model=gemini-3-flash-preview --prompt='do stuff'",
+            env={},
+        ),
+    ]
+
+    oauth_json = json.dumps(_SAMPLE_OAUTH_CREDS)
+
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch.object(
+            ConfigurableGemini.__bases__[0],
+            "create_run_agent_commands",
+            return_value=parent_commands,
+        ),
+        patch(
+            "nasde_toolkit.agents.configurable_gemini._read_gemini_oauth_creds",
+            return_value=oauth_json,
+        ),
+    ):
+        result = agent.create_run_agent_commands("do stuff")
+
+    assert len(result) == 1
+    assert "gemini-secrets" in result[0].command
+    assert "_GEMINI_OAUTH_CREDS_JSON" in result[0].env
+
+
+def test_create_run_agent_commands_prefers_api_key_over_oauth() -> None:
+    from harbor.agents.installed.base import ExecInput
+
+    agent = ConfigurableGemini(
+        logs_dir=Path("/tmp/logs"),
+        model_name="google/gemini-3-flash-preview",
+    )
+
+    parent_commands = [
+        ExecInput(
+            command=". ~/.nvm/nvm.sh; gemini --yolo --model=gemini-3-flash-preview --prompt='do stuff'",
+            env={"GEMINI_API_KEY": "test-key"},
+        ),
+    ]
+
+    oauth_json = json.dumps(_SAMPLE_OAUTH_CREDS)
+
+    with (
+        patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}, clear=True),
+        patch.object(
+            ConfigurableGemini.__bases__[0],
+            "create_run_agent_commands",
+            return_value=parent_commands,
+        ),
+        patch(
+            "nasde_toolkit.agents.configurable_gemini._read_gemini_oauth_creds",
+            return_value=oauth_json,
+        ),
+    ):
+        result = agent.create_run_agent_commands("do stuff")
+
+    assert result[0].env["GEMINI_API_KEY"] == "test-key"
+    assert "_GEMINI_OAUTH_CREDS_JSON" not in result[0].env

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -18,6 +18,7 @@ from nasde_toolkit.runner import (
     _ensure_auth,
     _generate_harbor_config,
     _is_codex_agent,
+    _is_gemini_agent,
     collect_available_variants,
     load_variant_agent_type,
 )
@@ -168,6 +169,11 @@ def test_load_variant_agent_type_codex(tmp_path: Path) -> None:
     assert load_variant_agent_type(tmp_path) == "codex"
 
 
+def test_load_variant_agent_type_gemini(tmp_path: Path) -> None:
+    (tmp_path / "variant.toml").write_text('agent = "gemini"')
+    assert load_variant_agent_type(tmp_path) == "gemini"
+
+
 def test_load_variant_agent_type_missing_file_raises(tmp_path: Path) -> None:
     with pytest.raises(SystemExit):
         load_variant_agent_type(tmp_path)
@@ -204,6 +210,27 @@ def test_is_codex_agent_with_claude_import_path() -> None:
 
 def test_is_codex_agent_with_none() -> None:
     assert not _is_codex_agent(None)
+
+
+# ---------------------------------------------------------------------------
+# _is_gemini_agent
+# ---------------------------------------------------------------------------
+
+
+def test_is_gemini_agent_with_gemini_import_path() -> None:
+    assert _is_gemini_agent("nasde_toolkit.agents.configurable_gemini:ConfigurableGemini")
+
+
+def test_is_gemini_agent_with_harbor_gemini() -> None:
+    assert _is_gemini_agent("harbor.agents.installed.gemini_cli:GeminiCli")
+
+
+def test_is_gemini_agent_with_claude_import_path() -> None:
+    assert not _is_gemini_agent("nasde_toolkit.agents.configurable_claude:ConfigurableClaude")
+
+
+def test_is_gemini_agent_with_none() -> None:
+    assert not _is_gemini_agent(None)
 
 
 # ---------------------------------------------------------------------------
@@ -292,3 +319,86 @@ def test_ensure_auth_codex_missing_raises() -> None:
         mock_home = mock_path_cls.home.return_value
         mock_home.joinpath.return_value.exists.return_value = False
         _ensure_auth(codex_path)
+
+
+# ---------------------------------------------------------------------------
+# _generate_harbor_config — gemini variant
+# ---------------------------------------------------------------------------
+
+
+def test_generate_harbor_config_gemini_variant(tmp_path: Path) -> None:
+    variant_dir = tmp_path / "variants" / "gemini-vanilla"
+    variant_dir.mkdir(parents=True)
+    (variant_dir / "GEMINI.md").write_text("# Gemini")
+    (variant_dir / "variant.toml").write_text('agent = "gemini"')
+
+    _generate_harbor_config(variant_dir, "gemini-vanilla")
+
+    config = json.loads((variant_dir / "harbor_config.json").read_text())
+    assert "configurable_gemini" in config["agents"][0]["import_path"]
+    assert config["agents"][0]["name"] == "gemini-vanilla"
+    assert "/app/GEMINI.md" in config["agents"][0]["kwargs"]["sandbox_files"]
+
+
+def test_generate_harbor_config_gemini_with_skills(tmp_path: Path) -> None:
+    variant_dir = tmp_path / "variants" / "gemini-skilled"
+    variant_dir.mkdir(parents=True)
+    (variant_dir / "GEMINI.md").write_text("# Gemini")
+    (variant_dir / "variant.toml").write_text('agent = "gemini"')
+    skill_dir = variant_dir / "gemini_skills" / "tactical-ddd"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# TDD Skill")
+
+    _generate_harbor_config(variant_dir, "gemini-skilled")
+
+    config = json.loads((variant_dir / "harbor_config.json").read_text())
+    sandbox = config["agents"][0]["kwargs"]["sandbox_files"]
+    assert "/app/.gemini/skills/tactical-ddd/SKILL.md" in sandbox
+
+
+# ---------------------------------------------------------------------------
+# _ensure_auth — gemini provider
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_auth_gemini_with_gemini_api_key() -> None:
+    gemini_path = "nasde_toolkit.agents.configurable_gemini:ConfigurableGemini"
+    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}, clear=True):
+        _ensure_auth(gemini_path)
+
+
+def test_ensure_auth_gemini_with_google_api_key() -> None:
+    gemini_path = "nasde_toolkit.agents.configurable_gemini:ConfigurableGemini"
+    with patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}, clear=True):
+        _ensure_auth(gemini_path)
+
+
+def test_ensure_auth_gemini_with_google_credentials() -> None:
+    gemini_path = "nasde_toolkit.agents.configurable_gemini:ConfigurableGemini"
+    with patch.dict("os.environ", {"GOOGLE_APPLICATION_CREDENTIALS": "/path/to/creds.json"}, clear=True):
+        _ensure_auth(gemini_path)
+
+
+def test_ensure_auth_gemini_with_oauth_file(tmp_path: Path) -> None:
+    gemini_path = "nasde_toolkit.agents.configurable_gemini:ConfigurableGemini"
+    creds_file = tmp_path / ".gemini" / "oauth_creds.json"
+    creds_file.parent.mkdir(parents=True)
+    creds_file.write_text('{"access_token": "test"}')
+
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch("pathlib.Path.home", return_value=tmp_path),
+    ):
+        _ensure_auth(gemini_path)
+
+
+def test_ensure_auth_gemini_missing_raises() -> None:
+    gemini_path = "nasde_toolkit.agents.configurable_gemini:ConfigurableGemini"
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch("nasde_toolkit.runner.Path") as mock_path_cls,
+        pytest.raises(SystemExit),
+    ):
+        mock_home = mock_path_cls.home.return_value
+        mock_home.joinpath.return_value.exists.return_value = False
+        _ensure_auth(gemini_path)


### PR DESCRIPTION
## Summary

- Add `ConfigurableGemini` agent extending Harbor's `GeminiCli` with sandbox file injection and Google OAuth credential forwarding
- Support three auth methods: `GEMINI_API_KEY`, Google Cloud/Vertex AI (`GOOGLE_API_KEY`), and `gemini login` OAuth (`~/.gemini/oauth_creds.json`)
- Add `gemini_skills/` directory convention for Gemini skill snapshots (injected into `/app/.gemini/skills/` and `~/.gemini/skills/`)
- Add 5 Gemini variants across all 3 example benchmarks (`gemini-vanilla` + skill variants) with `google/gemini-3-flash-preview` as default model
- Add `scripts/export_gemini_oauth_token.sh` and `scripts/validate_gemini_auth.sh` for auth management
- Update all documentation: CLAUDE.md, ARCHITECTURE.md, README.md, benchmark creator/runner skills

### Smoke test results

| Metric | Value |
|--------|-------|
| Task | ddd-threshold-discount |
| Variant | gemini-vanilla |
| Model | google/gemini-3-flash-preview |
| Auth | OAuth (gemini login) |
| Reward | 1.0 |
| Assessment | **82/100** (domain_modeling: 20/25, encapsulation: 15/20, architecture_compliance: 20/20, extensibility: 15/15, test_quality: 12/20) |
| Duration | ~17 min (free tier rate limits) |

### Known issue (pre-existing)

Evaluator skips trials with `AgentTimeoutError` even when reward > 0 — tracked separately.

## Test plan

- [x] `uv run ruff check src/ tests/` — passes
- [x] `uv run ruff format --check src/ tests/` — passes  
- [x] `uv run mypy src/nasde_toolkit/` — passes
- [x] `uv run pytest` — 81/81 pass (12 new Gemini agent tests, 8 new runner tests)
- [x] CLI smoke test: `uv run nasde --version`
- [x] End-to-end run: gemini-vanilla on ddd-threshold-discount with OAuth auth — reward 1.0, assessment 82/100
- [ ] Test with `GEMINI_API_KEY` (API key auth)
- [x] Test gemini skill variant (gemini-ntcoding-tactical-ddd)
- [x] Cross-agent comparison run (Claude vs Codex vs Gemini)

🤖 Generated with [Claude Code](https://claude.com/claude-code)