### PR TITLE
feat: replace Claude Code SDK with subprocess evaluator backends (Claude + Codex)

### DIFF
--- a/.claude/skills/nasde-benchmark-runner/SKILL.md
+++ b/.claude/skills/nasde-benchmark-runner/SKILL.md
@@ -25,7 +25,7 @@ Before running any benchmark, set up authentication tokens. Both are needed for 
 source scripts/export_oauth_token.sh
 ```
 
-This extracts `CLAUDE_CODE_OAUTH_TOKEN` from macOS Keychain (written by `claude` CLI login). Required for both Claude agent runs AND assessment evaluation (which uses Claude Code SDK).
+This extracts `CLAUDE_CODE_OAUTH_TOKEN` from macOS Keychain (written by `claude` CLI login). Required for both Claude agent runs AND assessment evaluation (which spawns the `claude` CLI as a subprocess when `[evaluation] backend = "claude"`).
 
 Alternatively, set `ANTHROPIC_API_KEY` for API billing.
 

--- a/.claude/skills/nasde-dev/SKILL.md
+++ b/.claude/skills/nasde-dev/SKILL.md
@@ -5,7 +5,7 @@ description: |
   - Making changes to nasde-toolkit source code (CLI, runner, evaluator, config, agents)
   - Refactoring or adding features to the toolkit
   - Fixing bugs in the evaluation pipeline
-  - Updating dependencies or integration points (Harbor, Opik, Claude Code SDK)
+  - Updating dependencies or integration points (Harbor, Opik, `claude` / `codex` CLI subprocess backends)
   This skill defines the verification protocol that must be followed after any significant change.
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 NASDE evaluates AI coding agents (e.g. Claude Code, OpenAI Codex, Gemini CLI) on programming tasks. It uses **Harbor** as the execution engine running agents in isolated sandbox environments and **Opik** as the observability platform for tracking results.
 
-Key design: evaluation is **two-stage** — Harbor assesses functional correctness (tests pass/fail), then a separate reviewer agent (Claude Code SDK) assesses architectural quality of the generated code.
+Key design: evaluation is **two-stage** — Harbor assesses functional correctness (tests pass/fail), then a separate reviewer agent (the `claude` or `codex` CLI, spawned as a subprocess) assesses architectural quality of the generated code.
 
 ---
 
@@ -33,7 +33,7 @@ flowchart TB
 
     subgraph ASSESSMENT ["3. Assessment evaluation (host machine, always local)"]
         ARTIFACTS -->|"Harbor done,\nsandboxes torn down"| EVAL["evaluator.evaluate_job()"]
-        EVAL --> SDK["Claude Code SDK\n(local subprocess, opus)\ntools: Read/Glob/Grep + MCP\ncwd = artifacts/workspace/\n+ optional skills & system prompt"]
+        EVAL --> SDK["Pluggable backend:\nClaudeSubprocessBackend ('claude -p')\nor CodexSubprocessBackend ('codex exec')\n(local subprocess, opus by default)\ntools: Read/Glob/Grep + MCP\ncwd = artifacts/workspace/\n+ optional skills & system prompt"]
         SDK --> SCORE["Score across N dimensions\n0-25 pts each"]
         SCORE --> JSON_OUT["assessment_eval.json"]
         SCORE --> OPIK_FB["Opik feedback scores\narch_*, reward, duration"]
@@ -159,9 +159,9 @@ flowchart TB
         INSTRUCTION["instruction.md\n(original task prompt)"]
     end
 
-    subgraph Evaluator["Claude Code SDK as evaluator"]
+    subgraph Evaluator["CLI subprocess as evaluator (pluggable backend)"]
         PROMPT["Composite prompt:\ninstruction + rubric +\ndimension constraints"]
-        SDK_RUN["query() with configurable:\nmodel (default: opus)\ntools (default: Read/Glob/Grep)\nMCP servers (optional)\nskills (optional)\nsystem prompt (optional)\nmax_turns (default: 30)"]
+        SDK_RUN["Backend subprocess call:\n  claude -p --output-format json (default)\n  codex exec --json --quiet --full-auto\nConfigurable:\nmodel (default: opus for claude)\ntools (default: Read/Glob/Grep)\nMCP servers (optional)\nskills (optional, via --add-dir + cwd)\nsystem prompt (optional)\nmax_turns (default: 30)"]
         PARSE["Parse JSON from\nlast json code block"]
     end
 
@@ -190,6 +190,7 @@ The evaluator agent is configurable via `[evaluation]` in `nasde.toml`. All opti
 
 | Setting | Default | Purpose |
 |---------|---------|---------|
+| `backend` | `claude` | Subprocess backend: `claude` (`ClaudeSubprocessBackend`) or `codex` (`CodexSubprocessBackend`) |
 | `model` | `claude-opus-4-6` | Evaluator model (Opus recommended for review quality) |
 | `dimensions_file` | `assessment_dimensions.json` | Path to scoring dimensions |
 | `max_turns` | `30` | Max conversation turns for evaluator |
@@ -199,11 +200,16 @@ The evaluator agent is configurable via `[evaluation]` in `nasde.toml`. All opti
 | `append_system_prompt` | — | Extra text appended to evaluator's system prompt |
 | `include_trajectory` | `false` | Include ATIF trajectory data in evaluation (opt-in) |
 
-When `include_trajectory` is set to `true`, the evaluator prompt includes a reference to the agent's ATIF trajectory file (`agent/trajectory.json`), and the trial directory is added to `add_dirs` so the evaluator can read it. This enables assessment dimensions that evaluate the agent's process (tool usage, efficiency, decision-making) alongside the final output. The trajectory file is not preprocessed — the evaluator reads it directly via the Read tool.
+Backends are pluggable via the `EvaluatorBackend` Protocol in `src/nasde_toolkit/evaluator_backends/protocol.py`. Both current backends spawn a CLI subprocess — not a Python SDK call — so the evaluator inherits the user's existing CLI authentication (OAuth subscription or API key). This avoids Anthropic's SDK-billing restrictions on subscription accounts: running `claude -p` under your shell is billed the same as interactive use.
 
-When `skills_dir` is set, the evaluator runs in a temporary workspace with skills installed. Trial artifacts are made accessible via `add_dirs`, and the prompt references the artifact path explicitly.
+- `ClaudeSubprocessBackend` invokes `claude -p --output-format json --model <model> --allowed-tools ... [--append-system-prompt ...] [--mcp-config ...] [--add-dir ...]`. The `--bare` flag is deliberately omitted so the CLI reads OAuth tokens from the keychain and auto-discovers skills.
+- `CodexSubprocessBackend` invokes `codex exec --json --quiet --full-auto --model <model> [--sandbox ...]` and parses the JSONL event stream emitted to stdout.
 
-When `mcp_config` is set, MCP servers are loaded from the JSON file and passed to the Claude Code SDK. MCP tool names follow the `mcp__<server>__<tool>` convention and must be included in `allowed_tools` if that field is overridden.
+When `include_trajectory` is set to `true`, the evaluator prompt includes a reference to the agent's ATIF trajectory file (`agent/trajectory.json`), and the trial directory is added to the backend's `--add-dir` set so the evaluator can read it. This enables assessment dimensions that evaluate the agent's process (tool usage, efficiency, decision-making) alongside the final output. The trajectory file is not preprocessed — the evaluator reads it directly via the Read tool.
+
+When `skills_dir` is set, the `ClaudeSubprocessBackend` stages a temp-dir workspace with the skills copied under `.claude/skills/`, runs `claude` with `cwd` pointing there, and passes the artifact path via `--add-dir` so Claude's native skill auto-discovery picks up the skills.
+
+When `mcp_config` is set, its path is passed through to the backend CLI (`--mcp-config` for Claude). MCP tool names follow the `mcp__<server>__<tool>` convention and must be included in `allowed_tools` if that field is overridden.
 
 ---
 
@@ -361,7 +367,11 @@ src/nasde_toolkit/
   cli.py                   # Typer CLI (init, run, eval + harbor/opik pass-through)
   config.py                # nasde.toml + task.json parsing into dataclasses
   runner.py                # Harbor Python API — variant resolution, config merging, Job execution
-  evaluator.py             # Post-hoc assessment via Claude Code SDK
+  evaluator.py             # Post-hoc assessment — builds the prompt, delegates to a pluggable subprocess backend
+  evaluator_backends/
+    protocol.py            # EvaluatorBackend Protocol + factory
+    claude_subprocess.py   # `claude -p --output-format json` backend (default)
+    codex_subprocess.py    # `codex exec --json --quiet --full-auto` backend
   docker.py                # Docker environment helpers
   scaffold/                # Project scaffolding templates
   agents/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,12 @@ src/nasde_toolkit/
   cli.py                   # Typer CLI (init, run, eval + harbor/opik pass-through)
   config.py                # nasde.toml + task.json parsing into dataclasses
   runner.py                # Harbor Python API — variant resolution, config merging, Job execution
-  evaluator.py             # Post-hoc assessment via Claude Code SDK
+  evaluator.py             # Post-hoc assessment via pluggable CLI subprocess backends
+  evaluator_backends/
+    __init__.py
+    protocol.py            # EvaluatorBackend Protocol
+    claude_subprocess.py   # `claude -p` subprocess backend (default)
+    codex_subprocess.py    # `codex exec` subprocess backend
   docker.py                # Docker environment helpers
   scaffold/
     __init__.py            # Project scaffolding templates and file creation
@@ -56,11 +61,11 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the full system architecture with dia
 - **CLI framework**: Typer with Rich markup mode. The `app` object in `cli.py` is the entry point registered in `pyproject.toml` as `nasde`.
 - **Configuration**: Two-layer config — `nasde.toml` for project-level settings, `task.json` per task. Both parsed into `@dataclass` models in `config.py`. Task discovery walks `tasks/` (or `.nasde/tasks/`) automatically.
 - **Benchmark runner**: Uses Harbor Python API (`Job`, `JobConfig`) directly instead of subprocess. The runner merges variant config with task registry into a dict, passes it to `JobConfig.model_validate()`, then runs `await job.run()`. Opik tracking via `track_harbor()` (monkey-patches Harbor at runtime).
-- **Evaluator**: Uses Claude Code SDK async API to run a Claude agent that reads trial artifacts and scores them against assessment criteria. Configurable via `[evaluation]` in `nasde.toml` — model, tools, MCP servers, skills, system prompt, and trajectory inclusion can all be customized. When `include_trajectory = true`, the evaluator also has access to the agent's ATIF trajectory (`agent/trajectory.json`), enabling assessment dimensions that evaluate the agent's process alongside its output. Default model is `claude-opus-4-6` (best available for review quality). Monkeypatches SDK's `parse_message` to handle unknown message types (remove when SDK fixes this). Results written to `assessment_eval.json` per trial and optionally uploaded to Opik.
+- **Evaluator**: Subprocess-based assessment evaluation with pluggable backends. The evaluator spawns a CLI agent (`claude -p` or `codex exec`) as a subprocess to read trial artifacts and score them against assessment criteria. Backend selection via `[evaluation] backend` in `nasde.toml` (`"claude"` default, `"codex"` available). Claude backend uses `--output-format json` (without `--bare` — preserves OAuth/keychain auth for subscription billing and skills auto-discovery). Codex backend uses `--json --quiet --full-auto` for JSONL event streaming. Both backends respect the user's existing CLI authentication (OAuth subscription or API key) — no Agent SDK required, which avoids Anthropic's SDK-billing restrictions on subscription accounts. Configurable via `[evaluation]` in `nasde.toml` — backend, model, tools, MCP servers, skills, system prompt, and trajectory inclusion can all be customized. When `include_trajectory = true`, the evaluator also has access to the agent's ATIF trajectory (`agent/trajectory.json`). Default Claude model is `claude-opus-4-6`. Skills dir is mounted via temp-dir + `cwd` with `--add-dir <workspace>` so Claude's auto-discovery picks them up. Results written to `assessment_eval.json` per trial and optionally uploaded to Opik.
 - **Variant system**: Each variant is a directory under `variants/` with a required `variant.toml` declaring the agent type (`agent = "claude"`, `agent = "codex"`, or `agent = "gemini"`). For Claude Code variants, `CLAUDE.md` is injected into `/app/CLAUDE.md`; for Codex variants, `AGENTS.md` is injected into `/app/AGENTS.md`; for Gemini CLI variants, `GEMINI.md` is injected into `/app/GEMINI.md`. An optional `skills/` subdirectory contains Claude skill snapshots — each `skills/<name>/SKILL.md` is injected into `/app/.claude/skills/<name>/SKILL.md`. An optional `agents_skills/` subdirectory contains Codex skill snapshots — all files under `agents_skills/<name>/` are injected into `/app/.agents/skills/<name>/`. An optional `gemini_skills/` subdirectory contains Gemini skill snapshots — all files under `gemini_skills/<name>/` are injected into `/app/.gemini/skills/<name>/`. If no `harbor_config.json` exists, one is auto-generated from `variant.toml`.
 - **Codex ChatGPT OAuth**: When `~/.codex/auth.json` contains `auth_mode: "chatgpt"` and no API key env var is set, `ConfigurableCodex` injects the full OAuth token structure into the sandbox via env var. API key always takes priority over OAuth. Tokens are not extracted back from sandbox after runs. Validate with `source scripts/export_codex_oauth_token.sh`.
 - **Gemini Google OAuth**: When `~/.gemini/oauth_creds.json` exists (created by `gemini login`) and no API key env var is set (`GEMINI_API_KEY`, `GOOGLE_API_KEY`, `GOOGLE_APPLICATION_CREDENTIALS`), `ConfigurableGemini` injects the OAuth credentials into the sandbox via env var. API key always takes priority over OAuth. Validate with `source scripts/export_gemini_oauth_token.sh`.
-- **All dependencies are core**: `harbor`, `opik`, `claude-code-sdk` are in `[project.dependencies]`. No optional extras — `uv tool install .` gives full functionality. Assessment evaluation is on by default (`--without-eval` to skip).
+- **All dependencies are core**: `harbor`, `opik` are in `[project.dependencies]`. The evaluator depends on having `claude` CLI (default) or `codex` CLI installed and authenticated on the host — not bundled. No optional extras — `uv tool install .` gives full functionality. Assessment evaluation is on by default (`--without-eval` to skip).
 - **Versioning**: Derived from git tags via `hatch-vcs` plugin. Tag `v0.1.0` → version `0.1.0`. Commits after a tag produce dev versions like `0.1.1.dev3+gabcdef`. `_version.py` is auto-generated at build time and gitignored. See ADR-007.
 - **Auto-generated Dockerfile**: When a task has no `environment/Dockerfile`, nasde generates one from `source.git` + `[docker]`. For local paths, also generates `docker-compose.yaml` to override the build context. See `docker.py:ensure_task_environment()`.
 - **Pass-through CLI**: `nasde harbor ...` delegates to Harbor's Typer app via `add_typer()`. `nasde opik ...` forwards args to Opik's Click CLI via `ctx.args`.
@@ -152,6 +157,7 @@ base_image = "ubuntu:22.04"
 build_commands = []
 
 [evaluation]
+backend = "claude"                            # "claude" (default) | "codex"
 model = "claude-opus-4-6"
 dimensions_file = "assessment_dimensions.json"
 # max_turns = 30                              # Max evaluator conversation turns
@@ -294,8 +300,7 @@ Final success must `echo 1 > /logs/verifier/reward.txt && exit 0`.
 
 ## Known issues and workarounds
 
-- **claude-code-sdk 0.0.25**: crashes on `rate_limit_event` — runtime monkeypatch in `evaluator.py`. Remove when SDK handles unknown message types.
 - **opik 1.10.x**: token usage=None for Harbor spans — runtime monkeypatch in `runner.py` (`_patch_opik_deferred_metrics`). Defers Step span creation to `__setattr__` because Harbor assigns metrics after `Step.__init__`. See ADR-006. Remove when opik fixes upstream.
-- **Nested Claude Code sessions**: SDK detects `CLAUDECODE` env var. Runner unsets it before assessment eval.
+- **Nested Claude Code sessions**: `claude` CLI detects `CLAUDECODE` env var. Runner unsets it before assessment eval.
 - **Opik REST API auth**: use `authorization: <OPIK_API_KEY>` header (not `Comet-Api-Key`), plus `Comet-Workspace` header.
 - **Opik verification**: always use Python `urllib.request`, not curl (curl drops the `Comet-Workspace` header).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 NASDE is a **wrapper layer** over [Harbor](https://github.com/cased/harbor) (sandboxed agent execution — Docker locally or cloud providers for scaling) and [Opik](https://github.com/comet-ml/opik) (observability & experiment tracking). The backends are swappable — different execution engines or observability platforms can be plugged in.
 
-What NASDE adds on top is the **"nasty" reviewer** — that's where the name comes from. After a coding agent completes a task and passes functional tests, NASDE deploys a separate **reviewer agent** (powered by Claude Code SDK) that freely navigates the produced codebase and scores it across multiple **dimensions** defined by the benchmark author. It checks not just whether the code works, but *how well* it's written according to your custom criteria.
+What NASDE adds on top is the **"nasty" reviewer** — that's where the name comes from. After a coding agent completes a task and passes functional tests, NASDE deploys a separate **reviewer agent** (powered by the `claude` or `codex` CLI as a subprocess, using your existing CLI auth) that freely navigates the produced codebase and scores it across multiple **dimensions** defined by the benchmark author. It checks not just whether the code works, but *how well* it's written according to your custom criteria.
 
 ## Why NASDE?
 
@@ -131,7 +131,7 @@ cd nasde-toolkit
 uv sync
 ```
 
