### PR TITLE
fix: restore Opik token usage reporting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,7 +268,7 @@ Final success must `echo 1 > /logs/verifier/reward.txt && exit 0`.
 ## Known issues and workarounds
 
 - **claude-code-sdk 0.0.25**: crashes on `rate_limit_event` — runtime monkeypatch in `evaluator.py`. Remove when SDK handles unknown message types.
-- **opik 1.10.x**: token usage=None for Harbor spans — file patch in `patches/`. Re-apply after `uv sync`.
+- **opik 1.10.x**: token usage=None for Harbor spans — runtime monkeypatch in `runner.py` (`_patch_opik_deferred_metrics`). Defers Step span creation to `__setattr__` because Harbor assigns metrics after `Step.__init__`. See ADR-006. Remove when opik fixes upstream.
 - **Nested Claude Code sessions**: SDK detects `CLAUDECODE` env var. Runner unsets it before assessment eval.
 - **Opik REST API auth**: use `authorization: <OPIK_API_KEY>` header (not `Comet-Api-Key`), plus `Comet-Workspace` header.
 - **Opik verification**: always use Python `urllib.request`, not curl (curl drops the `Comet-Workspace` header).

--- a/docs/adr/006-opik-deferred-metrics-patch.md
+++ b/docs/adr/006-opik-deferred-metrics-patch.md
@@ -1,0 +1,31 @@
+# ADR-006: Runtime monkey-patch for Opik Harbor token usage
+
+**Status:** Accepted
+**Date:** 2026-03-26
+
+## Context
+
+Opik's Harbor integration (`opik.integrations.harbor.opik_tracker._patch_step_class`) patches `Step.__init__` to read `self.metrics` and create Opik spans with `usage` data (token counts). However, Harbor's `ClaudeCode._convert_event_to_step()` creates `Step(...)` without `metrics`, then assigns `step.metrics = metrics` after construction. This means the Opik patch always sees `self.metrics = None`, all spans have `usage=None`, and the Opik backend has nothing to aggregate into the trace's "Total tokens" column.
+
+This bug was originally fixed in the SDLC repo (commit `66c2c11`, 2026-03-09) via a vendor `.patch` file applied to the installed opik package (`evals/eval-platforms/patches/opik_harbor_deferred_metrics.patch`). When the evaluation infrastructure was extracted into nasde-toolkit (SDLC commit `74bfb06`, 2026-03-20), the patch was not ported.
+
+As of opik 1.10.50 (latest), this bug remains unfixed upstream.
+
+## Decision
+
+Apply the fix as a **runtime monkey-patch** in `runner.py` instead of a vendor `.patch` file. The patch is applied immediately after `track_harbor()` and re-patches `Step.__init__` + adds `Step.__setattr__`:
+
+- `__init__`: stashes Opik trace context on the Step instance; emits spans immediately for non-agent steps (which never receive metrics).
+- `__setattr__`: when `metrics` is assigned, creates the Opik span with token usage data at that point.
+
+## Rationale
+
+- **Survives `uv sync`**: vendor `.patch` files must be re-applied after every dependency install. Runtime patches are applied each run automatically.
+- **No external scripts**: the SDLC approach required `apply_opik_patches.sh` — easy to forget after `uv sync`.
+- **Same fix, different delivery**: the logic is identical to the SDLC `.patch` file; only the application mechanism differs.
+- **Follows existing pattern**: `evaluator.py` already uses a runtime monkey-patch for the claude-code-sdk `parse_message` bug.
+
+## Consequences
+
+- The patch must be maintained alongside opik upgrades. If opik changes `_patch_step_class` internals, our re-patch may need adjustment.
+- Remove when: opik upstream fixes the timing issue (check changelog for "harbor" + "metrics" or "deferred" mentions).

