### PR TITLE
feat: add ASCII art banner with Noesis brand colors

### DIFF
--- a/src/nasde_toolkit/banner.py
+++ b/src/nasde_toolkit/banner.py
@@ -1,0 +1,82 @@
+"""ASCII art banner for nasde CLI with Noesis brand colors."""
+
+from __future__ import annotations
+
+from rich.console import Console
+from rich.text import Text
+
+from nasde_toolkit import __version__
+
+GREEN = "#1B5E20"
+GREEN_LIGHT = "#2E7D32"
+BLUE = "#1565C0"
+BLUE_LIGHT = "#1E88E5"
+ACCENT = "#4CAF50"
+
+_INDENT = "  "
+_LOGO_LINES = [
+    f"{_INDENT}                         __",
+    f"{_INDENT}   ____  ____ _________ / /__",
+    f"{_INDENT}  / __ \\/ __ `/ ___/ __  / _ \\",
+    f"{_INDENT} / / / / /_/ (__  ) /_/ /  __/",
+    f"{_INDENT}/_/ /_/\\__,_/____/\\__,_/\\___/",
+]
+
+_LINE_STYLES: list[list[tuple[str, str]]] = [
+    [(GREEN, "full")],
+    [(GREEN, "full")],
+    [(GREEN_LIGHT, "full")],
+    [(BLUE, "full")],
+    [(BLUE_LIGHT, "full")],
+]
+
+
+def _render_logo() -> Text:
+    text = Text()
+    for i, line in enumerate(_LOGO_LINES):
+        color = _LINE_STYLES[i][0][0]
+        text.append(line, style=f"bold {color}")
+        if i < len(_LOGO_LINES) - 1:
+            text.append("\n")
+    return text
+
+
+def _render_tagline() -> Text:
+    text = Text()
+    text.append(f"{_INDENT}Noesis ", style=f"bold {GREEN}")
+    text.append("Agentic Software Development Evals", style=f"{BLUE_LIGHT}")
+    return text
+
+
+def _render_version_line() -> Text:
+    text = Text()
+    text.append(f"{_INDENT}v{__version__}", style=f"bold {ACCENT}")
+    return text
+
+
+_banner_suppressed = False
+
+
+def suppress_banner() -> None:
+    global _banner_suppressed  # noqa: PLW0603
+    _banner_suppressed = True
+
+
+def is_banner_suppressed() -> bool:
+    if _banner_suppressed:
+        return True
+    import os
+
+    return os.environ.get("NASDE_NO_BANNER", "").strip() not in ("", "0", "false")
+
+
+def print_banner(console: Console | None = None) -> None:
+    if is_banner_suppressed():
+        return
+    c = console or Console()
+    c.print()
+    c.print(_render_logo())
+    c.print()
+    c.print(_render_tagline())
+    c.print(_render_version_line())
+    c.print()

--- a/src/nasde_toolkit/cli.py
+++ b/src/nasde_toolkit/cli.py
@@ -10,32 +10,66 @@ import asyncio
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import click
 import typer
 from rich.console import Console
 from rich.panel import Panel
-
-from nasde_toolkit import __version__
+from typer.core import TyperGroup
 
 if TYPE_CHECKING:
     from nasde_toolkit.config import ProjectConfig
 
+console = Console()
+
+
+class _BannerGroup(TyperGroup):
+    def format_help(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        from nasde_toolkit.banner import print_banner
+
+        print_banner(console)
+        super().format_help(ctx, formatter)
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        cmd = super().get_command(ctx, cmd_name)
+        if cmd is not None:
+            original_format_help = cmd.format_help
+
+            def patched_format_help(ctx: click.Context, formatter: click.HelpFormatter) -> None:
+                from nasde_toolkit.banner import print_banner
+
+                print_banner(console)
+                original_format_help(ctx, formatter)
+
+            cmd.format_help = patched_format_help  # type: ignore[assignment]
+        return cmd
+
+
 app = typer.Typer(
     name="nasde",
     help="Noesis Agentic Software Development Evals Toolkit",
-    no_args_is_help=True,
     rich_markup_mode="rich",
+    cls=_BannerGroup,
 )
-console = Console()
 
 
 def _version_callback(value: bool) -> None:
     if value:
-        console.print(f"nasde [bold]{__version__}[/bold]")
+        from nasde_toolkit.banner import print_banner
+
+        print_banner(console)
         raise typer.Exit()
 
 
-@app.callback()
+def _no_banner_callback(value: bool) -> None:
+    if value:
+        from nasde_toolkit.banner import suppress_banner
+
+        suppress_banner()
+
+
+@app.callback(invoke_without_command=True)
 def main(
+    ctx: typer.Context,
     version: bool = typer.Option(
         False,
         "--version",
@@ -44,8 +78,18 @@ def main(
         callback=_version_callback,
         is_eager=True,
     ),
+    no_banner: bool = typer.Option(
+        False,
+        "--no-banner",
+        help="Suppress ASCII banner. Also: NASDE_NO_BANNER=1.",
+        callback=_no_banner_callback,
+        is_eager=True,
+    ),
 ) -> None:
     """Noesis Agentic Software Development Evals Toolkit."""
+    if ctx.invoked_subcommand is None:
+        console.print(ctx.get_help())
+        raise typer.Exit()
 
 
 @app.command()
@@ -62,8 +106,10 @@ def init(
     ),
 ) -> None:
     """Scaffold a new evaluation project."""
+    from nasde_toolkit.banner import print_banner
     from nasde_toolkit.scaffold import create_project
 
+    print_banner(console)
     project_name = name or project_dir.resolve().name
     create_project(project_dir.resolve(), project_name)
 
@@ -247,6 +293,9 @@ def eval_command(
 
     config = load_project_config(project_dir.resolve())
 
+    from nasde_toolkit.banner import print_banner
+
+    print_banner(console)
     console.print(
         Panel(
             f"[bold]Assessment Evaluation[/bold]\nJob: {job_dir}\nOpik: {'enabled' if with_opik else 'disabled'}",
@@ -306,6 +355,10 @@ def _print_run_header(
     attempts: int = 1,
     agent_type: str = "claude",
 ) -> None:
+    from nasde_toolkit.banner import print_banner
+
+    print_banner(console)
+
     tasks_str = ", ".join(tasks_filter) if tasks_filter else "all"
     eval_str = "enabled" if with_eval else "[yellow]disabled[/yellow]"
     env_str = harbor_env or "docker"
@@ -336,6 +389,10 @@ def _confirm_multi_variant_run(
     attempts: int,
 ) -> None:
     from rich.table import Table
+
+    from nasde_toolkit.banner import print_banner
+
+    print_banner(console)
 
     task_names = [t.name for t in config.tasks]
     if tasks_filter:


### PR DESCRIPTION
## Summary
- Add colorful ASCII art banner (`nasde` in figlet style) with Noesis brand gradient (bottle green → blue) using Rich styling
- Banner displays on: CLI startup, `--help` (including subcommand help), `--version`, `run`, `eval`, `init`
- Suppressible via `--no-banner` CLI flag or `NASDE_NO_BANNER=1` env var for CI

## Test plan
- [x] `uv run nasde` — banner + help
- [x] `uv run nasde --version` — banner only
- [x] `uv run nasde --help` — banner + help
- [x] `uv run nasde run --help` — banner + subcommand help
- [x] `uv run nasde --no-banner --help` — no banner
- [x] `NASDE_NO_BANNER=1 uv run nasde` — no banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)