### PR TITLE
docs: add CHANGELOG, SECURITY, RELEASING + README nudges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,141 @@
+# Changelog
+
+All notable changes to **nasde-toolkit** are documented in this file.
+
+The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+
+See [docs/RELEASING.md](docs/RELEASING.md) for the release procedure.
+
+## [Unreleased]
+
+### Changed
+- Modernized dependencies: `harbor` 0.1.45 → 0.4.0, `opik` 1.10.39 → 2.0.9.
+  Brings upstream bugfixes and removes a long-standing Opik monkey-patch that
+  is no longer needed. `ConfigurableCodex` simplified by ~80 LOC thanks to
+  Harbor 0.4 adding first-class support for files-to-inject. ([#25])
+- Default reviewer model bumped to `claude-opus-4-7` across README, ARCHITECTURE,
+  bundled `nasde-benchmark-runner` skill, and example benchmarks
+  (`ddd-architectural-challenges`, `refactoring-skill`). `nasde-dev-skill`
+  stays on Sonnet 4.6 as documented in [benchmark results](docs/benchmark-results.md).
+
+### Security
+- Added `pip-audit` as a CI gate. Fixes 20 known CVEs across the transitive
+  dependency tree, including 1 CRITICAL and 3 HIGH in `litellm` / `cbor2`.
+  New vulnerabilities will now fail the quality gate instead of shipping
+  silently. ([#25])
+
+### Docs
+- README: unified "what NASDE does" opener around four steps, mentioning the
+  rough `test.sh` pass/fail gate that precedes LLM-as-a-judge scoring.
+- README: scoring section now calls out that criteria can cover the agent's
+  run-time signals — tool-call trajectory, token usage, wall-clock duration —
+  alongside the produced artifacts.
+
+## [0.2.0] — 2026-04-22
+
+### Added
+- **Subprocess evaluator backends.** The LLM-as-a-judge reviewer now runs as
+  a subprocess against the installed `claude` or `codex` CLI instead of going
+  through the Anthropic Agent SDK. Select with `[evaluation] backend` in
+  `nasde.toml` (`"claude"` default, `"codex"` available). This unlocks
+  subscription billing (Claude Max, ChatGPT Plus) for local evaluation, and
+  picks up the user's existing OAuth/keychain auth without extra config. ([#24])
+- **Bundled authoring skills.** `nasde install-skills` copies the
+  `nasde-benchmark-*` skills into `~/.claude/skills/` so they're available in
+  every Claude Code session. `--scope project` and `--force` flags supported.
+- **Trajectory-aware evaluation.** Set `[evaluation] include_trajectory = true`
+  to give the reviewer access to the agent's ATIF trajectory
+  (`agent/trajectory.json`) alongside the final workspace — lets criteria
+  reward *how* the agent arrived at the result, not just the result itself. ([#22])
+- **MCP server configuration per variant.** Drop a `claude_config.json` into
+  a variant directory to wire up MCP servers for that variant's agent runs.
+
+### Changed
+- README rewritten for a developer audience: problem-first framing, explicit
+  "why NASDE" section, reference point for how the rubric concept maps to
+  familiar engineering practice.
+- `nasde eval` now forwards the full `[evaluation]` config from `nasde.toml`
+  to the post-hoc evaluator (previously some keys were dropped). ([#23])
+
+### Fixed
+- Evaluator now captures a real stderr file descriptor, surfacing actual
+  error output when the subprocess fails.
+- Clearer diagnostics when the evaluator's Claude Code process exits non-zero.
+- `scripts/export_*_oauth_token.sh` no longer use `set -e`, so sourcing them
+  into a shell that hits an error no longer kills the terminal.
+
+## [0.1.1] — 2026-03-26
+
+### Added
+- Noesis Vision, CI status, and License badges in the README header.
+- Stable-vs-HEAD installation instructions: `@v0.1.1` for pinned installs,
+  `@main` for bleeding edge.
+
+### Changed
+- Version is now derived from git tags via `hatch-vcs` — no more hand-edited
+  `version = "…"` in `pyproject.toml`. `_version.py` is auto-generated and
+  gitignored. See [ADR-007](docs/adr/).
+
+### Fixed
+- `_version.py` correctly excluded from ruff and mypy (no more noisy lint
+  output on generated code).
+- Removed auto-generated `harbor_config.json` from shipped examples — it was
+  leaking per-machine absolute paths into the repo.
+
+## [0.1.0] — 2026-03-26
+
+Initial release under the **nasde-toolkit** name (rebrand from
+`sdlc-eval-kit`). This is the first version intended for outside use.
+
+### Added
+- **`nasde` CLI** with `init`, `run`, `eval`, `install-skills`, plus
+  pass-throughs for `nasde harbor …` and `nasde opik …`.
+- **Harbor Python API integration.** The runner builds `JobConfig` directly
+  and calls `await job.run()`, replacing the earlier subprocess dance. Trial
+  lifecycle, variant resolution, and sandbox execution all go through
+  Harbor.
+- **Cloud sandbox providers.** `--harbor-env` selects `docker` (default),
+  `daytona`, `modal`, `e2b`, `runloop`, or `gke` for where the agent trial
+  runs. Same benchmark, any backend.
+- **Assessment evaluation on by default** — LLM-as-a-judge reviewer runs
+  after every trial unless `--without-eval` is passed. Results land in
+  `assessment_eval.json` per trial and upload to Opik when `--with-opik`
+  is set.
+- **Three agent types:** Claude Code, Codex (OpenAI), and Gemini CLI. Each
+  with its own sandbox file-injection path (`CLAUDE.md` / `AGENTS.md` /
+  `GEMINI.md`) and OAuth support (ChatGPT subscription for Codex, Google
+  account for Gemini).
+- **Auto-generated Dockerfile.** When a task has no
+  `environment/Dockerfile`, `nasde` generates one from `source.git` and
+  `[docker]` config in `nasde.toml`. Local paths get a
+  `docker-compose.yaml` override for the build context.
+- **Skill snapshots per variant.** `variants/<name>/skills/`,
+  `agents_skills/`, and `gemini_skills/` directories are injected into the
+  agent's sandbox so benchmarks stay deterministic across runs.
+- **Benchmark-authoring skills.** `nasde-benchmark-creator`,
+  `nasde-benchmark-from-history`, `nasde-benchmark-from-public-repos`, and
+  `nasde-benchmark-runner` for building and running benchmark suites from
+  inside Claude Code.
+- **Docs.** `ARCHITECTURE.md` (end-to-end flow with diagrams),
+  `docs/use-cases.md` (worked examples), `docs/benchmark-results.md`
+  (reference numbers), ADRs for key decisions, MIT license,
+  Noesis-branded ASCII banner.
+- **CI pipeline.** GitHub Actions for quality gate (lint, typecheck,
+  tests), example validation, and dogfooding.
+- **Parallel runs and retries.** `--all-variants` for Cartesian product
+  runs, `--attempts/-n` for multi-attempt per task, per-trial streaming
+  hooks for Opik.
+
+### Notes
+- `v0.1.0` represents the first public-oriented baseline; earlier commits
+  on the `sdlc-eval-kit` history are not cataloged here.
+
+[Unreleased]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/NoesisVision/nasde-toolkit/releases/tag/v0.1.0
+[#22]: https://github.com/NoesisVision/nasde-toolkit/pull/22
+[#23]: https://github.com/NoesisVision/nasde-toolkit/pull/23
+[#24]: https://github.com/NoesisVision/nasde-toolkit/pull/24
+[#25]: https://github.com/NoesisVision/nasde-toolkit/pull/25

--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ After installation, only `nasde` appears on PATH. Harbor and Opik are bundled as
 
 Check the installed version with `nasde --version`. Stable releases follow semver tags (e.g. `v0.2.0`); dev installs show versions like `0.2.1.dev3+gabcdef`.
 
+Release notes for every tagged version live in [CHANGELOG.md](CHANGELOG.md). See [docs/RELEASING.md](docs/RELEASING.md) if you're cutting a release yourself.
+
 ## CLI cheatsheet
 
 Most users only need `nasde run` — everything else is occasional. See [Commands](#commands) below for the full reference.
@@ -657,3 +659,7 @@ Expected feedback scores after a full run with `--with-opik`:
 Have questions, want to share your benchmarks, or discuss AI agent evaluation strategies? Join our Discord community — we'd love to hear from you!
 
 [![Discord](https://img.shields.io/badge/Discord-Join%20Community-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/QF5PMX4Dqg)
+
+## Security
+
+Found a security issue? Please report it privately — see [SECURITY.md](SECURITY.md) for the reporting channels, response timeline, and what's in scope.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,120 @@
+# Security Policy
+
+Thanks for taking the time to help keep **nasde-toolkit** safe for everyone
+who uses it. This document describes what we consider a vulnerability, how to
+report one, and what to expect in return.
+
+## Supported Versions
+
+nasde-toolkit is maintained by a small team. **Only the latest released
+version receives security fixes.** If you're on an older release, the upgrade
+path is part of the fix.
+
+| Version | Supported |
+|---------|-----------|
+| Latest release (see [CHANGELOG.md](CHANGELOG.md)) | ✅ |
+| Older tagged releases                            | ❌ |
+| `main` branch                                    | Best-effort (dev channel) |
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for a suspected vulnerability.
+Use one of the following private channels instead:
+
+1. **Preferred — GitHub Security Advisories.**
+   Open a private advisory at
+   <https://github.com/NoesisVision/nasde-toolkit/security/advisories/new>.
+   This gives us a shared workspace to triage the report and coordinate a fix
+   without disclosing the issue to the public feed.
+
+2. **Email.**
+   If the repo security tab is not available to you, send a report to
+   **<szymon@noesis-vision.com>** with the subject prefix
+   `[nasde-toolkit security]`.
+
+Please include, to the extent you can:
+
+- A description of the issue and the impact you believe it has.
+- Steps to reproduce (a minimal benchmark project or command line helps a lot).
+- The nasde-toolkit version (`nasde --version`) and the platform
+  (`uname -a`, Python version, container runtime).
+- Your suggested severity and any proposed mitigation.
+
+## Response Timeline
+
+Because this project is maintained by one person most weeks, we aim for a
+realistic SLA rather than a formal one:
+
+- **Initial acknowledgement:** within **7 calendar days** of receiving a
+  report.
+- **Triage outcome** (confirmed / not-a-vulnerability / need-more-info):
+  within **14 calendar days**.
+- **Patch and release:** on a case-by-case basis. Critical and High-severity
+  issues that affect the latest release are prioritized above all other work.
+
+If you don't hear back within 7 days, please resend via the other channel —
+email can get lost in spam, and GitHub notifications occasionally slip past.
+
+## Scope
+
+### In scope
+
+Issues in **nasde-toolkit itself**, including:
+
+- **CLI handling** — argument parsing, subprocess invocation, command
+  injection via task / variant config files (`nasde.toml`, `task.json`,
+  `variant.toml`, `harbor_config.json`, `claude_config.json`).
+- **Sandbox file injection** — the `sandbox_files` mapping in the
+  Configurable{Claude,Codex,Gemini} agents and the way skills / MCP configs
+  are materialized inside the agent container.
+- **Authentication handling** — OAuth token plumbing for `claude`, `codex`,
+  and `gemini` CLIs; `scripts/export_*_oauth_token.sh`; how credentials
+  cross the host/sandbox boundary.
+- **Evaluator backends** — subprocess invocation of `claude -p` and
+  `codex exec`, handling of trial artifacts (`assessment_eval.json`,
+  trajectory files), and any path traversal or deserialization risk in
+  processing them.
+- **Auto-generated Dockerfile / docker-compose** — anything in
+  `docker.py:ensure_task_environment()` that could let a crafted `task.json`
+  escape the intended build context.
+- **Reporting integrations** — Opik upload path, Harbor-span patching,
+  anything that could leak secrets into external systems.
+
+### Out of scope / report upstream
+
+- **Vulnerabilities in transitive dependencies** (`harbor`, `opik`,
+  `litellm`, etc.). Report these to the upstream project directly. We
+  monitor these via `pip-audit` in CI and will upgrade promptly, but fixes
+  belong upstream.
+- **The `claude`, `codex`, and `gemini` CLIs themselves.** Report to
+  Anthropic / OpenAI / Google respectively.
+- **Issues that require an attacker to already have `nasde` running
+  arbitrary local code.** nasde-toolkit runs trusted benchmark definitions
+  on the user's own machine; a malicious `task.json` from an untrusted
+  source is out of scope *unless* it can escape the agent sandbox or
+  exfiltrate credentials beyond what running the CLI itself would allow.
+- **Denial-of-service** against a user's own workstation (a task that
+  consumes a lot of CPU is not a security issue).
+
+If you're not sure whether something is in scope, send it anyway — we'd
+rather review an out-of-scope report than miss a real one.
+
+## Disclosure Policy
+
+We follow **coordinated disclosure**:
+
+1. You report privately via one of the channels above.
+2. We confirm, work on a fix, and agree on a disclosure window with you.
+3. Once a patched release is out, we publish a GitHub Security Advisory
+   crediting you (unless you'd rather stay anonymous).
+
+We do not have a fixed disclosure clock — how long we need depends on the
+fix. We will keep you informed and won't sit on a confirmed issue.
+
+## Credit
+
+Reporters are credited in the resulting GitHub Security Advisory and in
+[CHANGELOG.md](CHANGELOG.md) under the `### Security` section, unless you
+ask to be left anonymous.
+
+Thanks again.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -65,6 +65,26 @@ change to those three is a major bump.
 - Any `### Added` or `### Changed` → at least a minor bump.
 - A `### Removed` entry or a `### Changed` marked *(breaking)* → major bump.
 
+**Dependency upgrades follow the impact on the user, not the upstream
+semver.** A `harbor 0.1 → 0.4` or `opik 1 → 2` in our lockfile is an
+implementation detail as long as the user's benchmark still runs the same
+way. Apply these three cases:
+
+- **Transitive or internal dep bump with no visible behavior change** →
+  patch. The user's `nasde.toml`, benchmark layout, and CLI output are
+  unchanged. The CVE noise in `### Security` and the lockfile churn in
+  `### Changed` stay in a patch release.
+- **Dep bump that changes `nasde.toml` schema, CLI output, benchmark
+  project layout, or the format of trial artifacts** → at least minor.
+  The user has to do something or notices something different.
+- **Dep bump that drops a supported integration or breaks existing
+  benchmarks** (e.g. Harbor drops a sandbox provider we exposed via
+  `--harbor-env`) → major.
+
+The rule is "what does the person running `nasde run` see differently",
+not "did an upstream major bump". Otherwise every quarterly refresh of
+`uv.lock` would push us toward `v2.x` without adding features.
+
 **How the version is actually set.** We use
 [`hatch-vcs`](https://github.com/ofek/hatch-vcs) (see
 `pyproject.toml` → `[tool.hatch.version] source = "vcs"`). The version is

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,288 @@
+# Releasing nasde-toolkit
+
+This document describes how to cut a new release of nasde-toolkit. It is
+written so that **a contributor who has never released before can follow it
+end-to-end without asking questions**. If you hit a step that's unclear or
+out of date, fix the doc in the same PR as the release.
+
+## TL;DR
+
+```bash
+# 1. Start from a clean, green main
+git checkout main && git pull
+
+# 2. Move [Unreleased] section under the new version header in CHANGELOG.md,
+#    add a fresh empty [Unreleased] block, update compare links at the bottom
+$EDITOR CHANGELOG.md
+
+# 3. Commit the changelog and push the PR
+git checkout -b chore/release-vX.Y.Z
+git add CHANGELOG.md
+git commit -m "chore: release vX.Y.Z"
+git push -u origin chore/release-vX.Y.Z
+gh pr create --fill
+
+# 4. Merge the PR once CI is green, then tag and push from main
+git checkout main && git pull
+git tag vX.Y.Z
+git push origin vX.Y.Z
+
+# 5. Publish the GitHub Release from the tag
+gh release create vX.Y.Z \
+  --title "vX.Y.Z — <one-line theme>" \
+  --notes-file .release-notes.tmp \
+  --latest
+
+# Optional sanity check: version derived from the tag
+uv build
+ls dist/    # should contain nasde_toolkit-X.Y.Z-*.whl and *.tar.gz
+```
+
+The rest of this document explains each step, how to pick the version
+number, how to hotfix an older release, and what **not** to do.
+
+## Versioning
+
+nasde-toolkit follows [Semantic Versioning 2.0.0](https://semver.org/) and
+its [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) section
+convention.
+
+| Bump      | When                                                                       | Example       |
+|-----------|-----------------------------------------------------------------------------|---------------|
+| **Major** | Breaking change for users of the CLI, config, or benchmark project layout | `0.2.3 → 1.0.0` |
+| **Minor** | Backwards-compatible new feature, or a meaningful change in behavior      | `0.1.4 → 0.2.0` |
+| **Patch** | Backwards-compatible bugfix or doc-only change                            | `0.2.0 → 0.2.1` |
+
+**Pre-1.0 policy.** While we're on `0.x`, a minor bump (`0.x → 0.(x+1)`) is
+allowed to contain breaking changes to *internal* APIs or to evaluator /
+runner internals, as long as the **user-facing CLI, `nasde.toml` schema,
+and benchmark project layout** stay backwards-compatible. Any breaking
+change to those three is a major bump.
+
+**`CHANGELOG.md` section → bump rule of thumb:**
+
+- Only `### Fixed`, `### Docs`, or `### Security` entries → patch bump.
+- Any `### Added` or `### Changed` → at least a minor bump.
+- A `### Removed` entry or a `### Changed` marked *(breaking)* → major bump.
+
+**How the version is actually set.** We use
+[`hatch-vcs`](https://github.com/ofek/hatch-vcs) (see
+`pyproject.toml` → `[tool.hatch.version] source = "vcs"`). The version is
+derived from the latest annotated git tag at build time. **Do not edit a
+`version = "…"` line** — there isn't one, and adding one would break the
+build. `src/nasde_toolkit/_version.py` is auto-generated and gitignored.
+
+This means:
+
+- Between releases, dev builds carry a version like `0.2.1.dev3+gabcdef`.
+- As soon as you create tag `vX.Y.Z`, any build from that tag resolves to
+  exactly `X.Y.Z`.
+- Tags **must** follow the `vMAJOR.MINOR.PATCH` pattern (lowercase `v`,
+  no suffixes) for `hatch-vcs` to interpret them as release versions.
+
+## Pre-flight checklist
+
+Before you start the release commit, confirm on `main`:
+
+- [ ] **CI is green on main.** Open the Actions tab and check the latest
+      run of `quality-gate.yml`. All of `lint`, `typecheck`, `test`,
+      `audit`, `validate-configs`, and `docker-smoke` must be passing.
+- [ ] **`example-validation.yml` is green on main** — the examples still
+      build and run.
+- [ ] **No `### Unreleased` entries are in a half-finished state.** If
+      something is still in review, either land it first or leave it out
+      of this release and bump the PR description to target the next one.
+- [ ] **`pip-audit` shows zero known vulnerabilities** (the quality gate
+      already enforces this; double-check locally with
+      `uv run pip-audit` if you're paranoid).
+- [ ] **Working tree is clean** — `git status` should be spotless.
+
+If any of those fail: **do not release**. Fix the underlying issue in a
+separate PR first.
+
+## Step 1 — Update `CHANGELOG.md`
+
+The source of truth for what's in each release is `CHANGELOG.md`.
+
+1. Open `CHANGELOG.md`. Under `## [Unreleased]` you'll find entries
+   accumulated since the last tag.
+2. Rename the section header to the new version and add today's date
+   (ISO 8601):
+
+   ```diff
+   -## [Unreleased]
+   +## [Unreleased]
+   +
+   +## [0.2.1] — 2026-05-04
+   ```
+
+3. Scan the moved entries. Make sure each one is:
+   - **User-facing.** "Refactored internal cache" isn't worth listing;
+     "`nasde eval` now forwards `[evaluation]` config" is.
+   - **One sentence.** Link to the PR (`([#25])`) for detail.
+   - **In the right section.** `### Added` / `### Changed` / `### Fixed` /
+     `### Removed` / `### Security` / `### Docs`.
+
+4. At the bottom of the file, add a new compare link for the version and
+   shift `[Unreleased]`:
+
+   ```diff
+   -[Unreleased]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.2.0...HEAD
+   +[Unreleased]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.2.1...HEAD
+   +[0.2.1]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.2.0...v0.2.1
+   ```
+
+5. Open a PR titled `chore: release vX.Y.Z`. The PR body should be the
+   changelog section for this release, so reviewers see exactly what
+   goes out.
+
+6. **Wait for CI to go green, then merge.** Prefer a squash merge so the
+   release commit is a single entry.
+
+## Step 2 — Tag and push
+
+After the changelog PR is merged:
+
+```bash
+git checkout main
+git pull
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+Notes:
+
+- **Always tag `main` after the changelog merge**, not the PR branch.
+- **Do not push a tag with `git push --tags`** — push the single tag by
+  name. This avoids accidentally publishing stale local tags.
+- The tag triggers no workflow today. `hatch-vcs` picks up the tag at
+  build time; nothing else is automated yet.
+
+## Step 3 — Create the GitHub Release
+
+```bash
+# Extract the notes for this version from CHANGELOG.md
+awk "/^## \\[X\\.Y\\.Z\\]/,/^## \\[/" CHANGELOG.md \
+  | sed '$d' > .release-notes.tmp     # drop trailing "## [" of next section
+
+gh release create vX.Y.Z \
+  --title "vX.Y.Z — <one-line theme>" \
+  --notes-file .release-notes.tmp \
+  --latest
+
+rm .release-notes.tmp
+```
+
+The `--latest` flag controls what users see on the repo homepage. Always
+set it on the newest release and never on a hotfix for an older line.
+
+If the `awk` / `sed` dance is finicky for you, paste the release section
+from `CHANGELOG.md` manually into `gh release create ... --notes "..."`
+or drop the `--notes-file` flag and let `gh` open `$EDITOR`. Either way,
+the release notes on GitHub should match the CHANGELOG entry for that
+version — **don't let them drift.**
+
+## Step 4 — Sanity check the build (optional but recommended)
+
+```bash
+git checkout vX.Y.Z
+uv build
+ls dist/
+```
+
+You should see exactly `nasde_toolkit-X.Y.Z-py3-none-any.whl` and
+`nasde_toolkit-X.Y.Z.tar.gz`. If you see `X.Y.Z.dev…+gabcdef`, the tag
+isn't pointing where you think it is — check `git describe`.
+
+## Hotfixing an older release line
+
+If `main` has moved on (say we're on `0.3.x`) and a user on `0.2.x` hits
+a critical bug that needs a `0.2.4`:
+
+1. **Create a release branch from the last tag in that line.**
+   ```bash
+   git checkout -b release/0.2.x v0.2.3
+   git push -u origin release/0.2.x
+   ```
+
+2. **Cherry-pick the fix commits from main** onto the release branch.
+   ```bash
+   git cherry-pick <sha1> <sha2>
+   ```
+
+3. **Update `CHANGELOG.md` on the release branch** — insert a new
+   `## [0.2.4] — YYYY-MM-DD` section between the previous entries.
+   Do *not* touch `[Unreleased]` on this branch; that's only meaningful
+   on `main`.
+
+4. **Tag the release branch, not `main`.**
+   ```bash
+   git tag v0.2.4
+   git push origin v0.2.4
+   ```
+
+5. **Create the GitHub Release without `--latest`** so it doesn't
+   overshadow the newer `main`-line release:
+   ```bash
+   gh release create v0.2.4 --title "v0.2.4" --notes-file …
+   ```
+
+6. **Keep the release branch alive** — `release/0.X.x` is the home for
+   future fixes on that line. Do not delete it.
+
+7. **Forward-port the fix to `main`** if it isn't there already (usually
+   the cherry-pick came from main, but double-check).
+
+We currently only commit to supporting the **latest** release line in
+`SECURITY.md`. If you find yourself hotfixing an older line, update that
+doc in the same PR so the promise matches reality.
+
+## What NOT to do
+
+- **Do not amend or move a published tag.** If `vX.Y.Z` went out wrong,
+  cut `vX.Y.(Z+1)` with the fix. Tags are immutable from the user's
+  perspective the moment they're on GitHub.
+- **Do not `git push --force` to `main`.** Even if nobody has pulled yet,
+  force-push rewrites the commit that `hatch-vcs` will anchor future
+  versions on. Fix-forward with a new commit.
+- **Do not skip CI** (`--no-verify` on the release commit, manual
+  `gh release create` while the quality gate is red, etc.). If CI is
+  flaky, file an issue and wait; if CI found a real problem, the release
+  stops until it's fixed.
+- **Do not bundle a release with unrelated work.** The release PR should
+  only touch `CHANGELOG.md` (and this document, if you're updating the
+  procedure). Feature work lands in its own PR first.
+- **Do not hand-edit `src/nasde_toolkit/_version.py`.** It's generated by
+  `hatch-vcs` at build time and gitignored. Any manual changes will be
+  lost on the next build.
+- **Do not publish to PyPI** until we've set that up properly (PyPI org
+  account, `publish-to-pypi` workflow with trusted publisher, signature
+  policy). Until then, users install from a git tag:
+  `uv tool install git+https://github.com/NoesisVision/nasde-toolkit.git@vX.Y.Z`.
+
+## Future work (tracked, not required today)
+
+- **PyPI publishing.** We'll want a `publish-to-pypi.yml` workflow that
+  triggers on tag push, uses PyPI Trusted Publishers (no long-lived token),
+  and `uv publish` from the same wheel `hatch-vcs` produces. Document here
+  once set up and link back from the README.
+- **Dependency automation.** Dependabot or Renovate would keep
+  `uv.lock` fresh without a human in the loop. For now, the `pip-audit`
+  CI gate catches anything that acquires a CVE.
+- **Automated changelog assist.** `release-drafter` or similar to pre-fill
+  the `[Unreleased]` section from merged PR titles. Nice to have, not
+  urgent.
+
+## Questions, wake-ups, gotchas
+
+- **What if I forgot to update `CHANGELOG.md` before tagging?** Not the
+  end of the world — edit the GitHub Release notes, then backfill the
+  CHANGELOG in the next commit on `main`. The next release PR picks it
+  up naturally.
+- **What if `hatch-vcs` reports a weird version like
+  `0.2.1.dev0+dirty`?** Your working tree wasn't clean at build time. Run
+  `git status`, stash or commit the stray changes, and `uv build` again.
+- **What if I want to pre-release something (`v0.3.0a1`)?** Tag it
+  exactly like that; hatch-vcs handles PEP 440 suffixes. Create the GH
+  Release with `--prerelease` instead of `--latest`. CHANGELOG entry goes
+  under a `## [0.3.0a1] — YYYY-MM-DD` header.


### PR DESCRIPTION
## Summary

Release-governance housekeeping before offering **nasde-toolkit** to early adopters from outside the team. Pure docs additions; no code changes, no CI gate changes.

- **`CHANGELOG.md`** — Keep a Changelog 1.1.0, backfilled entries for `v0.1.0`, `v0.1.1`, `v0.2.0`, plus `[Unreleased]` covering the harbor 0.4 / opik 2.x upgrade and pip-audit CI gate from #25, the reviewer-model bump to `claude-opus-4-7`, and the recent README polish.
- **`SECURITY.md`** — supported versions (latest only, stated explicitly), private reporting via GitHub Security Advisories or `szymon@noesis-vision.com`, a realistic 7-day acknowledgement SLA, in-scope vs upstream-dep scope split, coordinated-disclosure policy.
- **`docs/RELEASING.md`** — end-to-end release procedure a new contributor can follow without asking questions: pre-flight checks, CHANGELOG move, tag/push, `gh release create`, build sanity check, hotfix flow via `release/0.X.x` branch, semver policy tied to CHANGELOG sections, and an explicit "don'ts" list (no amended tags, no force-push main, no `--no-verify`, no hand-edits to `_version.py`, no PyPI publish yet).
- **`README.md`** — two small nudges only: CHANGELOG link at the end of "Installation reference", SECURITY link as a new section after "Community".

Versioning stays automatic via `hatch-vcs` — no `pyproject.toml` changes.

## Out of scope (intentionally)

- PyPI publishing, Dependabot/Renovate, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, issue/PR templates. Each is a separate follow-up and flagged as such in `RELEASING.md`.
- Backfilling GitHub Releases for `v0.1.0`, `v0.1.1`, `v0.2.0` — will be done as a separate step once this PR is merged, so release notes link to the merged `CHANGELOG.md`.

## Test plan

- [ ] CI stays green (quality gate, example validation — docs changes shouldn't touch any gate).
- [ ] `CHANGELOG.md` renders correctly on GitHub (headings, compare links, PR backrefs).
- [ ] `SECURITY.md` appears on the repo Security tab.
- [ ] README links to `CHANGELOG.md` and `SECURITY.md` resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Before making the repo public

`SECURITY.md` links to `…/security/advisories/new`. That URL returns 404 until Private Vulnerability Reporting is enabled, and PVR only exists on public repos. **Once you flip the repo to public, also flip Settings → Code security → "Private vulnerability reporting" to ON** — one click, same sitting. Until then the email channel in `SECURITY.md` is the only working path (which is fine; the advisory link just doesn't resolve yet).



## Update — dep-upgrade policy + next release target

Added a second commit to this PR: `docs(releasing): add dep-upgrade semver policy`.

New section in `docs/RELEASING.md` spells out how dependency bumps affect the version number: the rule keys on **what the user running `nasde run` sees differently**, not on the upstream semver. A `harbor 0.1 → 0.4` or `opik 1 → 2` with no visible behavior change is a **patch** bump, not minor. Otherwise any quarterly `uv.lock` refresh with a major upstream bump would push us toward `v2.x` without adding a single feature.

Implication for the current `[Unreleased]` section: the next release after merging this PR is **v0.2.1** (patch), not v0.3.0. The content of `[Unreleased]` — harbor 0.4 / opik 2.x bump, pip-audit CI gate, reviewer model → opus-4-7 — fits the patch definition under the new policy.