--- a/src/nasde_toolkit/runner.py
+++ b/src/nasde_toolkit/runner.py
@@ -403,6 +403,152 @@ def _resolve_jobs_dir(project_dir: Path) -> Path:
 
 
 # ---------------------------------------------------------------------------
+# Opik monkey-patch: deferred Step metrics (ADR-006)
+# ---------------------------------------------------------------------------
+
+
+def _patch_opik_deferred_metrics() -> None:
+    """Fix opik Harbor integration: defer Step span creation until metrics assigned.
+
+    opik's ``_patch_step_class`` reads ``self.metrics`` during ``Step.__init__``,
+    but Harbor assigns metrics *after* construction (``step.metrics = m``).
+    Result: every Opik span has ``usage=None`` and "Total tokens" is empty.
+
+    This re-patches Step so that ``__init__`` only stashes the Opik trace context,
+    and span creation is deferred to ``__setattr__`` when ``metrics`` is set.
+
+    Origin: SDLC repo commit 66c2c11 (2026-03-09).
+    Remove when: opik changelog mentions harbor token/metrics fix.
+    """
+    from typing import Any, Dict, Optional, Tuple
+
+    from harbor.models.trajectories.step import Step
+
+    from opik import datetime_helpers, id_helpers, opik_context
+    from opik.api_objects import opik_client
+
+    if getattr(_patch_opik_deferred_metrics, "_applied", False):
+        return
+
+    def _build_usage_from_metrics(
+        metrics: Any,
+    ) -> Tuple[Optional[Dict[str, Any]], Optional[float]]:
+        if not metrics:
+            return None, None
+        usage: Dict[str, Any] = {}
+        if metrics.prompt_tokens is not None:
+            usage["prompt_tokens"] = metrics.prompt_tokens
+        if metrics.completion_tokens is not None:
+            usage["completion_tokens"] = metrics.completion_tokens
+        if metrics.prompt_tokens and metrics.completion_tokens:
+            usage["total_tokens"] = metrics.prompt_tokens + metrics.completion_tokens
+        if not usage:
+            return None, None
+        total_cost = getattr(metrics, "cost_usd", None)
+        return usage, total_cost
+
+    def _source_to_span_type(source: str) -> str:
+        return "llm" if source == "agent" else "general"
+
+    def _create_span_for_step(step: Step) -> None:
+        trace_data = getattr(step, "_opik_trace_data", None)
+        if trace_data is None:
+            return
+        parent_span_id = getattr(step, "_opik_parent_span_id", None)
+        try:
+            client = opik_client.get_client_cached()
+            project_name = (
+                getattr(trace_data, "project_name", None)
+                or os.environ.get("OPIK_PROJECT_NAME")
+                or "Default Project"
+            )
+
+            input_dict: Dict[str, Any] = {}
+            if step.message:
+                input_dict["message"] = step.message
+            if step.tool_calls:
+                input_dict["tool_calls"] = [
+                    {
+                        "tool_call_id": tc.tool_call_id,
+                        "function_name": tc.function_name,
+                        "arguments": tc.arguments,
+                    }
+                    for tc in step.tool_calls
+                ]
+
+            output_dict: Optional[Dict[str, Any]] = None
+            if step.observation and step.observation.results:
+                output_dict = {
+                    "results": [{"content": r.content} for r in step.observation.results]
+                }
+
+            metadata: Dict[str, Any] = {
+                "source": step.source,
+                "created_from": "harbor",
+            }
+            if step.reasoning_content:
+                metadata["reasoning"] = step.reasoning_content
+
+            usage, total_cost = _build_usage_from_metrics(step.metrics)
+
+            client.span(
+                id=id_helpers.generate_id(),
+                trace_id=trace_data.id,
+                parent_span_id=parent_span_id,
+                name=f"step_{step.step_id}",
+                type=_source_to_span_type(step.source),
+                start_time=datetime_helpers.parse_iso_timestamp(step.timestamp),
+                input=input_dict if input_dict else None,
+                output=output_dict,
+                metadata=metadata,
+                usage=usage,
+                total_cost=total_cost,
+                model=step.model_name if step.source == "agent" else None,
+                tags=["harbor", step.source],
+                project_name=project_name,
+                provider="anthropic" if step.source == "agent" else None,
+            )
+            object.__setattr__(step, "_opik_span_emitted", True)
+        except Exception:
+            pass
+
+    original_init = Step.__init__
+
+    def patched_init(self: Step, *args: Any, **kwargs: Any) -> None:
+        original_init(self, *args, **kwargs)
+
+        trace_data = opik_context.get_current_trace_data()
+        if trace_data is None:
+            return
+
+        parent_span = opik_context.get_current_span_data()
+        parent_span_id = parent_span.id if parent_span else None
+
+        object.__setattr__(self, "_opik_trace_data", trace_data)
+        object.__setattr__(self, "_opik_parent_span_id", parent_span_id)
+        object.__setattr__(self, "_opik_span_emitted", False)
+
+        if self.metrics:
+            _create_span_for_step(self)
+        elif self.source != "agent":
+            _create_span_for_step(self)
+
+    original_setattr = Step.__setattr__
+
+    def patched_setattr(self: Step, name: str, value: Any) -> None:
+        original_setattr(self, name, value)
+        if name != "metrics" or value is None:
+            return
+        if getattr(self, "_opik_span_emitted", False):
+            return
+        _create_span_for_step(self)
+
+    Step.__init__ = patched_init  # type: ignore[assignment]
+    Step.__setattr__ = patched_setattr  # type: ignore[assignment]
+    _patch_opik_deferred_metrics._applied = True  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
 # Job execution
 # ---------------------------------------------------------------------------
 