-After installation, only `nasde` appears on PATH. Harbor, Opik, and Claude Code SDK are bundled as core dependencies — no separate installation needed.
+After installation, only `nasde` appears on PATH. Harbor and Opik are bundled as core dependencies — no separate installation needed. The assessment evaluator spawns your already-installed `claude` or `codex` CLI as a subprocess (not bundled) so it reuses whatever authentication you've set up interactively.
 
 Check your installed version with `nasde --version`. Stable releases follow semver tags (e.g. `v0.1.1`); dev installs show versions like `0.1.2.dev3+gabcdef`.
 
@@ -214,6 +214,22 @@ See the [Harbor documentation](https://harborframework.com/docs/cloud) for detai
 
 The reviewer agent (assessment evaluator) is configurable via the `[evaluation]` section in `nasde.toml`. By default it uses `claude-opus-4-6` with read-only tools (`Read`, `Glob`, `Grep`).
 
+### Evaluator backend
+
+By default, nasde uses Claude Code CLI for assessment evaluation. You can switch to Codex:
+
+```toml
+[evaluation]
+backend = "codex"      # "claude" (default) | "codex"
+model = "gpt-5.3-codex"
+```
+
+Supported backends:
+- `claude` (default) — requires `claude` CLI installed and authenticated
+- `codex` — requires `codex` CLI installed and authenticated
+
+Both backends use your existing CLI authentication (subscription OAuth or API key) — no additional setup required. The evaluator spawns the CLI as a subprocess, so you get the same billing treatment as interactive use.
+
 ### Model
 
 Use the best available model for review quality:
@@ -239,7 +255,7 @@ my-benchmark/
 skills_dir = "./evaluator_skills"
 ```
 
-Skills are copied into the evaluator's workspace and loaded natively by Claude Code. The evaluator's prompt automatically adjusts to reference artifact paths correctly.
+Skills are copied into the evaluator's workspace and loaded via the CLI's native auto-discovery (`claude --add-dir <workspace>`). The evaluator's prompt automatically adjusts to reference artifact paths correctly.
 
 ### MCP servers
 
@@ -279,6 +295,7 @@ append_system_prompt = "Pay special attention to SOLID principles when scoring."
 
 | Setting | Default | Purpose |
 |---------|---------|---------|
+| `backend` | `claude` | Subprocess backend: `claude` or `codex` |
 | `model` | `claude-opus-4-6` | Evaluator model |
 | `dimensions_file` | `assessment_dimensions.json` | Scoring dimensions file |
 | `max_turns` | `30` | Max conversation turns |
@@ -409,6 +426,7 @@ base_image = "ubuntu:22.04"
 build_commands = []
 
 [evaluation]
+backend = "claude"                            # "claude" (default) | "codex"
 model = "claude-opus-4-6"
 dimensions_file = "assessment_dimensions.json"
 # max_turns = 30                              # Max evaluator conversation turns
@@ -519,7 +537,7 @@ The Opik project name is automatically set to the benchmark name (from `nasde.to
   - Claude Code: `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`
   - OpenAI Codex: `CODEX_API_KEY` (API key) or `codex login` (ChatGPT subscription OAuth)
   - Gemini CLI: `GEMINI_API_KEY` (API key), `GOOGLE_API_KEY` (Vertex AI), or `gemini login` (Google account OAuth)
-- **ANTHROPIC_API_KEY** or **CLAUDE_CODE_OAUTH_TOKEN** — Also required for the assessment evaluator (which always uses Claude Code SDK)
+- **Evaluator CLI** — the assessment evaluator spawns the `claude` CLI by default (or `codex` if `[evaluation] backend = "codex"`). That CLI must be installed and authenticated (OAuth subscription or API key — whichever you already use interactively)
 
 ## Verifying Opik results
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ Supported backends:
 
 Both backends use your existing CLI authentication (subscription OAuth or API key) — no additional setup required. The evaluator spawns the CLI as a subprocess, so you get the same billing treatment as interactive use.
 
+See [`examples/nasde-dev-skill/nasde.codex.toml`](examples/nasde-dev-skill/nasde.codex.toml) for a ready-to-use Codex configuration — swap it in with:
+
+```bash
+cp examples/nasde-dev-skill/nasde.codex.toml examples/nasde-dev-skill/nasde.toml
+```
+
 ### Model
 
 Use the best available model for review quality:

--- a/docs/adr/001-open-host-service.md
+++ b/docs/adr/001-open-host-service.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-The eval pipeline requires three tools: Harbor (agent execution), Opik (observability), and Claude Code SDK (LLM-as-a-Judge). Originally orchestrated by a bash script (`run-benchmark.sh`) that called each tool via subprocess with `uv run` prefix. This forced users to either activate a venv or use `uv run` for every command — not viable for open-source distribution.
+The eval pipeline requires three tools: Harbor (agent execution), Opik (observability), and a CLI-based LLM judge (`claude` or `codex` spawned as a subprocess). Originally orchestrated by a bash script (`run-benchmark.sh`) that called each tool via subprocess with `uv run` prefix. This forced users to either activate a venv or use `uv run` for every command — not viable for open-source distribution.
 
 Three approaches were considered:
 

--- a/docs/adr/002-all-deps-as-core.md
+++ b/docs/adr/002-all-deps-as-core.md
@@ -1,28 +1,30 @@
 # ADR-002: All dependencies as core (no optional extras)
 
-**Status:** Accepted
+**Status:** Accepted (updated 2026-04-21 — SDK replaced by CLI subprocess; see ADR-008)
 **Date:** 2026-03-16
 
 ## Context
 
-Harbor, Opik, and Claude Code SDK are heavy dependencies (~160 transitive packages). A common pattern is to make them optional extras (`pip install nasde-toolkit[harbor,opik]`). However, the tool's entire purpose is the integrated pipeline — there is no useful subset without all three.
+Harbor and Opik are heavy dependencies (~160 transitive packages). A common pattern is to make them optional extras (`pip install nasde-toolkit[harbor,opik]`). However, the tool's entire purpose is the integrated pipeline — there is no useful subset without them.
 
 ## Decision
 
-All three are core dependencies in `[project.dependencies]`. No `[project.optional-dependencies]` section.
+Both are core dependencies in `[project.dependencies]`. No `[project.optional-dependencies]` section.
 
 ```toml
 dependencies = [
     "harbor>=0.1.40,<0.2",
     "opik>=1.10,<2",
-    "claude-code-sdk>=0.0.25,<1",
     ...
 ]
 ```
+
+> **Note (2026-04-21):** The original ADR also listed `claude-code-sdk>=0.0.25,<1` as a core dep for the assessment evaluator. That SDK was removed when the evaluator was refactored to spawn the `claude` / `codex` CLI binaries as subprocesses — see `src/nasde_toolkit/evaluator_backends/`. The CLI binaries themselves are a runtime prerequisite, not a Python dependency.
 
 ## Consequences
 
 - `uv tool install nasde-toolkit` gives complete functionality — no "did you install the extras?" support issues
 - Larger install footprint (~160 packages), but this is a developer tool, not a production dependency
-- Version pins (`<0.2`, `<2`, `<1`) protect against breaking API changes in Harbor/Opik/SDK
+- Version pins (`<0.2`, `<2`) protect against breaking API changes in Harbor/Opik
 - Only `nasde` appears on PATH (verified empirically with `uv tool install`) — Harbor and Opik CLIs are accessible only through pass-through commands, preventing confusion
+- Assessment evaluation requires the user to have `claude` or `codex` CLI installed and authenticated on the host (documented in README "Prerequisites")

--- a/docs/adr/003-eval-on-by-default.md
+++ b/docs/adr/003-eval-on-by-default.md
@@ -22,5 +22,5 @@ nasde run baseline -C examples/ddd-architectural-challenges --without-eval
 ## Consequences
 
 - Users get full value immediately without needing to know about the `--with-eval` flag
-- Running without eval is still possible for quick iteration (skips ~2 min of Claude Code SDK calls per trial)
+- Running without eval is still possible for quick iteration (skips ~2 min of evaluator subprocess calls per trial)
 - Opik tracing remains opt-in (`--with-opik`) because it requires external credentials and is not universally needed

--- a/docs/adr/006-opik-deferred-metrics-patch.md
+++ b/docs/adr/006-opik-deferred-metrics-patch.md
@@ -23,7 +23,6 @@ Apply the fix as a **runtime monkey-patch** in `runner.py` instead of a vendor `
 - **Survives `uv sync`**: vendor `.patch` files must be re-applied after every dependency install. Runtime patches are applied each run automatically.
 - **No external scripts**: the SDLC approach required `apply_opik_patches.sh` — easy to forget after `uv sync`.
 - **Same fix, different delivery**: the logic is identical to the SDLC `.patch` file; only the application mechanism differs.
-- **Follows existing pattern**: `evaluator.py` already uses a runtime monkey-patch for the claude-code-sdk `parse_message` bug.
 
 ## Consequences
 

--- a/docs/superpowers/plans/2026-04-16-subprocess-evaluator-backend.md
+++ b/docs/superpowers/plans/2026-04-16-subprocess-evaluator-backend.md
@@ -1,0 +1,1110 @@
+# Subprocess Evaluator Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Claude Code SDK-based evaluator with a subprocess-based architecture that supports both Claude Code CLI and Codex CLI as pluggable evaluator backends, enabling evaluation via subscription billing (OAuth) without Agent SDK restrictions.
+
+**Architecture:** Introduce an `EvaluatorBackend` Protocol with two implementations: `ClaudeSubprocessBackend` (spawns `claude -p --output-format json`) and `CodexSubprocessBackend` (spawns `codex exec --quiet --json`). The existing SDK-based code in `_run_claude_code_evaluation()` is replaced. Backend selection is driven by a new `backend` field in `EvaluationConfig` (`"claude"` default, `"codex"` available). Everything upstream of the backend call (prompt construction, response parsing, Opik upload) remains unchanged.
+
+**Tech Stack:** Python 3.12, asyncio subprocess, NDJSON parsing, pytest
+
+---
+
+### File Structure
+
+| Action | Path | Responsibility |
+|--------|------|---------------|
+| Create | `src/nasde_toolkit/evaluator_backends/__init__.py` | Re-exports `EvaluatorBackend`, `create_backend()` |
+| Create | `src/nasde_toolkit/evaluator_backends/protocol.py` | `EvaluatorBackend` Protocol definition |
+| Create | `src/nasde_toolkit/evaluator_backends/claude_subprocess.py` | Claude CLI subprocess backend |
+| Create | `src/nasde_toolkit/evaluator_backends/codex_subprocess.py` | Codex CLI subprocess backend |
+| Modify | `src/nasde_toolkit/config.py:32-42` | Add `backend` field to `EvaluationConfig` |
+| Modify | `src/nasde_toolkit/evaluator.py:20-56,458-585` | Remove SDK imports/monkeypatch, use backend |
+| Create | `tests/test_evaluator_backends.py` | Tests for both backends |
+| Modify | `tests/test_evaluator.py` | Update existing tests for new backend flow |
+| Modify | `CLAUDE.md` | Update architecture decisions section |
+| Modify | `README.md` | Document new evaluator backend config |
+| Modify | `ARCHITECTURE.md` | Update evaluator section |
+
+---
+
+### Task 1: Add `backend` field to `EvaluationConfig`
+
+**Files:**
+- Modify: `src/nasde_toolkit/config.py:32-42`
+- Modify: `src/nasde_toolkit/config.py:127-135`
+- Test: `tests/test_config.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# In tests/test_config.py — add to existing tests
+
+def test_evaluation_config_default_backend() -> None:
+    config = EvaluationConfig()
+    assert config.backend == "claude"
+
+
+def test_evaluation_config_codex_backend(tmp_path: Path) -> None:
+    toml_content = """
+[project]
+name = "test"
+
+[evaluation]
+backend = "codex"
+model = "o3"
+"""
+    (tmp_path / "nasde.toml").write_text(toml_content)
+    config = load_project_config(tmp_path)
+    assert config.evaluation.backend == "codex"
+    assert config.evaluation.model == "o3"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_config.py::test_evaluation_config_default_backend tests/test_config.py::test_evaluation_config_codex_backend -v`
+Expected: FAIL — `EvaluationConfig` has no `backend` attribute
+
+- [ ] **Step 3: Add `backend` field to `EvaluationConfig` and parsing**
+
+In `src/nasde_toolkit/config.py`, add to `EvaluationConfig` dataclass:
+
+```python
+@dataclass
+class EvaluationConfig:
+    """Assessment evaluation settings."""
+
+    backend: str = "claude"
+    model: str = "claude-opus-4-6"
+    dimensions_file: str = "assessment_dimensions.json"
+    max_turns: int = 30
+    allowed_tools: list[str] | None = None
+    mcp_config: str | None = None
+    skills_dir: str | None = None
+    append_system_prompt: str | None = None
+    include_trajectory: bool = False
+```
+
+In `_parse_toml()`, add backend parsing in the `EvaluationConfig(...)` constructor:
+
+```python
+        evaluation=EvaluationConfig(
+            backend=eval_raw.get("backend", "claude"),
+            model=eval_raw.get("model", "claude-opus-4-6"),
+            # ... rest unchanged
+        ),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_config.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nasde_toolkit/config.py tests/test_config.py
+git commit -m "feat: add backend field to EvaluationConfig for pluggable evaluator"
+```
+
+---
+
+### Task 2: Define `EvaluatorBackend` Protocol
+
+**Files:**
+- Create: `src/nasde_toolkit/evaluator_backends/__init__.py`
+- Create: `src/nasde_toolkit/evaluator_backends/protocol.py`
+- Test: `tests/test_evaluator_backends.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_evaluator_backends.py
+from __future__ import annotations
+
+from pathlib import Path
+
+from nasde_toolkit.evaluator_backends import EvaluatorBackend, create_backend
+from nasde_toolkit.config import EvaluationConfig
+
+
+def test_create_backend_returns_claude_by_default() -> None:
+    config = EvaluationConfig()
+    backend = create_backend(config)
+    assert isinstance(backend, EvaluatorBackend)
+
+
+def test_create_backend_returns_codex_when_configured() -> None:
+    config = EvaluationConfig(backend="codex")
+    backend = create_backend(config)
+    assert isinstance(backend, EvaluatorBackend)
+
+
+def test_create_backend_raises_on_unknown() -> None:
+    import pytest
+
+    config = EvaluationConfig(backend="unknown-agent")
+    with pytest.raises(ValueError, match="Unknown evaluator backend"):
+        create_backend(config)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_evaluator_backends.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'nasde_toolkit.evaluator_backends'`
+
+- [ ] **Step 3: Create the Protocol and factory**
+
+`src/nasde_toolkit/evaluator_backends/protocol.py`:
+
+```python
+"""Evaluator backend protocol — defines the interface for CLI-based evaluators."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from nasde_toolkit.config import EvaluationConfig
+
+
+@runtime_checkable
+class EvaluatorBackend(Protocol):
+    """Interface for subprocess-based evaluator backends.
+
+    Each backend spawns a CLI agent (claude, codex, etc.) as a subprocess,
+    passes the evaluation prompt, and returns the agent's text response.
+    """
+
+    async def run_evaluation(
+        self,
+        prompt: str,
+        workspace_path: Path,
+        eval_config: EvaluationConfig,
+        project_root: Path,
+        trial_dir: Path | None = None,
+    ) -> str: ...
+
+    def validate_auth(self) -> None: ...
+```
+
+`src/nasde_toolkit/evaluator_backends/__init__.py`:
+
+```python
+"""Pluggable evaluator backends for nasde assessment evaluation."""
+
+from nasde_toolkit.evaluator_backends.protocol import EvaluatorBackend
+
+__all__ = ["EvaluatorBackend", "create_backend"]
+
+
+def create_backend(eval_config: "EvaluationConfig") -> EvaluatorBackend:
+    from nasde_toolkit.config import EvaluationConfig
+
+    if eval_config.backend == "claude":
+        from nasde_toolkit.evaluator_backends.claude_subprocess import ClaudeSubprocessBackend
+
+        return ClaudeSubprocessBackend()
+    elif eval_config.backend == "codex":
+        from nasde_toolkit.evaluator_backends.codex_subprocess import CodexSubprocessBackend
+
+        return CodexSubprocessBackend()
+    else:
+        raise ValueError(
+            f"Unknown evaluator backend: '{eval_config.backend}'. "
+            f"Supported: 'claude', 'codex'"
+        )
+```
+
+- [ ] **Step 4: Create stub backend files so imports resolve**
+
+`src/nasde_toolkit/evaluator_backends/claude_subprocess.py`:
+
+```python
+"""Claude Code CLI subprocess evaluator backend."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nasde_toolkit.config import EvaluationConfig
+
+
+class ClaudeSubprocessBackend:
+    """Evaluator backend that spawns `claude -p` as a subprocess."""
+
+    async def run_evaluation(
+        self,
+        prompt: str,
+        workspace_path: Path,
+        eval_config: EvaluationConfig,
+        project_root: Path,
+        trial_dir: Path | None = None,
+    ) -> str:
+        raise NotImplementedError
+
+    def validate_auth(self) -> None:
+        raise NotImplementedError
+```
+
+`src/nasde_toolkit/evaluator_backends/codex_subprocess.py`:
+
+```python
+"""Codex CLI subprocess evaluator backend."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nasde_toolkit.config import EvaluationConfig
+
+
+class CodexSubprocessBackend:
+    """Evaluator backend that spawns `codex exec` as a subprocess."""
+
+    async def run_evaluation(
+        self,
+        prompt: str,
+        workspace_path: Path,
+        eval_config: EvaluationConfig,
+        project_root: Path,
+        trial_dir: Path | None = None,
+    ) -> str:
+        raise NotImplementedError
+
+    def validate_auth(self) -> None:
+        raise NotImplementedError
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_evaluator_backends.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nasde_toolkit/evaluator_backends/ tests/test_evaluator_backends.py
+git commit -m "feat: add EvaluatorBackend protocol and factory with stub implementations"
+```
+
+---
+
+### Task 3: Implement `ClaudeSubprocessBackend`
+
+**Files:**
+- Modify: `src/nasde_toolkit/evaluator_backends/claude_subprocess.py`
+- Test: `tests/test_evaluator_backends.py`
+
+- [ ] **Step 1: Write the failing test for auth validation**
+
+```python
+# Add to tests/test_evaluator_backends.py
+import os
+
+from nasde_toolkit.evaluator_backends.claude_subprocess import ClaudeSubprocessBackend
+
+
+def test_claude_backend_validate_auth_succeeds_with_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    backend = ClaudeSubprocessBackend()
+    backend.validate_auth()
+
+
+def test_claude_backend_validate_auth_succeeds_with_oauth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-oat-test")
+    backend = ClaudeSubprocessBackend()
+    backend.validate_auth()
+
+
+def test_claude_backend_validate_auth_fails_without_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    backend = ClaudeSubprocessBackend()
+    with pytest.raises(SystemExit):
+        backend.validate_auth()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_evaluator_backends.py::test_claude_backend_validate_auth_succeeds_with_api_key -v`
+Expected: FAIL — `NotImplementedError`
+
+- [ ] **Step 3: Write the failing test for command construction**
+
+```python
+# Add to tests/test_evaluator_backends.py
+
+def test_claude_backend_builds_command(tmp_path: Path) -> None:
+    backend = ClaudeSubprocessBackend()
+    eval_config = EvaluationConfig(model="claude-sonnet-4-6", max_turns=10)
+    cmd = backend._build_command(
+        workspace_path=tmp_path,
+        eval_config=eval_config,
+        project_root=tmp_path.parent,
+        trial_dir=None,
+    )
+    assert cmd[0] == "claude"
+    assert "-p" in cmd
+    assert "--output-format" in cmd
+    assert "json" in cmd
+    assert "--model" in cmd
+    assert "claude-sonnet-4-6" in cmd
+    assert "--max-turns" in cmd
+    assert "10" in cmd
+    assert "--bare" in cmd
+    assert "--allowedTools" in cmd
+
+
+def test_claude_backend_command_includes_add_dir_for_trajectory(tmp_path: Path) -> None:
+    trial_dir = tmp_path / "trial"
+    trial_dir.mkdir()
+    backend = ClaudeSubprocessBackend()
+    eval_config = EvaluationConfig(include_trajectory=True)
+    cmd = backend._build_command(
+        workspace_path=tmp_path,
+        eval_config=eval_config,
+        project_root=tmp_path.parent,
+        trial_dir=trial_dir,
+    )
+    assert "--add-dir" in cmd
+    assert str(trial_dir) in cmd
+
+
+def test_claude_backend_command_includes_mcp_config(tmp_path: Path) -> None:
+    mcp_file = tmp_path / "mcp.json"
+    mcp_file.write_text("{}")
+    backend = ClaudeSubprocessBackend()
+    eval_config = EvaluationConfig(mcp_config=str(mcp_file))
+    cmd = backend._build_command(
+        workspace_path=tmp_path,
+        eval_config=eval_config,
+        project_root=tmp_path.parent,
+        trial_dir=None,
+    )
+    assert "--mcp-config" in cmd
+    assert str(mcp_file) in cmd
+
+
+def test_claude_backend_command_includes_append_system_prompt(tmp_path: Path) -> None:
+    backend = ClaudeSubprocessBackend()
+    eval_config = EvaluationConfig(append_system_prompt="Be strict.")
+    cmd = backend._build_command(
+        workspace_path=tmp_path,
+        eval_config=eval_config,
+        project_root=tmp_path.parent,
+        trial_dir=None,
+    )
+    assert "--append-system-prompt" in cmd
+    assert "Be strict." in cmd
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_evaluator_backends.py -k "claude_backend" -v`
+Expected: FAIL — methods not implemented
+
+- [ ] **Step 5: Implement `ClaudeSubprocessBackend`**
+
+Replace `src/nasde_toolkit/evaluator_backends/claude_subprocess.py`:
+
+```python
+"""Claude Code CLI subprocess evaluator backend."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+from rich.console import Console
+
+from nasde_toolkit.config import EvaluationConfig
+
+console = Console()
+
+
+class ClaudeSubprocessBackend:
+    """Evaluator backend that spawns `claude -p` as a subprocess.
+
+    Uses `--output-format json` to get structured output with a `result`
+    field containing the agent's text response. Authenticates via whatever
+    credentials are configured (ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN).
+    """
+
+    async def run_evaluation(
+        self,
+        prompt: str,
+        workspace_path: Path,
+        eval_config: EvaluationConfig,
+        project_root: Path,
+        trial_dir: Path | None = None,
+    ) -> str:
+        self.validate_auth()
+        cmd = self._build_command(workspace_path, eval_config, project_root, trial_dir)
+        env = self._build_env()
+        return await self._run_subprocess(cmd, prompt, workspace_path, env)
+
+    def validate_auth(self) -> None:
+        has_api_key = bool(os.environ.get("ANTHROPIC_API_KEY"))
+        has_oauth = bool(os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"))
+        if not has_api_key and not has_oauth:
+            console.print("[red]ERROR: Set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN[/red]")
+            raise SystemExit(1)
+
+    def _build_command(
+        self,
+        workspace_path: Path,
+        eval_config: EvaluationConfig,
+        project_root: Path,
+        trial_dir: Path | None,
+    ) -> list[str]:
+        cmd = [
+            "claude",
+            "-p",
+            "--output-format", "json",
+            "--bare",
+            "--no-session-persistence",
+            "--model", eval_config.model,
+            "--max-turns", str(eval_config.max_turns),
+        ]
+
+        allowed_tools = eval_config.allowed_tools or ["Read", "Glob", "Grep"]
+        cmd.extend(["--allowedTools", ",".join(allowed_tools)])
+
+        if eval_config.include_trajectory and trial_dir:
+            cmd.extend(["--add-dir", str(trial_dir)])
+
+        if eval_config.mcp_config:
+            mcp_path = _resolve_path(eval_config.mcp_config, project_root)
+            cmd.extend(["--mcp-config", str(mcp_path)])
+
+        if eval_config.append_system_prompt:
+            cmd.extend(["--append-system-prompt", eval_config.append_system_prompt])
+
+        return cmd
+
+    def _build_env(self) -> dict[str, str]:
+        env = dict(os.environ)
+        env.pop("CLAUDECODE", None)
+        return env
+
+    async def _run_subprocess(
+        self,
+        cmd: list[str],
+        prompt: str,
+        workspace_path: Path,
+        env: dict[str, str],
+    ) -> str:
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=str(workspace_path),
+            env=env,
+        )
+        stdout_bytes, stderr_bytes = await process.communicate(input=prompt.encode())
+
+        if process.returncode != 0:
+            stderr_text = stderr_bytes.decode(errors="replace").strip()
+            last_lines = "\n".join(stderr_text.splitlines()[-10:]) if stderr_text else ""
+            raise RuntimeError(
+                f"Claude Code process failed (exit code {process.returncode}). "
+                f"Model: {cmd[cmd.index('--model') + 1]}, cwd: {workspace_path}. "
+                f"stderr (last 10 lines):\n{last_lines}"
+            )
+
+        return _extract_result_text(stdout_bytes.decode())
+
+
+def _resolve_path(relative_or_absolute: str, project_root: Path) -> Path:
+    path = Path(relative_or_absolute)
+    if path.is_absolute():
+        return path
+    return project_root / path
+
+
+def _extract_result_text(stdout: str) -> str:
+    try:
+        data = json.loads(stdout)
+        return data.get("result", "")
+    except json.JSONDecodeError:
+        return stdout
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_evaluator_backends.py -k "claude_backend" -v`
+Expected: ALL PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/nasde_toolkit/evaluator_backends/claude_subprocess.py tests/test_evaluator_backends.py
+git commit -m "feat: implement ClaudeSubprocessBackend with claude -p subprocess"
+```
+
+---
+
+### Task 4: Implement `CodexSubprocessBackend`
+
+**Files:**
+- Modify: `src/nasde_toolkit/evaluator_backends/codex_subprocess.py`
+- Test: `tests/test_evaluator_backends.py`
+
+- [ ] **Step 1: Write the failing tests for auth and command**
+
+```python
+# Add to tests/test_evaluator_backends.py
+from nasde_toolkit.evaluator_backends.codex_subprocess import CodexSubprocessBackend
+
+
+def test_codex_backend_validate_auth_succeeds_with_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+    backend = CodexSubprocessBackend()
+    backend.validate_auth()
+
+
+def test_codex_backend_validate_auth_succeeds_with_codex_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("CODEX_API_KEY", "sk-test-key")
+    backend = CodexSubprocessBackend()
+    backend.validate_auth()
+
+
+def test_codex_backend_validate_auth_succeeds_with_chatgpt_oauth(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("CODEX_API_KEY", raising=False)
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    auth_file = codex_home / "auth.json"
+    auth_file.write_text('{"auth_mode": "chatgpt", "tokens": {"access_token": "tok"}}')
+    monkeypatch.setenv("HOME", str(tmp_path))
+    backend = CodexSubprocessBackend()
+    backend.validate_auth()
+
+
+def test_codex_backend_validate_auth_fails_without_credentials(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("CODEX_API_KEY", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    backend = CodexSubprocessBackend()
+    with pytest.raises(SystemExit):
+        backend.validate_auth()
+
+
+def test_codex_backend_builds_command(tmp_path: Path) -> None:
+    backend = CodexSubprocessBackend()
+    eval_config = EvaluationConfig(backend="codex", model="o3")
+    cmd = backend._build_command(
+        workspace_path=tmp_path,
+        eval_config=eval_config,
+    )
+    assert cmd[0] == "codex"
+    assert "exec" in cmd
+    assert "--json" in cmd
+    assert "--quiet" in cmd
+    assert "--full-auto" in cmd
+    assert "--model" in cmd
+    assert "o3" in cmd
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_evaluator_backends.py -k "codex_backend" -v`
+Expected: FAIL — `NotImplementedError`
+
+- [ ] **Step 3: Implement `CodexSubprocessBackend`**
+
+Replace `src/nasde_toolkit/evaluator_backends/codex_subprocess.py`:
+
+```python
+"""Codex CLI subprocess evaluator backend."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+from rich.console import Console
+
+from nasde_toolkit.config import EvaluationConfig
+
+console = Console()
+
+
+class CodexSubprocessBackend:
+    """Evaluator backend that spawns `codex exec` as a subprocess.
+
+    Uses `--json` for JSONL event streaming. Extracts the final
+    agent_message from the event stream as the evaluation response.
+    Authenticates via OPENAI_API_KEY, CODEX_API_KEY, or ChatGPT OAuth.
+    """
+
+    async def run_evaluation(
+        self,
+        prompt: str,
+        workspace_path: Path,
+        eval_config: EvaluationConfig,
+        project_root: Path,
+        trial_dir: Path | None = None,
+    ) -> str:
+        self.validate_auth()
+        cmd = self._build_command(workspace_path, eval_config)
+        cmd.append(prompt)
+        return await self._run_subprocess(cmd, workspace_path)
+
+    def validate_auth(self) -> None:
+        has_openai_key = bool(os.environ.get("OPENAI_API_KEY"))
+        has_codex_key = bool(os.environ.get("CODEX_API_KEY"))
+        has_chatgpt_oauth = _has_chatgpt_oauth()
+        if not has_openai_key and not has_codex_key and not has_chatgpt_oauth:
+            console.print(
+                "[red]ERROR: Set OPENAI_API_KEY, CODEX_API_KEY, "
+                "or log in via `codex login`[/red]"
+            )
+            raise SystemExit(1)
+
+    def _build_command(
+        self,
+        workspace_path: Path,
+        eval_config: EvaluationConfig,
+    ) -> list[str]:
+        cmd = [
+            "codex",
+            "exec",
+            "--json",
+            "--quiet",
+            "--full-auto",
+            "--model", eval_config.model,
+        ]
+        return cmd
+
+    async def _run_subprocess(
+        self,
+        cmd: list[str],
+        workspace_path: Path,
+    ) -> str:
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=str(workspace_path),
+        )
+        stdout_bytes, stderr_bytes = await process.communicate()
+
+        if process.returncode != 0:
+            stderr_text = stderr_bytes.decode(errors="replace").strip()
+            last_lines = "\n".join(stderr_text.splitlines()[-10:]) if stderr_text else ""
+            raise RuntimeError(
+                f"Codex process failed (exit code {process.returncode}). "
+                f"cwd: {workspace_path}. "
+                f"stderr (last 10 lines):\n{last_lines}"
+            )
+
+        return _extract_agent_messages(stdout_bytes.decode())
+
+
+def _has_chatgpt_oauth() -> bool:
+    auth_path = Path.home() / ".codex" / "auth.json"
+    if not auth_path.exists():
+        return False
+    try:
+        raw = json.loads(auth_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return False
+    return (
+        raw.get("auth_mode") == "chatgpt"
+        and bool(raw.get("tokens", {}).get("access_token"))
+    )
+
+
+def _extract_agent_messages(stdout: str) -> str:
+    messages: list[str] = []
+    for line in stdout.strip().splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("type") == "item.completed":
+            item = event.get("item", {})
+            if item.get("type") == "agent_message":
+                text = item.get("text", "")
+                if text:
+                    messages.append(text)
+    return "\n".join(messages)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_evaluator_backends.py -k "codex_backend" -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nasde_toolkit/evaluator_backends/codex_subprocess.py tests/test_evaluator_backends.py
+git commit -m "feat: implement CodexSubprocessBackend with codex exec subprocess"
+```
+
+---
+
+### Task 5: Wire backend into `evaluator.py` — remove SDK dependency
+
+**Files:**
+- Modify: `src/nasde_toolkit/evaluator.py`
+- Modify: `tests/test_evaluator.py`
+
+This is the core refactoring task. We remove all `claude_code_sdk` imports, the monkeypatch, and `_run_claude_code_evaluation()` + `_build_claude_code_options()`. Replace with backend dispatch.
+
+- [ ] **Step 1: Write test for backend dispatch in evaluator**
+
+```python
+# Add to tests/test_evaluator.py
+from unittest.mock import AsyncMock, patch
+
+from nasde_toolkit.config import EvaluationConfig
+
+
+def test_evaluate_trial_uses_configured_backend(tmp_path: Path) -> None:
+    """Verify evaluator creates the right backend type based on config."""
+    from nasde_toolkit.evaluator_backends import create_backend
+
+    claude_config = EvaluationConfig(backend="claude")
+    codex_config = EvaluationConfig(backend="codex")
+
+    claude_backend = create_backend(claude_config)
+    codex_backend = create_backend(codex_config)
+
+    assert type(claude_backend).__name__ == "ClaudeSubprocessBackend"
+    assert type(codex_backend).__name__ == "CodexSubprocessBackend"
+```
+
+- [ ] **Step 2: Run test to verify it passes (factory already works)**
+
+Run: `uv run pytest tests/test_evaluator.py::test_evaluate_trial_uses_configured_backend -v`
+Expected: PASS
+
+- [ ] **Step 3: Refactor `evaluator.py` — remove SDK, use backend**
+
+Key changes to `src/nasde_toolkit/evaluator.py`:
+
+1. **Remove** these imports (lines 20-25):
+```python
+# DELETE these lines:
+from claude_code_sdk import ClaudeCodeOptions, query
+from claude_code_sdk._errors import ProcessError
+from claude_code_sdk._internal import client as _sdk_client
+from claude_code_sdk._internal import message_parser as _mp
+from claude_code_sdk.types import AssistantMessage, TextBlock
+```
+
+2. **Remove** the entire monkeypatch block (lines 29-56)
+
+3. **Add** new import:
+```python
+from nasde_toolkit.evaluator_backends import create_backend
+```
+
+4. **Replace** the `_run_claude_code_evaluation()` call in `evaluate_trial()` (lines 246-252) with:
+```python
+    backend = create_backend(eval_config)
+    backend.validate_auth()
+    raw_response = await backend.run_evaluation(
+        prompt=prompt,
+        workspace_path=workspace_path,
+        eval_config=eval_config,
+        project_root=project_root,
+        trial_dir=trial_dir,
+    )
+```
+
+5. **Delete** these functions entirely:
+   - `_run_claude_code_evaluation()` (lines 459-497)
+   - `_extract_stderr_detail()` (lines 500-506)
+   - `_build_claude_code_options()` (lines 509-558)
+   - `_prepare_skills_workspace()` (lines 561-566)
+   - `_resolve_path()` (lines 569-573)
+   - `_validate_auth()` (lines 576-585)
+
+6. **Update** the console message (line 244) to be backend-aware:
+```python
+    console.print(f"  Running {eval_config.backend} evaluation...")
+```
+
+- [ ] **Step 4: Update existing tests**
+
+In `tests/test_evaluator.py`, update tests that reference `_build_claude_code_options`:
+
+- Remove `test_claude_code_options_adds_trial_dir_when_trajectory_enabled` — this is now tested via `ClaudeSubprocessBackend._build_command()`
+- Remove `test_claude_code_options_no_trial_dir_when_trajectory_disabled` — same reason
+- Keep all prompt-building and trajectory-path tests (they're unchanged)
+
+Add import fix at top:
+```python
+# Remove this import:
+from nasde_toolkit.evaluator import _build_claude_code_options, _build_evaluator_prompt, _resolve_trajectory_path
+# Replace with:
+from nasde_toolkit.evaluator import _build_evaluator_prompt, _resolve_trajectory_path
+```
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest -v`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nasde_toolkit/evaluator.py tests/test_evaluator.py
+git commit -m "refactor: replace Claude Code SDK with subprocess-based evaluator backend"
+```
+
+---
+
+### Task 6: Handle skills_dir in Claude subprocess backend
+
+**Files:**
+- Modify: `src/nasde_toolkit/evaluator_backends/claude_subprocess.py`
+- Test: `tests/test_evaluator_backends.py`
+
+The current SDK-based evaluator has special handling for `skills_dir`: it creates a temp directory, copies skills into `.claude/skills/`, and sets that as `cwd` with the workspace as an `add_dir`. We need to replicate this in the subprocess backend.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Add to tests/test_evaluator_backends.py
+
+def test_claude_backend_command_includes_skills_dir_setup(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "evaluator_skills" / "my-skill"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "SKILL.md").write_text("# Skill content")
+
+    workspace_path = tmp_path / "workspace"
+    workspace_path.mkdir()
+
+    backend = ClaudeSubprocessBackend()
+    eval_config = EvaluationConfig(skills_dir=str(tmp_path / "evaluator_skills"))
+    cmd, temp_dir = backend._build_command_with_skills(
+        workspace_path=workspace_path,
+        eval_config=eval_config,
+        project_root=tmp_path,
+        trial_dir=None,
+    )
+    assert temp_dir is not None
+    assert (temp_dir / ".claude" / "skills" / "my-skill" / "SKILL.md").exists()
+    assert "--add-dir" in cmd
+    assert str(workspace_path) in cmd
+
+    import shutil
+    shutil.rmtree(temp_dir, ignore_errors=True)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_evaluator_backends.py::test_claude_backend_command_includes_skills_dir_setup -v`
+Expected: FAIL — `_build_command_with_skills` doesn't exist
+
+- [ ] **Step 3: Add skills_dir handling to `ClaudeSubprocessBackend`**
+
+Add to `claude_subprocess.py`:
+
+```python
+import shutil
+import tempfile
+
+# Modify run_evaluation to handle skills cleanup:
+    async def run_evaluation(
+        self,
+        prompt: str,
+        workspace_path: Path,
+        eval_config: EvaluationConfig,
+        project_root: Path,
+        trial_dir: Path | None = None,
+    ) -> str:
+        self.validate_auth()
+        cmd, temp_dir = self._build_command_with_skills(
+            workspace_path, eval_config, project_root, trial_dir
+        )
+        env = self._build_env()
+        cwd = temp_dir if temp_dir else workspace_path
+        try:
+            return await self._run_subprocess(cmd, prompt, cwd, env)
+        finally:
+            if temp_dir:
+                shutil.rmtree(temp_dir, ignore_errors=True)
+
+    def _build_command_with_skills(
+        self,
+        workspace_path: Path,
+        eval_config: EvaluationConfig,
+        project_root: Path,
+        trial_dir: Path | None,
+    ) -> tuple[list[str], Path | None]:
+        cmd = self._build_command(workspace_path, eval_config, project_root, trial_dir)
+        temp_dir: Path | None = None
+
+        if eval_config.skills_dir:
+            skills_source = _resolve_path(eval_config.skills_dir, project_root)
+            temp_dir = Path(tempfile.mkdtemp(prefix="nasde_eval_"))
+            target = temp_dir / ".claude" / "skills"
+            if skills_source.is_dir():
+                shutil.copytree(skills_source, target)
+            cmd.extend(["--add-dir", str(workspace_path)])
+
+        return cmd, temp_dir
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_evaluator_backends.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nasde_toolkit/evaluator_backends/claude_subprocess.py tests/test_evaluator_backends.py
+git commit -m "feat: add skills_dir support to ClaudeSubprocessBackend"
+```
+
+---
+
+### Task 7: Update documentation
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+- Modify: `ARCHITECTURE.md`
+
+- [ ] **Step 1: Update CLAUDE.md architecture decisions**
+
+Replace the **Evaluator** bullet in the "Architecture decisions" section:
+
+```markdown
+- **Evaluator**: Subprocess-based assessment evaluation with pluggable backends. The evaluator spawns a CLI agent (`claude -p` or `codex exec`) as a subprocess to read trial artifacts and score them against assessment criteria. Backend selection via `[evaluation] backend` in `nasde.toml` (`"claude"` default, `"codex"` available). Claude backend uses `--output-format json --bare` for clean non-interactive output. Codex backend uses `--json --quiet --full-auto` for JSONL event streaming. Both backends respect the user's existing CLI authentication (OAuth subscription or API key) — no Agent SDK required. Configurable via `[evaluation]` in `nasde.toml` — model, tools, MCP servers, skills, system prompt, trajectory inclusion, and backend can all be customized. Results written to `assessment_eval.json` per trial and optionally uploaded to Opik.
+```
+
+Also update the dependencies bullet to remove `claude-code-sdk`:
+```markdown
+- **All dependencies are core**: `harbor`, `opik` are in `[project.dependencies]`. No optional extras — `uv tool install .` gives full functionality. Assessment evaluation requires `claude` CLI (default) or `codex` CLI to be installed and authenticated. Evaluation is on by default (`--without-eval` to skip).
+```
+
+- [ ] **Step 2: Update README.md**
+
+Add a section about evaluator backend configuration in the relevant place:
+
+```markdown
+### Evaluator backend
+
+By default, nasde uses Claude Code CLI for assessment evaluation. You can switch to Codex:
+
+```toml
+[evaluation]
+backend = "codex"
+model = "o3"
+```
+
+Supported backends:
+- `claude` (default) — requires `claude` CLI installed and authenticated
+- `codex` — requires `codex` CLI installed and authenticated
+
+Both backends use your existing CLI authentication (subscription or API key).
+```
+
+- [ ] **Step 3: Update ARCHITECTURE.md evaluator section**
+
+Update the evaluator description to reflect subprocess-based architecture.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md README.md ARCHITECTURE.md
+git commit -m "docs: update documentation for subprocess-based evaluator backends"
+```
+
+---
+
+### Task 8: Remove `claude-code-sdk` dependency from `pyproject.toml`
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Remove `claude-code-sdk` from dependencies**
+
+In `pyproject.toml`, remove `claude-code-sdk` from `[project.dependencies]`. The evaluator no longer imports it.
+
+- [ ] **Step 2: Verify no remaining imports**
+
+Run: `uv run python -c "from nasde_toolkit.evaluator import evaluate_job; print('OK')"`
+Expected: `OK` — no ImportError
+
+Run: `grep -r "claude_code_sdk\|claude-code-sdk" src/`
+Expected: No matches
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `uv run pytest -v`
+Expected: ALL PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml
+git commit -m "chore: remove claude-code-sdk dependency — evaluator uses subprocess now"
+```
+
+---
+
+### Task 9: Integration smoke test
+
+**Files:** (no new files — manual verification)
+
+- [ ] **Step 1: Verify Claude backend works end-to-end**
+
+Run with an existing job directory (if available):
+
+```bash
+uv run nasde eval <job-dir> -C <benchmark-project>
+```
+
+Verify it spawns `claude -p` and produces `assessment_eval.json`.
+
+- [ ] **Step 2: Verify Codex backend configuration is recognized**
+
+Create a test `nasde.toml` with `backend = "codex"` and run:
+
+```bash
+uv run python -c "
+from nasde_toolkit.config import load_project_config
+from nasde_toolkit.evaluator_backends import create_backend
+from pathlib import Path
+
+# Point to a benchmark with backend = 'codex' in nasde.toml
+config = load_project_config(Path('<test-project>'))
+backend = create_backend(config.evaluation)
+print(f'Backend type: {type(backend).__name__}')
+print(f'Model: {config.evaluation.model}')
+"
+```
+
+Expected: `Backend type: CodexSubprocessBackend`
+
+- [ ] **Step 3: Verify linting passes**
+
+Run: `uv run ruff check src/ tests/`
+Expected: No errors
+
+- [ ] **Step 4: Final commit if any fixes needed**
+
+```bash
+git add -A
+git commit -m "fix: address integration test findings"
+```

--- a/docs/superpowers/plans/2026-04-16-subprocess-evaluator-backend.md
+++ b/docs/superpowers/plans/2026-04-16-subprocess-evaluator-backend.md
@@ -354,7 +354,7 @@ def test_claude_backend_builds_command(tmp_path: Path) -> None:
     assert "claude-sonnet-4-6" in cmd
     assert "--max-turns" in cmd
     assert "10" in cmd
-    assert "--bare" in cmd
+    assert "--bare" not in cmd
     assert "--allowedTools" in cmd
 
 
@@ -433,6 +433,11 @@ class ClaudeSubprocessBackend:
     Uses `--output-format json` to get structured output with a `result`
     field containing the agent's text response. Authenticates via whatever
     credentials are configured (ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN).
+
+    Does NOT use `--bare` mode — preserves OAuth/keychain auth reads
+    (required for subscription-based billing) and auto-discovery of user-level
+    skills. Trades a slightly slower startup for full compatibility with
+    subscription accounts.
     """
 
     async def run_evaluation(
@@ -466,7 +471,6 @@ class ClaudeSubprocessBackend:
             "claude",
             "-p",
             "--output-format", "json",
-            "--bare",
             "--no-session-persistence",
             "--model", eval_config.model,
             "--max-turns", str(eval_config.max_turns),

--- a/examples/nasde-dev-skill/nasde.codex.toml
+++ b/examples/nasde-dev-skill/nasde.codex.toml
@@ -1,0 +1,31 @@
+[project]
+name = "nasde-dev-skill"
+version = "1.0.0"
+
+[defaults]
+variant = "claude-vanilla"
+model = "claude-sonnet-4-6"
+timeout_sec = 1800
+
+[docker]
+base_image = "python:3.12-slim"
+# TEMPORARY WORKAROUND: litellm is quarantined on PyPI (March 2026 supply chain attack —
+# versions 1.82.7-1.82.8 contained infostealer malware). PyPI blocked ALL versions pending
+# review. We install a safe version (v1.82.3) from GitHub as a uv override.
+# Remove override lines once litellm is restored on PyPI.
+build_commands = [
+  "pip install uv",
+  "echo 'litellm @ https://github.com/BerriAI/litellm/archive/refs/tags/v1.82.3.tar.gz' > /tmp/litellm-override.txt",
+  "uv tool install . --override /tmp/litellm-override.txt",
+  "nasde --version",
+]
+
+[evaluation]
+backend = "codex"
+model = "gpt-5.3-codex"
+dimensions_file = "assessment_dimensions.json"
+include_trajectory = true
+
+[reporting]
+platform = "opik"
+project_name = "nasde-dev-skill"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "platformdirs>=4.0",
     "harbor>=0.1.40,<0.2",
     "opik>=1.10,<2",
-    "claude-code-sdk>=0.0.25,<1",
 ]
 
 [project.scripts]

--- a/src/nasde_toolkit/config.py
+++ b/src/nasde_toolkit/config.py
@@ -32,6 +32,7 @@ class DockerConfig:
 class EvaluationConfig:
     """Assessment evaluation settings."""
 
+    backend: str = "claude"
     model: str = "claude-opus-4-6"
     dimensions_file: str = "assessment_dimensions.json"
     max_turns: int = 30
@@ -125,6 +126,7 @@ def _parse_toml(raw: dict, project_dir: Path) -> ProjectConfig:
             build_commands=docker_raw.get("build_commands", []),
         ),
         evaluation=EvaluationConfig(
+            backend=eval_raw.get("backend", "claude"),
             model=eval_raw.get("model", "claude-opus-4-6"),
             dimensions_file=eval_raw.get("dimensions_file", "assessment_dimensions.json"),
             max_turns=eval_raw.get("max_turns", 30),

--- a/src/nasde_toolkit/evaluator.py
+++ b/src/nasde_toolkit/evaluator.py
@@ -1,4 +1,4 @@
-"""Post-hoc assessment evaluation using Claude Code SDK.
+"""Post-hoc assessment evaluation via pluggable subprocess backends.
 
 Analyzes AI-generated artifacts from Harbor trials against assessment criteria
 and optional ground truth. Scores are written locally and optionally uploaded
@@ -9,51 +9,15 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 import re
-import shutil
-import tempfile
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
-from claude_code_sdk import ClaudeCodeOptions, query
-from claude_code_sdk._errors import ProcessError
-from claude_code_sdk._internal import client as _sdk_client
-from claude_code_sdk._internal import message_parser as _mp
-from claude_code_sdk.types import AssistantMessage, TextBlock
 from rich.console import Console
 
 from nasde_toolkit.config import EvaluationConfig
-
-# ---------------------------------------------------------------------------
-# Monkeypatch: claude-code-sdk 0.0.25 — unknown message type crash
-#
-# Bug:     SDK's parse_message() raises MessageParseError on message types it
-#          doesn't recognize (e.g. "rate_limit_event"). This crashes the entire
-#          async query stream — there is no way to catch it per-message because
-#          the exception is raised inside the SDK's async generator.
-#
-# Fix:     Replace parse_message in the client module (where it's imported as a
-#          local name) with a wrapper that returns None for unknown types.
-#          The async for loop in _run_claude_code_evaluation() skips None.
-#
-# When to remove:  when claude-code-sdk handles unknown message types gracefully.
-#                  Check: `grep "Unknown message type" .venv/.../message_parser.py`
-#                  If the line raises logger.debug instead of MessageParseError,
-#                  this monkeypatch is no longer needed.
-# ---------------------------------------------------------------------------
-_original_parse_message = _mp.parse_message
-
-
-def _patched_parse_message(data: dict) -> object:
-    try:
-        return _original_parse_message(data)
-    except _mp.MessageParseError:
-        return None
-
-
-_sdk_client.parse_message = _patched_parse_message  # type: ignore[assignment]
+from nasde_toolkit.evaluator_backends import create_backend
 
 console = Console()
 
@@ -241,14 +205,15 @@ async def evaluate_trial(
     )
     console.print(f"  Task: {task_name}")
     console.print(f"  Workspace: {workspace_path}")
-    console.print("  Running Claude Code evaluation...")
+    console.print(f"  Running {eval_config.backend} evaluation...")
 
-    raw_response = await _run_claude_code_evaluation(
-        prompt,
-        workspace_path,
-        eval_config,
-        project_root,
-        trial_dir,
+    backend = create_backend(eval_config)
+    raw_response = await backend.run_evaluation(
+        prompt=prompt,
+        workspace_path=workspace_path,
+        eval_config=eval_config,
+        project_root=project_root,
+        trial_dir=trial_dir,
     )
     evaluation = _parse_evaluation_response(raw_response, expected_dimensions)
 
@@ -449,140 +414,6 @@ Use the Read tool to examine it when your assessment criteria require evaluating
 the agent's process, efficiency, or decision-making — not just the final output.
 
 """
-
-
-# ---------------------------------------------------------------------------
-# Claude Code SDK interaction
-# ---------------------------------------------------------------------------
-
-
-async def _run_claude_code_evaluation(
-    prompt: str,
-    workspace_path: Path,
-    eval_config: EvaluationConfig | None = None,
-    project_root: Path = Path(),
-    trial_dir: Path | None = None,
-) -> str:
-    eval_config = eval_config or EvaluationConfig()
-    _validate_auth()
-    options, temp_dir, stderr_path = _build_claude_code_options(
-        workspace_path,
-        eval_config,
-        project_root,
-        trial_dir,
-    )
-
-    try:
-        text_parts: list[str] = []
-        async for message in query(prompt=prompt, options=options):
-            if message is None:
-                continue
-            if isinstance(message, AssistantMessage):
-                for block in message.content:
-                    if isinstance(block, TextBlock):
-                        text_parts.append(block.text)
-
-        return "\n".join(text_parts)
-    except ProcessError as exc:
-        stderr_detail = _extract_stderr_detail(stderr_path)
-        raise RuntimeError(
-            f"Claude Code process failed (exit code {exc.exit_code}). "
-            f"Model: {eval_config.model}, cwd: {workspace_path}. "
-            f"{stderr_detail}"
-        ) from exc
-    finally:
-        if temp_dir:
-            shutil.rmtree(temp_dir, ignore_errors=True)
-        if stderr_path:
-            stderr_path.unlink(missing_ok=True)
-
-
-def _extract_stderr_detail(stderr_path: Path | None) -> str:
-    if stderr_path and stderr_path.exists():
-        content = stderr_path.read_text().strip()
-        if content:
-            last_lines = "\n".join(content.splitlines()[-10:])
-            return f"stderr (last 10 lines):\n{last_lines}"
-    return "Enable debug-to-stderr for more details."
-
-
-def _build_claude_code_options(
-    workspace_path: Path,
-    eval_config: EvaluationConfig,
-    project_root: Path,
-    trial_dir: Path | None = None,
-) -> tuple[ClaudeCodeOptions, Path | None, Path | None]:
-    allowed_tools = eval_config.allowed_tools or ["Read", "Glob", "Grep"]
-    cwd = str(workspace_path)
-    add_dirs: list[str | Path] = []
-    temp_dir: Path | None = None
-
-    if eval_config.skills_dir:
-        temp_dir = Path(tempfile.mkdtemp(prefix="nasde_eval_"))
-        skills_source = _resolve_path(eval_config.skills_dir, project_root)
-        _prepare_skills_workspace(temp_dir, skills_source)
-        add_dirs.append(str(workspace_path))
-        cwd = str(temp_dir)
-
-    if eval_config.include_trajectory and trial_dir:
-        add_dirs.append(str(trial_dir))
-
-    mcp_servers: dict | str | Path = {}
-    if eval_config.mcp_config:
-        mcp_config_path = _resolve_path(eval_config.mcp_config, project_root)
-        mcp_servers = str(mcp_config_path)
-
-    kwargs: dict = {}
-    if mcp_servers:
-        kwargs["mcp_servers"] = mcp_servers
-    if eval_config.append_system_prompt:
-        kwargs["append_system_prompt"] = eval_config.append_system_prompt
-
-    stderr_file = tempfile.NamedTemporaryFile(  # noqa: SIM115
-        mode="w", prefix="nasde_stderr_", suffix=".log", delete=False
-    )
-    stderr_path = Path(stderr_file.name)
-
-    options = ClaudeCodeOptions(
-        allowed_tools=allowed_tools,
-        cwd=cwd,
-        max_turns=eval_config.max_turns,
-        model=eval_config.model,
-        env={"CLAUDECODE": ""},
-        add_dirs=add_dirs,
-        extra_args={"debug-to-stderr": None},
-        debug_stderr=stderr_file,
-        **kwargs,
-    )
-
-    return options, temp_dir, stderr_path
-
-
-def _prepare_skills_workspace(temp_dir: Path, skills_source: Path) -> None:
-    if not skills_source.is_dir():
-        console.print(f"  [yellow]WARN: skills_dir '{skills_source}' not found or not a directory[/yellow]")
-        return
-    target_skills_dir = temp_dir / ".claude" / "skills"
-    shutil.copytree(skills_source, target_skills_dir)
-
-
-def _resolve_path(relative_or_absolute: str, project_root: Path) -> Path:
-    path = Path(relative_or_absolute)
-    if path.is_absolute():
-        return path
-    return project_root / path
-
-
-def _validate_auth() -> dict[str, str]:
-    env: dict[str, str] = {}
-    for key in ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"):
-        val = os.environ.get(key)
-        if val:
-            env[key] = val
-    if not env:
-        console.print("[red]ERROR: Set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN[/red]")
-        raise SystemExit(1)
-    return env
 
 
 # ---------------------------------------------------------------------------

--- a/src/nasde_toolkit/evaluator_backends/__init__.py
+++ b/src/nasde_toolkit/evaluator_backends/__init__.py
@@ -1,0 +1,24 @@
+"""Pluggable evaluator backends for nasde assessment evaluation."""
+
+from __future__ import annotations
+
+from nasde_toolkit.config import EvaluationConfig
+from nasde_toolkit.evaluator_backends.protocol import EvaluatorBackend
+
+__all__ = ["EvaluatorBackend", "create_backend"]
+
+
+def create_backend(eval_config: EvaluationConfig) -> EvaluatorBackend:
+    if eval_config.backend == "claude":
+        from nasde_toolkit.evaluator_backends.claude_subprocess import ClaudeSubprocessBackend
+
+        return ClaudeSubprocessBackend()
+    elif eval_config.backend == "codex":
+        from nasde_toolkit.evaluator_backends.codex_subprocess import CodexSubprocessBackend
+
+        return CodexSubprocessBackend()
+    else:
+        raise ValueError(
+            f"Unknown evaluator backend: '{eval_config.backend}'. "
+            f"Supported: 'claude', 'codex'"
+        )

--- a/src/nasde_toolkit/evaluator_backends/__init__.py
+++ b/src/nasde_toolkit/evaluator_backends/__init__.py
@@ -18,7 +18,4 @@ def create_backend(eval_config: EvaluationConfig) -> EvaluatorBackend:
 
         return CodexSubprocessBackend()
     else:
-        raise ValueError(
-            f"Unknown evaluator backend: '{eval_config.backend}'. "
-            f"Supported: 'claude', 'codex'"
-        )
+        raise ValueError(f"Unknown evaluator backend: '{eval_config.backend}'. Supported: 'claude', 'codex'")

--- a/src/nasde_toolkit/evaluator_backends/claude_subprocess.py
+++ b/src/nasde_toolkit/evaluator_backends/claude_subprocess.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import shutil
+import tempfile
 from pathlib import Path
 
 from rich.console import Console
@@ -36,9 +38,16 @@ class ClaudeSubprocessBackend:
         trial_dir: Path | None = None,
     ) -> str:
         self.validate_auth()
-        cmd = self._build_command(workspace_path, eval_config, project_root, trial_dir)
+        cmd, temp_dir = self._build_command_with_skills(
+            workspace_path, eval_config, project_root, trial_dir
+        )
         env = self._build_env()
-        return await self._run_subprocess(cmd, prompt, workspace_path, env)
+        cwd = temp_dir if temp_dir else workspace_path
+        try:
+            return await self._run_subprocess(cmd, prompt, cwd, env)
+        finally:
+            if temp_dir:
+                shutil.rmtree(temp_dir, ignore_errors=True)
 
     def validate_auth(self) -> None:
         has_api_key = bool(os.environ.get("ANTHROPIC_API_KEY"))
@@ -46,6 +55,26 @@ class ClaudeSubprocessBackend:
         if not has_api_key and not has_oauth:
             console.print("[red]ERROR: Set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN[/red]")
             raise SystemExit(1)
+
+    def _build_command_with_skills(
+        self,
+        workspace_path: Path,
+        eval_config: EvaluationConfig,
+        project_root: Path,
+        trial_dir: Path | None,
+    ) -> tuple[list[str], Path | None]:
+        cmd = self._build_command(workspace_path, eval_config, project_root, trial_dir)
+        temp_dir: Path | None = None
+
+        if eval_config.skills_dir:
+            skills_source = _resolve_path(eval_config.skills_dir, project_root)
+            temp_dir = Path(tempfile.mkdtemp(prefix="nasde_eval_"))
+            target = temp_dir / ".claude" / "skills"
+            if skills_source.is_dir():
+                shutil.copytree(skills_source, target)
+            cmd.extend(["--add-dir", str(workspace_path)])
+
+        return cmd, temp_dir
 
     def _build_command(
         self,

--- a/src/nasde_toolkit/evaluator_backends/claude_subprocess.py
+++ b/src/nasde_toolkit/evaluator_backends/claude_subprocess.py
@@ -2,13 +2,30 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
+import os
 from pathlib import Path
+
+from rich.console import Console
 
 from nasde_toolkit.config import EvaluationConfig
 
+console = Console()
+
 
 class ClaudeSubprocessBackend:
-    """Evaluator backend that spawns `claude -p` as a subprocess."""
+    """Evaluator backend that spawns `claude -p` as a subprocess.
+
+    Uses `--output-format json` to get structured output with a `result`
+    field containing the agent's text response. Authenticates via whatever
+    credentials are configured (ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN).
+
+    Does NOT use `--bare` mode — preserves OAuth/keychain auth reads
+    (required for subscription-based billing) and auto-discovery of user-level
+    skills. Trades a slightly slower startup for full compatibility with
+    subscription accounts.
+    """
 
     async def run_evaluation(
         self,
@@ -18,7 +35,94 @@ class ClaudeSubprocessBackend:
         project_root: Path,
         trial_dir: Path | None = None,
     ) -> str:
-        raise NotImplementedError
+        self.validate_auth()
+        cmd = self._build_command(workspace_path, eval_config, project_root, trial_dir)
+        env = self._build_env()
+        return await self._run_subprocess(cmd, prompt, workspace_path, env)
 
     def validate_auth(self) -> None:
-        raise NotImplementedError
+        has_api_key = bool(os.environ.get("ANTHROPIC_API_KEY"))
+        has_oauth = bool(os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"))
+        if not has_api_key and not has_oauth:
+            console.print("[red]ERROR: Set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN[/red]")
+            raise SystemExit(1)
+
+    def _build_command(
+        self,
+        workspace_path: Path,
+        eval_config: EvaluationConfig,
+        project_root: Path,
+        trial_dir: Path | None,
+    ) -> list[str]:
+        cmd = [
+            "claude",
+            "-p",
+            "--output-format", "json",
+            "--no-session-persistence",
+            "--model", eval_config.model,
+            "--max-turns", str(eval_config.max_turns),
+        ]
+
+        allowed_tools = eval_config.allowed_tools or ["Read", "Glob", "Grep"]
+        cmd.extend(["--allowedTools", ",".join(allowed_tools)])
+
+        if eval_config.include_trajectory and trial_dir:
+            cmd.extend(["--add-dir", str(trial_dir)])
+
+        if eval_config.mcp_config:
+            mcp_path = _resolve_path(eval_config.mcp_config, project_root)
+            cmd.extend(["--mcp-config", str(mcp_path)])
+
+        if eval_config.append_system_prompt:
+            cmd.extend(["--append-system-prompt", eval_config.append_system_prompt])
+
+        return cmd
+
+    def _build_env(self) -> dict[str, str]:
+        env = dict(os.environ)
+        env.pop("CLAUDECODE", None)
+        return env
+
+    async def _run_subprocess(
+        self,
+        cmd: list[str],
+        prompt: str,
+        workspace_path: Path,
+        env: dict[str, str],
+    ) -> str:
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=str(workspace_path),
+            env=env,
+        )
+        stdout_bytes, stderr_bytes = await process.communicate(input=prompt.encode())
+
+        if process.returncode != 0:
+            stderr_text = stderr_bytes.decode(errors="replace").strip()
+            last_lines = "\n".join(stderr_text.splitlines()[-10:]) if stderr_text else ""
+            model = cmd[cmd.index("--model") + 1]
+            raise RuntimeError(
+                f"Claude Code process failed (exit code {process.returncode}). "
+                f"Model: {model}, cwd: {workspace_path}. "
+                f"stderr (last 10 lines):\n{last_lines}"
+            )
+
+        return _extract_result_text(stdout_bytes.decode())
+
+
+def _resolve_path(relative_or_absolute: str, project_root: Path) -> Path:
+    path = Path(relative_or_absolute)
+    if path.is_absolute():
+        return path
+    return project_root / path
+
+
+def _extract_result_text(stdout: str) -> str:
+    try:
+        data = json.loads(stdout)
+        return data.get("result", "")
+    except json.JSONDecodeError:
+        return stdout

--- a/src/nasde_toolkit/evaluator_backends/claude_subprocess.py
+++ b/src/nasde_toolkit/evaluator_backends/claude_subprocess.py
@@ -1,0 +1,24 @@
+"""Claude Code CLI subprocess evaluator backend."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nasde_toolkit.config import EvaluationConfig
+
+
+class ClaudeSubprocessBackend:
+    """Evaluator backend that spawns `claude -p` as a subprocess."""
+
+    async def run_evaluation(
+        self,
+        prompt: str,
+        workspace_path: Path,
+        eval_config: EvaluationConfig,
+        project_root: Path,
+        trial_dir: Path | None = None,
+    ) -> str:
+        raise NotImplementedError
+
+    def validate_auth(self) -> None:
+        raise NotImplementedError

--- a/src/nasde_toolkit/evaluator_backends/claude_subprocess.py
+++ b/src/nasde_toolkit/evaluator_backends/claude_subprocess.py
@@ -38,9 +38,7 @@ class ClaudeSubprocessBackend:
         trial_dir: Path | None = None,
     ) -> str:
         self.validate_auth()
-        cmd, temp_dir = self._build_command_with_skills(
-            workspace_path, eval_config, project_root, trial_dir
-        )
+        cmd, temp_dir = self._build_command_with_skills(workspace_path, eval_config, project_root, trial_dir)
         env = self._build_env()
         cwd = temp_dir if temp_dir else workspace_path
         try:
@@ -86,10 +84,13 @@ class ClaudeSubprocessBackend:
         cmd = [
             "claude",
             "-p",
-            "--output-format", "json",
+            "--output-format",
+            "json",
             "--no-session-persistence",
-            "--model", eval_config.model,
-            "--max-turns", str(eval_config.max_turns),
+            "--model",
+            eval_config.model,
+            "--max-turns",
+            str(eval_config.max_turns),
         ]
 
         allowed_tools = eval_config.allowed_tools or ["Read", "Glob", "Grep"]
@@ -152,6 +153,7 @@ def _resolve_path(relative_or_absolute: str, project_root: Path) -> Path:
 def _extract_result_text(stdout: str) -> str:
     try:
         data = json.loads(stdout)
-        return data.get("result", "")
     except json.JSONDecodeError:
         return stdout
+    result = data.get("result", "")
+    return result if isinstance(result, str) else ""

--- a/src/nasde_toolkit/evaluator_backends/codex_subprocess.py
+++ b/src/nasde_toolkit/evaluator_backends/codex_subprocess.py
@@ -1,0 +1,24 @@
+"""Codex CLI subprocess evaluator backend."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nasde_toolkit.config import EvaluationConfig
+
+
+class CodexSubprocessBackend:
+    """Evaluator backend that spawns `codex exec` as a subprocess."""
+
+    async def run_evaluation(
+        self,
+        prompt: str,
+        workspace_path: Path,
+        eval_config: EvaluationConfig,
+        project_root: Path,
+        trial_dir: Path | None = None,
+    ) -> str:
+        raise NotImplementedError
+
+    def validate_auth(self) -> None:
+        raise NotImplementedError

--- a/src/nasde_toolkit/evaluator_backends/codex_subprocess.py
+++ b/src/nasde_toolkit/evaluator_backends/codex_subprocess.py
@@ -56,10 +56,7 @@ class CodexSubprocessBackend:
         has_codex_key = bool(os.environ.get("CODEX_API_KEY"))
         has_chatgpt_oauth = _has_chatgpt_oauth()
         if not has_openai_key and not has_codex_key and not has_chatgpt_oauth:
-            console.print(
-                "[red]ERROR: Set OPENAI_API_KEY, CODEX_API_KEY, "
-                "or log in via `codex login`[/red]"
-            )
+            console.print("[red]ERROR: Set OPENAI_API_KEY, CODEX_API_KEY, or log in via `codex login`[/red]")
             raise SystemExit(1)
 
     def _build_command(
@@ -73,8 +70,10 @@ class CodexSubprocessBackend:
             "--json",
             "--full-auto",
             "--skip-git-repo-check",
-            "--color", "never",
-            "--model", eval_config.model,
+            "--color",
+            "never",
+            "--model",
+            eval_config.model,
         ]
         return cmd
 
@@ -118,10 +117,7 @@ def _has_chatgpt_oauth() -> bool:
         raw = json.loads(auth_path.read_text())
     except (json.JSONDecodeError, OSError):
         return False
-    return (
-        raw.get("auth_mode") == "chatgpt"
-        and bool(raw.get("tokens", {}).get("access_token"))
-    )
+    return raw.get("auth_mode") == "chatgpt" and bool(raw.get("tokens", {}).get("access_token"))
 
 
 def _extract_agent_messages(stdout: str) -> str:

--- a/src/nasde_toolkit/evaluator_backends/codex_subprocess.py
+++ b/src/nasde_toolkit/evaluator_backends/codex_subprocess.py
@@ -17,10 +17,11 @@ console = Console()
 class CodexSubprocessBackend:
     """Evaluator backend that spawns `codex exec` as a subprocess.
 
-    Uses `--json` for JSONL event streaming. Extracts the final
-    agent_message from the event stream as the evaluation response.
-    Authenticates via OPENAI_API_KEY, CODEX_API_KEY, or ChatGPT OAuth
-    (`~/.codex/auth.json` created by `codex login`).
+    Uses `--json` for JSONL event streaming on stdout. The CLI writes clean
+    NDJSON to stdout (banner and diagnostics go to stderr), so parsing is
+    straightforward. Extracts the final `agent_message` items as the
+    evaluation response. Authenticates via OPENAI_API_KEY, CODEX_API_KEY, or
+    ChatGPT OAuth (`~/.codex/auth.json` created by `codex login`).
     """
 
     async def run_evaluation(
@@ -33,8 +34,22 @@ class CodexSubprocessBackend:
     ) -> str:
         self.validate_auth()
         cmd = self._build_command(workspace_path, eval_config)
-        cmd.append(prompt)
-        return await self._run_subprocess(cmd, workspace_path)
+        cmd.append("-")
+        env = self._build_env()
+        return await self._run_subprocess(cmd, prompt, workspace_path, env)
+
+    def _build_env(self) -> dict[str, str]:
+        env = dict(os.environ)
+        has_openai_key = bool(env.get("OPENAI_API_KEY"))
+        has_codex_key = bool(env.get("CODEX_API_KEY"))
+        if not has_openai_key and not has_codex_key:
+            return env
+        if _has_chatgpt_oauth() and not has_openai_key:
+            env.pop("CODEX_API_KEY", None)
+            return env
+        if has_codex_key and not has_openai_key:
+            env["OPENAI_API_KEY"] = env["CODEX_API_KEY"]
+        return env
 
     def validate_auth(self) -> None:
         has_openai_key = bool(os.environ.get("OPENAI_API_KEY"))
@@ -56,8 +71,9 @@ class CodexSubprocessBackend:
             "codex",
             "exec",
             "--json",
-            "--quiet",
             "--full-auto",
+            "--skip-git-repo-check",
+            "--color", "never",
             "--model", eval_config.model,
         ]
         return cmd
@@ -65,26 +81,33 @@ class CodexSubprocessBackend:
     async def _run_subprocess(
         self,
         cmd: list[str],
+        prompt: str,
         workspace_path: Path,
+        env: dict[str, str],
     ) -> str:
         process = await asyncio.create_subprocess_exec(
             *cmd,
+            stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=str(workspace_path),
+            env=env,
         )
-        stdout_bytes, stderr_bytes = await process.communicate()
+        stdout_bytes, stderr_bytes = await process.communicate(input=prompt.encode())
 
+        stdout_text = stdout_bytes.decode(errors="replace")
         if process.returncode != 0:
             stderr_text = stderr_bytes.decode(errors="replace").strip()
-            last_lines = "\n".join(stderr_text.splitlines()[-10:]) if stderr_text else ""
+            stderr_tail = "\n".join(stderr_text.splitlines()[-10:]) or "<empty>"
+            stdout_tail = "\n".join(stdout_text.strip().splitlines()[-10:]) or "<empty>"
             raise RuntimeError(
                 f"Codex process failed (exit code {process.returncode}). "
                 f"cwd: {workspace_path}. "
-                f"stderr (last 10 lines):\n{last_lines}"
+                f"stderr (last 10 lines):\n{stderr_tail}\n"
+                f"stdout (last 10 lines):\n{stdout_tail}"
             )
 
-        return _extract_agent_messages(stdout_bytes.decode())
+        return _extract_agent_messages(stdout_text)
 
 
 def _has_chatgpt_oauth() -> bool:

--- a/src/nasde_toolkit/evaluator_backends/codex_subprocess.py
+++ b/src/nasde_toolkit/evaluator_backends/codex_subprocess.py
@@ -2,13 +2,26 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
+import os
 from pathlib import Path
+
+from rich.console import Console
 
 from nasde_toolkit.config import EvaluationConfig
 
+console = Console()
+
 
 class CodexSubprocessBackend:
-    """Evaluator backend that spawns `codex exec` as a subprocess."""
+    """Evaluator backend that spawns `codex exec` as a subprocess.
+
+    Uses `--json` for JSONL event streaming. Extracts the final
+    agent_message from the event stream as the evaluation response.
+    Authenticates via OPENAI_API_KEY, CODEX_API_KEY, or ChatGPT OAuth
+    (`~/.codex/auth.json` created by `codex login`).
+    """
 
     async def run_evaluation(
         self,
@@ -18,7 +31,89 @@ class CodexSubprocessBackend:
         project_root: Path,
         trial_dir: Path | None = None,
     ) -> str:
-        raise NotImplementedError
+        self.validate_auth()
+        cmd = self._build_command(workspace_path, eval_config)
+        cmd.append(prompt)
+        return await self._run_subprocess(cmd, workspace_path)
 
     def validate_auth(self) -> None:
-        raise NotImplementedError
+        has_openai_key = bool(os.environ.get("OPENAI_API_KEY"))
+        has_codex_key = bool(os.environ.get("CODEX_API_KEY"))
+        has_chatgpt_oauth = _has_chatgpt_oauth()
+        if not has_openai_key and not has_codex_key and not has_chatgpt_oauth:
+            console.print(
+                "[red]ERROR: Set OPENAI_API_KEY, CODEX_API_KEY, "
+                "or log in via `codex login`[/red]"
+            )
+            raise SystemExit(1)
+
+    def _build_command(
+        self,
+        workspace_path: Path,
+        eval_config: EvaluationConfig,
+    ) -> list[str]:
+        cmd = [
+            "codex",
+            "exec",
+            "--json",
+            "--quiet",
+            "--full-auto",
+            "--model", eval_config.model,
+        ]
+        return cmd
+
+    async def _run_subprocess(
+        self,
+        cmd: list[str],
+        workspace_path: Path,
+    ) -> str:
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=str(workspace_path),
+        )
+        stdout_bytes, stderr_bytes = await process.communicate()
+
+        if process.returncode != 0:
+            stderr_text = stderr_bytes.decode(errors="replace").strip()
+            last_lines = "\n".join(stderr_text.splitlines()[-10:]) if stderr_text else ""
+            raise RuntimeError(
+                f"Codex process failed (exit code {process.returncode}). "
+                f"cwd: {workspace_path}. "
+                f"stderr (last 10 lines):\n{last_lines}"
+            )
+
+        return _extract_agent_messages(stdout_bytes.decode())
+
+
+def _has_chatgpt_oauth() -> bool:
+    auth_path = Path.home() / ".codex" / "auth.json"
+    if not auth_path.exists():
+        return False
+    try:
+        raw = json.loads(auth_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return False
+    return (
+        raw.get("auth_mode") == "chatgpt"
+        and bool(raw.get("tokens", {}).get("access_token"))
+    )
+
+
+def _extract_agent_messages(stdout: str) -> str:
+    messages: list[str] = []
+    for line in stdout.strip().splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("type") == "item.completed":
+            item = event.get("item", {})
+            if item.get("type") == "agent_message":
+                text = item.get("text", "")
+                if text:
+                    messages.append(text)
+    return "\n".join(messages)

--- a/src/nasde_toolkit/evaluator_backends/protocol.py
+++ b/src/nasde_toolkit/evaluator_backends/protocol.py
@@ -1,0 +1,28 @@
+"""Evaluator backend protocol — defines the interface for CLI-based evaluators."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from nasde_toolkit.config import EvaluationConfig
+
+
+@runtime_checkable
+class EvaluatorBackend(Protocol):
+    """Interface for subprocess-based evaluator backends.
+
+    Each backend spawns a CLI agent (claude, codex, etc.) as a subprocess,
+    passes the evaluation prompt, and returns the agent's text response.
+    """
+
+    async def run_evaluation(
+        self,
+        prompt: str,
+        workspace_path: Path,
+        eval_config: EvaluationConfig,
+        project_root: Path,
+        trial_dir: Path | None = None,
+    ) -> str: ...
+
+    def validate_auth(self) -> None: ...

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from nasde_toolkit.config import load_project_config
+from nasde_toolkit.config import EvaluationConfig, load_project_config
 
 
 def _write_nasde_toml(project_dir: Path, content: str) -> None:
@@ -137,3 +137,23 @@ include_trajectory = true
     )
     config = load_project_config(tmp_path)
     assert config.evaluation.include_trajectory is True
+
+
+def test_evaluation_config_default_backend() -> None:
+    config = EvaluationConfig()
+    assert config.backend == "claude"
+
+
+def test_evaluation_config_codex_backend(tmp_path: Path) -> None:
+    toml_content = """
+[project]
+name = "test"
+
+[evaluation]
+backend = "codex"
+model = "o3"
+"""
+    (tmp_path / "nasde.toml").write_text(toml_content)
+    config = load_project_config(tmp_path)
+    assert config.evaluation.backend == "codex"
+    assert config.evaluation.model == "o3"

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -5,7 +5,21 @@ from __future__ import annotations
 from pathlib import Path
 
 from nasde_toolkit.config import EvaluationConfig
-from nasde_toolkit.evaluator import _build_claude_code_options, _build_evaluator_prompt, _resolve_trajectory_path
+from nasde_toolkit.evaluator import _build_evaluator_prompt, _resolve_trajectory_path
+
+
+def test_evaluate_trial_uses_configured_backend() -> None:
+    """Verify factory returns the right backend type based on config."""
+    from nasde_toolkit.evaluator_backends import create_backend
+
+    claude_config = EvaluationConfig(backend="claude")
+    codex_config = EvaluationConfig(backend="codex")
+
+    claude_backend = create_backend(claude_config)
+    codex_backend = create_backend(codex_config)
+
+    assert type(claude_backend).__name__ == "ClaudeSubprocessBackend"
+    assert type(codex_backend).__name__ == "CodexSubprocessBackend"
 
 
 def test_prompt_no_trajectory_section_when_disabled() -> None:
@@ -32,50 +46,6 @@ def test_prompt_includes_trajectory_section_when_path_provided() -> None:
     assert "## Agent trajectory" in prompt
     assert "../../agent/trajectory.json" in prompt
     assert "ATIF" in prompt
-
-
-def test_claude_code_options_adds_trial_dir_when_trajectory_enabled(tmp_path: Path) -> None:
-    workspace_path = tmp_path / "artifacts" / "workspace"
-    workspace_path.mkdir(parents=True)
-    trial_dir = tmp_path
-
-    eval_config = EvaluationConfig(include_trajectory=True)
-    options, temp_dir, stderr_path = _build_claude_code_options(
-        workspace_path,
-        eval_config,
-        project_root=Path(),
-        trial_dir=trial_dir,
-    )
-    assert str(trial_dir) in [str(d) for d in options.add_dirs]
-
-    if temp_dir:
-        import shutil
-
-        shutil.rmtree(temp_dir, ignore_errors=True)
-    if stderr_path:
-        stderr_path.unlink(missing_ok=True)
-
-
-def test_claude_code_options_no_trial_dir_when_trajectory_disabled(tmp_path: Path) -> None:
-    workspace_path = tmp_path / "artifacts" / "workspace"
-    workspace_path.mkdir(parents=True)
-    trial_dir = tmp_path
-
-    eval_config = EvaluationConfig(include_trajectory=False)
-    options, temp_dir, stderr_path = _build_claude_code_options(
-        workspace_path,
-        eval_config,
-        project_root=Path(),
-        trial_dir=trial_dir,
-    )
-    assert str(trial_dir) not in [str(d) for d in options.add_dirs]
-
-    if temp_dir:
-        import shutil
-
-        shutil.rmtree(temp_dir, ignore_errors=True)
-    if stderr_path:
-        stderr_path.unlink(missing_ok=True)
 
 
 def test_resolve_trajectory_path_returns_none_when_disabled(tmp_path: Path) -> None:

--- a/tests/test_evaluator_backends.py
+++ b/tests/test_evaluator_backends.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pytest
@@ -165,7 +164,10 @@ def test_codex_backend_validate_auth_succeeds_with_codex_api_key(monkeypatch: py
     backend.validate_auth()
 
 
-def test_codex_backend_validate_auth_succeeds_with_chatgpt_oauth(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_codex_backend_validate_auth_succeeds_with_chatgpt_oauth(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("CODEX_API_KEY", raising=False)
     codex_home = tmp_path / ".codex"

--- a/tests/test_evaluator_backends.py
+++ b/tests/test_evaluator_backends.py
@@ -136,6 +136,7 @@ def test_claude_backend_command_includes_skills_dir_setup(tmp_path: Path) -> Non
     assert str(workspace_path) in cmd
 
     import shutil
+
     shutil.rmtree(temp_dir, ignore_errors=True)
 
 
@@ -213,9 +214,7 @@ def test_codex_backend_env_strips_api_keys_when_oauth_present(
 ) -> None:
     codex_home = tmp_path / ".codex"
     codex_home.mkdir()
-    (codex_home / "auth.json").write_text(
-        '{"auth_mode": "chatgpt", "tokens": {"access_token": "tok"}}'
-    )
+    (codex_home / "auth.json").write_text('{"auth_mode": "chatgpt", "tokens": {"access_token": "tok"}}')
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("CODEX_API_KEY", "sk-stale-key-from-dotenv")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -248,9 +247,7 @@ def test_codex_backend_env_preserves_openai_key_priority(
 ) -> None:
     codex_home = tmp_path / ".codex"
     codex_home.mkdir()
-    (codex_home / "auth.json").write_text(
-        '{"auth_mode": "chatgpt", "tokens": {"access_token": "tok"}}'
-    )
+    (codex_home / "auth.json").write_text('{"auth_mode": "chatgpt", "tokens": {"access_token": "tok"}}')
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("OPENAI_API_KEY", "sk-explicit-openai-key")
     monkeypatch.setenv("CODEX_API_KEY", "sk-stale-codex-key")

--- a/tests/test_evaluator_backends.py
+++ b/tests/test_evaluator_backends.py
@@ -8,6 +8,7 @@ import pytest
 from nasde_toolkit.config import EvaluationConfig
 from nasde_toolkit.evaluator_backends import EvaluatorBackend, create_backend
 from nasde_toolkit.evaluator_backends.claude_subprocess import ClaudeSubprocessBackend
+from nasde_toolkit.evaluator_backends.codex_subprocess import CodexSubprocessBackend
 
 
 def test_create_backend_returns_claude_by_default() -> None:
@@ -112,3 +113,53 @@ def test_claude_backend_command_includes_append_system_prompt(tmp_path: Path) ->
     )
     assert "--append-system-prompt" in cmd
     assert "Be strict." in cmd
+
+
+def test_codex_backend_validate_auth_succeeds_with_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+    backend = CodexSubprocessBackend()
+    backend.validate_auth()
+
+
+def test_codex_backend_validate_auth_succeeds_with_codex_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("CODEX_API_KEY", "sk-test-key")
+    backend = CodexSubprocessBackend()
+    backend.validate_auth()
+
+
+def test_codex_backend_validate_auth_succeeds_with_chatgpt_oauth(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("CODEX_API_KEY", raising=False)
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    auth_file = codex_home / "auth.json"
+    auth_file.write_text('{"auth_mode": "chatgpt", "tokens": {"access_token": "tok"}}')
+    monkeypatch.setenv("HOME", str(tmp_path))
+    backend = CodexSubprocessBackend()
+    backend.validate_auth()
+
+
+def test_codex_backend_validate_auth_fails_without_credentials(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("CODEX_API_KEY", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    backend = CodexSubprocessBackend()
+    with pytest.raises(SystemExit):
+        backend.validate_auth()
+
+
+def test_codex_backend_builds_command(tmp_path: Path) -> None:
+    backend = CodexSubprocessBackend()
+    eval_config = EvaluationConfig(backend="codex", model="o3")
+    cmd = backend._build_command(
+        workspace_path=tmp_path,
+        eval_config=eval_config,
+    )
+    assert cmd[0] == "codex"
+    assert "exec" in cmd
+    assert "--json" in cmd
+    assert "--quiet" in cmd
+    assert "--full-auto" in cmd
+    assert "--model" in cmd
+    assert "o3" in cmd

--- a/tests/test_evaluator_backends.py
+++ b/tests/test_evaluator_backends.py
@@ -115,6 +115,43 @@ def test_claude_backend_command_includes_append_system_prompt(tmp_path: Path) ->
     assert "Be strict." in cmd
 
 
+def test_claude_backend_command_includes_skills_dir_setup(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "evaluator_skills" / "my-skill"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "SKILL.md").write_text("# Skill content")
+
+    workspace_path = tmp_path / "workspace"
+    workspace_path.mkdir()
+
+    backend = ClaudeSubprocessBackend()
+    eval_config = EvaluationConfig(skills_dir=str(tmp_path / "evaluator_skills"))
+    cmd, temp_dir = backend._build_command_with_skills(
+        workspace_path=workspace_path,
+        eval_config=eval_config,
+        project_root=tmp_path,
+        trial_dir=None,
+    )
+    assert temp_dir is not None
+    assert (temp_dir / ".claude" / "skills" / "my-skill" / "SKILL.md").exists()
+    assert "--add-dir" in cmd
+    assert str(workspace_path) in cmd
+
+    import shutil
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_claude_backend_no_skills_returns_no_temp_dir(tmp_path: Path) -> None:
+    backend = ClaudeSubprocessBackend()
+    eval_config = EvaluationConfig()  # no skills_dir
+    cmd, temp_dir = backend._build_command_with_skills(
+        workspace_path=tmp_path,
+        eval_config=eval_config,
+        project_root=tmp_path.parent,
+        trial_dir=None,
+    )
+    assert temp_dir is None
+
+
 def test_codex_backend_validate_auth_succeeds_with_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
     backend = CodexSubprocessBackend()

--- a/tests/test_evaluator_backends.py
+++ b/tests/test_evaluator_backends.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
 
 from nasde_toolkit.config import EvaluationConfig
 from nasde_toolkit.evaluator_backends import EvaluatorBackend, create_backend
+from nasde_toolkit.evaluator_backends.claude_subprocess import ClaudeSubprocessBackend
 
 
 def test_create_backend_returns_claude_by_default() -> None:
@@ -24,3 +26,89 @@ def test_create_backend_raises_on_unknown() -> None:
     config = EvaluationConfig(backend="unknown-agent")
     with pytest.raises(ValueError, match="Unknown evaluator backend"):
         create_backend(config)
+
+
+def test_claude_backend_validate_auth_succeeds_with_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    backend = ClaudeSubprocessBackend()
+    backend.validate_auth()
+
+
+def test_claude_backend_validate_auth_succeeds_with_oauth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-oat-test")
+    backend = ClaudeSubprocessBackend()
+    backend.validate_auth()
+
+
+def test_claude_backend_validate_auth_fails_without_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    backend = ClaudeSubprocessBackend()
+    with pytest.raises(SystemExit):
+        backend.validate_auth()
+
+
+def test_claude_backend_builds_command(tmp_path: Path) -> None:
+    backend = ClaudeSubprocessBackend()
+    eval_config = EvaluationConfig(model="claude-sonnet-4-6", max_turns=10)
+    cmd = backend._build_command(
+        workspace_path=tmp_path,
+        eval_config=eval_config,
+        project_root=tmp_path.parent,
+        trial_dir=None,
+    )
+    assert cmd[0] == "claude"
+    assert "-p" in cmd
+    assert "--output-format" in cmd
+    assert "json" in cmd
+    assert "--model" in cmd
+    assert "claude-sonnet-4-6" in cmd
+    assert "--max-turns" in cmd
+    assert "10" in cmd
+    assert "--bare" not in cmd
+    assert "--allowedTools" in cmd
+
+
+def test_claude_backend_command_includes_add_dir_for_trajectory(tmp_path: Path) -> None:
+    trial_dir = tmp_path / "trial"
+    trial_dir.mkdir()
+    backend = ClaudeSubprocessBackend()
+    eval_config = EvaluationConfig(include_trajectory=True)
+    cmd = backend._build_command(
+        workspace_path=tmp_path,
+        eval_config=eval_config,
+        project_root=tmp_path.parent,
+        trial_dir=trial_dir,
+    )
+    assert "--add-dir" in cmd
+    assert str(trial_dir) in cmd
+
+
+def test_claude_backend_command_includes_mcp_config(tmp_path: Path) -> None:
+    mcp_file = tmp_path / "mcp.json"
+    mcp_file.write_text("{}")
+    backend = ClaudeSubprocessBackend()
+    eval_config = EvaluationConfig(mcp_config=str(mcp_file))
+    cmd = backend._build_command(
+        workspace_path=tmp_path,
+        eval_config=eval_config,
+        project_root=tmp_path.parent,
+        trial_dir=None,
+    )
+    assert "--mcp-config" in cmd
+    assert str(mcp_file) in cmd
+
+
+def test_claude_backend_command_includes_append_system_prompt(tmp_path: Path) -> None:
+    backend = ClaudeSubprocessBackend()
+    eval_config = EvaluationConfig(append_system_prompt="Be strict.")
+    cmd = backend._build_command(
+        workspace_path=tmp_path,
+        eval_config=eval_config,
+        project_root=tmp_path.parent,
+        trial_dir=None,
+    )
+    assert "--append-system-prompt" in cmd
+    assert "Be strict." in cmd

--- a/tests/test_evaluator_backends.py
+++ b/tests/test_evaluator_backends.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nasde_toolkit.config import EvaluationConfig
+from nasde_toolkit.evaluator_backends import EvaluatorBackend, create_backend
+
+
+def test_create_backend_returns_claude_by_default() -> None:
+    config = EvaluationConfig()
+    backend = create_backend(config)
+    assert isinstance(backend, EvaluatorBackend)
+
+
+def test_create_backend_returns_codex_when_configured() -> None:
+    config = EvaluationConfig(backend="codex")
+    backend = create_backend(config)
+    assert isinstance(backend, EvaluatorBackend)
+
+
+def test_create_backend_raises_on_unknown() -> None:
+    config = EvaluationConfig(backend="unknown-agent")
+    with pytest.raises(ValueError, match="Unknown evaluator backend"):
+        create_backend(config)

--- a/tests/test_evaluator_backends.py
+++ b/tests/test_evaluator_backends.py
@@ -198,7 +198,65 @@ def test_codex_backend_builds_command(tmp_path: Path) -> None:
     assert cmd[0] == "codex"
     assert "exec" in cmd
     assert "--json" in cmd
-    assert "--quiet" in cmd
     assert "--full-auto" in cmd
+    assert "--skip-git-repo-check" in cmd
+    assert "--color" in cmd
+    assert "never" in cmd
     assert "--model" in cmd
     assert "o3" in cmd
+    assert "--quiet" not in cmd
+
+
+def test_codex_backend_env_strips_api_keys_when_oauth_present(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text(
+        '{"auth_mode": "chatgpt", "tokens": {"access_token": "tok"}}'
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CODEX_API_KEY", "sk-stale-key-from-dotenv")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    backend = CodexSubprocessBackend()
+    env = backend._build_env()
+
+    assert "CODEX_API_KEY" not in env
+    assert "OPENAI_API_KEY" not in env
+
+
+def test_codex_backend_env_promotes_codex_key_to_openai_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CODEX_API_KEY", "sk-codex-key")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    backend = CodexSubprocessBackend()
+    env = backend._build_env()
+
+    assert env["OPENAI_API_KEY"] == "sk-codex-key"
+    assert env["CODEX_API_KEY"] == "sk-codex-key"
+
+
+def test_codex_backend_env_preserves_openai_key_priority(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text(
+        '{"auth_mode": "chatgpt", "tokens": {"access_token": "tok"}}'
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-explicit-openai-key")
+    monkeypatch.setenv("CODEX_API_KEY", "sk-stale-codex-key")
+
+    backend = CodexSubprocessBackend()
+    env = backend._build_env()
+
+    assert env["OPENAI_API_KEY"] == "sk-explicit-openai-key"
+    assert env.get("CODEX_API_KEY") == "sk-stale-codex-key"

--- a/uv.lock
+++ b/uv.lock
@@ -412,19 +412,6 @@ wheels = [
 ]
 
 [[package]]
-name = "claude-code-sdk"
-version = "0.0.25"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "mcp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/0d/0f4a71415826578a5ace16817c52df84d76ffbda5cdad02f520a2b963bde/claude_code_sdk-0.0.25.tar.gz", hash = "sha256:0d9e1eba432d4fe8a2f75f06ec9bb4c310f39b1d55246e7e4b2c69bfdd69eab3", size = 41273, upload-time = "2025-09-29T20:14:51.882Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/41/c934058080f3233bbc95bc9abac5e0191bf336ad5f69a33b5f54a4737e88/claude_code_sdk-0.0.25-py3-none-any.whl", hash = "sha256:3d6a4ef958182f311d6050776d2675d9b39650a2db221c582a0a5156472dcee3", size = 31031, upload-time = "2025-09-29T20:14:50.687Z" },
-]
-
-[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1720,7 +1707,6 @@ wheels = [
 name = "nasde-toolkit"
 source = { editable = "." }
 dependencies = [
-    { name = "claude-code-sdk" },
     { name = "harbor" },
     { name = "opik" },
     { name = "platformdirs" },
@@ -1737,7 +1723,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "claude-code-sdk", specifier = ">=0.0.25,<1" },
     { name = "harbor", specifier = ">=0.1.40,<0.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14" },
     { name = "opik", specifier = ">=1.10,<2" },


### PR DESCRIPTION
## Summary

- Replace `claude-code-sdk` Python dependency with subprocess-based evaluator backends, bypassing Anthropic's Agent SDK billing restrictions that forbid OAuth subscription auth
- Introduce `EvaluatorBackend` Protocol with `ClaudeSubprocessBackend` (`claude -p --output-format json`) and `CodexSubprocessBackend` (`codex exec --json --full-auto`) implementations
- Add `[evaluation] backend = "claude" | "codex"` config option, defaulting to `"claude"` for backward compatibility
- Preserve all existing evaluator features: trajectory-aware scoring, skills_dir auto-discovery, MCP config, append_system_prompt, per-trial Opik upload

## Why

Anthropic's February 2026 policy change explicitly prohibits using Claude subscription OAuth tokens (Pro/Max `CLAUDE_CODE_OAUTH_TOKEN`) with the Agent SDK — programmatic SDK calls must use API keys, billed separately. The SDK also requires `claude-code-sdk==0.0.25` (abandoned Sept 2025).

By spawning the user's existing `claude` / `codex` CLI binary as a subprocess, the evaluator gets the same billing treatment as interactive use: OAuth subscription quotas apply naturally, no pay-per-token API costs, and the SDK-abandonment risk disappears.

## Architecture

```
evaluator.py (orchestration, prompt, parsing, Opik)
     │
     ▼
create_backend(eval_config) ──► EvaluatorBackend Protocol
                                     │
                     ┌───────────────┴───────────────┐
                     ▼                               ▼
         ClaudeSubprocessBackend         CodexSubprocessBackend
         `claude -p --output-format      `codex exec --json
          json`                           --full-auto`
```

- Claude backend: uses `--output-format json` (not `--bare`) to preserve OAuth/keychain reads and skills auto-discovery from `.claude/skills/`.
- Codex backend: uses `--json` NDJSON output, extracts `agent_message` items. Respects OAuth priority — strips any stale `CODEX_API_KEY` (Harbor auto-loads `.env` which can leak it) when `~/.codex/auth.json` has ChatGPT tokens.

## Verification

- **Unit tests**: 113 total, including 20 new tests in `tests/test_evaluator_backends.py` covering auth paths, command construction, trajectory integration, skills_dir setup, and OAuth priority logic.
- **End-to-end Claude eval**: `nasde eval` on existing trial (`csharp-anemic-to-rich-domain__3NXo9dd`) scored 49/100 with trajectory-aware scoring, using `CLAUDE_CODE_OAUTH_TOKEN` (Max subscription).
- **End-to-end Codex eval**: `nasde eval` on existing trial (`add-multi-attempt-support__tRTe7QX`) scored 68/100 using ChatGPT OAuth (`~/.codex/auth.json`) — validated that stale `CODEX_API_KEY` from `.env` no longer hijacks billing.
- **Cross-vendor full run**: `nasde run --variant claude-nasde-dev-with-testing --tasks add-multi-attempt-support` with `backend = "codex"` config — Claude agent produced workspace + trajectory in Docker; Codex evaluator scored 76/100 with trajectory-aware scoring (`verification_discipline: 8/25` — evaluator inspected trajectory to assess process discipline).
- **Lint**: `ruff check` and `ruff format --check` clean. mypy strict passes.

## Follow-up (not in this PR)

- CLI version check at backend start (warn/error if `claude` or `codex` below minimum supported version) — tracked as task to prevent silent breakage from flag removals like Codex's `--quiet` in 0.121.0.

## Test plan

- [x] `uv run pytest` — 113/113 pass
- [x] `uvx ruff format --check src/ tests/ && uvx ruff check src/ tests/` — clean
- [x] `uvx mypy src/nasde_toolkit/` — clean
- [x] `nasde eval <job-dir>` end-to-end with Claude backend + `CLAUDE_CODE_OAUTH_TOKEN` on an existing trial
- [x] `nasde eval <job-dir>` end-to-end with Codex backend + ChatGPT OAuth on an existing trial
- [x] `nasde run` cross-vendor (Claude agent in Docker + Codex evaluator) on a single task with trajectory-aware scoring — produced 76/100 with `verification_discipline` grounded in trajectory evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)