### PR TITLE
fix: forward eval_config from nasde eval command

### DIFF
--- a/src/nasde_toolkit/cli.py
+++ b/src/nasde_toolkit/cli.py
@@ -310,6 +310,7 @@ def eval_command(
             project_name=config.reporting.project_name,
             with_opik=with_opik,
             max_concurrent=max_concurrent_eval,
+            eval_config=config.evaluation,
         )
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,3 +89,25 @@ def test_all_variants_continues_on_failure(mock_run: AsyncMock, benchmark_projec
     assert mock_run.await_count == 2
     assert "FAILED" in result.output
     assert "OK" in result.output
+
+
+@patch("nasde_toolkit.evaluator.evaluate_job", new_callable=AsyncMock)
+def test_eval_command_forwards_evaluation_config(
+    mock_evaluate_job: AsyncMock, tmp_path: Path
+) -> None:
+    (tmp_path / "nasde.toml").write_text(
+        '[project]\nname = "test"\n'
+        '[defaults]\nvariant = "vanilla"\n'
+        "[evaluation]\ninclude_trajectory = true\n"
+    )
+    job_dir = tmp_path / "jobs" / "job1"
+    job_dir.mkdir(parents=True)
+
+    result = runner.invoke(
+        app,
+        ["eval", str(job_dir), "-C", str(tmp_path)],
+    )
+    assert result.exit_code == 0, result.output
+    assert mock_evaluate_job.await_count == 1
+    eval_config = mock_evaluate_job.call_args.kwargs["eval_config"]
+    assert eval_config.include_trajectory is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,13 +92,9 @@ def test_all_variants_continues_on_failure(mock_run: AsyncMock, benchmark_projec
 
 
 @patch("nasde_toolkit.evaluator.evaluate_job", new_callable=AsyncMock)
-def test_eval_command_forwards_evaluation_config(
-    mock_evaluate_job: AsyncMock, tmp_path: Path
-) -> None:
+def test_eval_command_forwards_evaluation_config(mock_evaluate_job: AsyncMock, tmp_path: Path) -> None:
     (tmp_path / "nasde.toml").write_text(
-        '[project]\nname = "test"\n'
-        '[defaults]\nvariant = "vanilla"\n'
-        "[evaluation]\ninclude_trajectory = true\n"
+        '[project]\nname = "test"\n[defaults]\nvariant = "vanilla"\n[evaluation]\ninclude_trajectory = true\n'
     )
     job_dir = tmp_path / "jobs" / "job1"
     job_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- `nasde eval <job_dir>` was calling `evaluate_job()` without `eval_config`, so it fell back to `EvaluationConfig()` defaults (including `include_trajectory=False`).
- Post-hoc re-evaluation silently lost trajectory-aware scoring — the LLM judge reported "No ATIF trajectory file is available" and penalized scores (e.g. 15/25 on diagnostic_path_efficiency).
- The `nasde run` path already forwarded `config.evaluation` correctly; this aligns the CLI `eval` command to match.

## Test plan
- [x] Added regression test in `tests/test_cli.py` — invokes `nasde eval` and asserts `include_trajectory=True` from `nasde.toml` reaches `evaluate_job`.
- [x] Full test suite: 92 passed.
- [x] Manually verified in a separate session — re-evaluation of existing trials now reads trajectory.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)