@@ -467,6 +613,7 @@ async def _run_job(
 
         console.print("Opik tracking enabled\n")
         track_harbor(project_name=project_name)
+        _patch_opik_deferred_metrics()
 
     saved_cwd = Path.cwd()
     if project_dir:

--- a/src/nasde_toolkit/runner.py
+++ b/src/nasde_toolkit/runner.py
@@ -459,9 +459,7 @@ def _patch_opik_deferred_metrics() -> None:
         try:
             client = opik_client.get_client_cached()
             span_project_name: str = (
-                getattr(trace_data, "project_name", None)
-                or os.environ.get("OPIK_PROJECT_NAME")
-                or "Default Project"
+                getattr(trace_data, "project_name", None) or os.environ.get("OPIK_PROJECT_NAME") or "Default Project"
             )
 
             input_dict: dict[str, Any] = {}
@@ -479,9 +477,7 @@ def _patch_opik_deferred_metrics() -> None:
 
             output_dict: dict[str, Any] | None = None
             if step.observation and step.observation.results:
-                output_dict = {
-                    "results": [{"content": r.content} for r in step.observation.results]
-                }
+                output_dict = {"results": [{"content": r.content} for r in step.observation.results]}
 
             metadata: dict[str, Any] = {
                 "source": step.source,

--- a/src/nasde_toolkit/runner.py
+++ b/src/nasde_toolkit/runner.py
@@ -420,10 +420,9 @@ def _patch_opik_deferred_metrics() -> None:
     Origin: SDLC repo commit 66c2c11 (2026-03-09).
     Remove when: opik changelog mentions harbor token/metrics fix.
     """
-    from typing import Any, Dict, Optional, Tuple
+    from typing import Any
 
     from harbor.models.trajectories.step import Step
-
     from opik import datetime_helpers, id_helpers, opik_context
     from opik.api_objects import opik_client
 
@@ -432,10 +431,10 @@ def _patch_opik_deferred_metrics() -> None:
 
     def _build_usage_from_metrics(
         metrics: Any,
-    ) -> Tuple[Optional[Dict[str, Any]], Optional[float]]:
+    ) -> tuple[dict[str, Any] | None, float | None]:
         if not metrics:
             return None, None
-        usage: Dict[str, Any] = {}
+        usage: dict[str, Any] = {}
         if metrics.prompt_tokens is not None:
             usage["prompt_tokens"] = metrics.prompt_tokens
         if metrics.completion_tokens is not None:
@@ -444,26 +443,28 @@ def _patch_opik_deferred_metrics() -> None:
             usage["total_tokens"] = metrics.prompt_tokens + metrics.completion_tokens
         if not usage:
             return None, None
-        total_cost = getattr(metrics, "cost_usd", None)
+        total_cost: float | None = getattr(metrics, "cost_usd", None)
         return usage, total_cost
 
-    def _source_to_span_type(source: str) -> str:
+    from opik.types import SpanType
+
+    def _source_to_span_type(source: str) -> SpanType:
         return "llm" if source == "agent" else "general"
 
     def _create_span_for_step(step: Step) -> None:
         trace_data = getattr(step, "_opik_trace_data", None)
         if trace_data is None:
             return
-        parent_span_id = getattr(step, "_opik_parent_span_id", None)
+        parent_span_id: str | None = getattr(step, "_opik_parent_span_id", None)
         try:
             client = opik_client.get_client_cached()
-            project_name = (
+            span_project_name: str = (
                 getattr(trace_data, "project_name", None)
                 or os.environ.get("OPIK_PROJECT_NAME")
                 or "Default Project"
             )
 
-            input_dict: Dict[str, Any] = {}
+            input_dict: dict[str, Any] = {}
             if step.message:
                 input_dict["message"] = step.message
             if step.tool_calls:
@@ -476,13 +477,13 @@ def _patch_opik_deferred_metrics() -> None:
                     for tc in step.tool_calls
                 ]
 
-            output_dict: Optional[Dict[str, Any]] = None
+            output_dict: dict[str, Any] | None = None
             if step.observation and step.observation.results:
                 output_dict = {
                     "results": [{"content": r.content} for r in step.observation.results]
                 }
 
-            metadata: Dict[str, Any] = {
+            metadata: dict[str, Any] = {
                 "source": step.source,
                 "created_from": "harbor",
             }
@@ -505,7 +506,7 @@ def _patch_opik_deferred_metrics() -> None:
                 total_cost=total_cost,
                 model=step.model_name if step.source == "agent" else None,
                 tags=["harbor", step.source],
-                project_name=project_name,
+                project_name=span_project_name,
                 provider="anthropic" if step.source == "agent" else None,
             )
             object.__setattr__(step, "_opik_span_emitted", True)
@@ -528,9 +529,7 @@ def _patch_opik_deferred_metrics() -> None:
         object.__setattr__(self, "_opik_parent_span_id", parent_span_id)
         object.__setattr__(self, "_opik_span_emitted", False)
 
-        if self.metrics:
-            _create_span_for_step(self)
-        elif self.source != "agent":
+        if self.metrics or self.source != "agent":
             _create_span_for_step(self)
 
     original_setattr = Step.__setattr__


### PR DESCRIPTION
## Summary

- Port deferred-metrics monkey-patch from SDLC repo (commit `66c2c11`) lost during nasde-toolkit migration
- Harbor assigns `step.metrics` after `Step.__init__`, but Opik reads during `__init__` → all spans have `usage=None` → "Total tokens" empty in Opik UI
- Runtime monkey-patch in `runner.py` defers span creation to `Step.__setattr__` when metrics are assigned

## Changes

- `src/nasde_toolkit/runner.py` — `_patch_opik_deferred_metrics()` called after `track_harbor()`
- `docs/adr/006-opik-deferred-metrics-patch.md` — decision record
- `CLAUDE.md` — updated known issues (removed stale `patches/` reference)

## Test plan

- [x] `uv run pytest` — 57 tests pass
- [ ] Run benchmark with `--with-opik`, verify "Total tokens" populated in Opik UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)