### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ See [docs/RELEASING.md](docs/RELEASING.md) for the release procedure.
 
 ## [Unreleased]
 
+## [0.2.1] — 2026-04-22
+
 ### Changed
 - Modernized dependencies: `harbor` 0.1.45 → 0.4.0, `opik` 1.10.39 → 2.0.9.
   Brings upstream bugfixes and removes a long-standing Opik monkey-patch that
@@ -24,6 +26,9 @@ See [docs/RELEASING.md](docs/RELEASING.md) for the release procedure.
   dependency tree, including 1 CRITICAL and 3 HIGH in `litellm` / `cbor2`.
   New vulnerabilities will now fail the quality gate instead of shipping
   silently. ([#25])
+
+### Added
+- `CHANGELOG.md`, `SECURITY.md`, `docs/RELEASING.md`. ([#26])
 
 ### Docs
 - README: unified "what NASDE does" opener around four steps, mentioning the
@@ -131,7 +136,8 @@ Initial release under the **nasde-toolkit** name (rebrand from
 - `v0.1.0` represents the first public-oriented baseline; earlier commits
   on the `sdlc-eval-kit` history are not cataloged here.
 
-[Unreleased]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/NoesisVision/nasde-toolkit/releases/tag/v0.1.0
@@ -139,3 +145,4 @@ Initial release under the **nasde-toolkit** name (rebrand from
 [#23]: https://github.com/NoesisVision/nasde-toolkit/pull/23
 [#24]: https://github.com/NoesisVision/nasde-toolkit/pull/24
 [#25]: https://github.com/NoesisVision/nasde-toolkit/pull/25
+[#26]: https://github.com/NoesisVision/nasde-toolkit/pull/26

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The fastest path from zero to a working benchmark built from **your own git hist
 ### 1. Install the CLI
 
 ```bash
-uv tool install git+https://github.com/NoesisVision/nasde-toolkit.git@v0.2.0
+uv tool install git+https://github.com/NoesisVision/nasde-toolkit.git@v0.2.1
 nasde --version
 ```
 
@@ -219,12 +219,12 @@ uv sync
 Upgrading to a new stable release:
 
 ```bash
-uv tool install --reinstall git+https://github.com/NoesisVision/nasde-toolkit.git@v0.2.0
+uv tool install --reinstall git+https://github.com/NoesisVision/nasde-toolkit.git@v0.2.1
 ```
 
 After installation, only `nasde` appears on PATH. Harbor and Opik are bundled as core dependencies. The reviewer agent spawns your already-installed `claude` or `codex` CLI as a subprocess (not bundled), so it reuses whatever authentication you've set up interactively.
 
-Check the installed version with `nasde --version`. Stable releases follow semver tags (e.g. `v0.2.0`); dev installs show versions like `0.2.1.dev3+gabcdef`.
+Check the installed version with `nasde --version`. Stable releases follow semver tags (e.g. `v0.2.1`); dev installs show versions like `0.2.2.dev3+gabcdef`.
 
 Release notes for every tagged version live in [CHANGELOG.md](CHANGELOG.md). See [docs/RELEASING.md](docs/RELEASING.md) if you're cutting a release yourself.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -12,8 +12,15 @@ out of date, fix the doc in the same PR as the release.
 git checkout main && git pull
 
 # 2. Move [Unreleased] section under the new version header in CHANGELOG.md,
-#    add a fresh empty [Unreleased] block, update compare links at the bottom
+#    add a fresh empty [Unreleased] block, update compare links, and add
+#    a new PR link-ref (`[#NN]: …/pull/NN`) at the bottom for any PR
+#    cited in this release's entries
 $EDITOR CHANGELOG.md
+
+# 2b. (Temporary — until PyPI.) Bump the pinned tag in user-facing docs
+#     so copy-paste installs land on the new version:
+#       grep -rn "@vOLD" README.md docs/ examples/
+#     then update every hit (README has two install commands).
 
 # 3. Commit the changelog and push the PR
 git checkout -b chore/release-vX.Y.Z
@@ -152,11 +159,46 @@ The source of truth for what's in each release is `CHANGELOG.md`.
    +[0.2.1]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.2.0...v0.2.1
    ```
 
-5. Open a PR titled `chore: release vX.Y.Z`. The PR body should be the
+5. **Also at the bottom, keep the PR link-ref table in sync.** The
+   `## [Unreleased]` section uses [Keep a Changelog][kac-linkrefs]-style
+   shortcuts like `([#25])` instead of inline URLs. Every PR number that
+   appears in a changelog entry needs a matching `[#NN]: …/pull/NN` line
+   at the bottom of the file. Add a row for any new PR referenced in
+   this release.
+
+   ```diff
+   +[#27]: https://github.com/NoesisVision/nasde-toolkit/pull/27
+   ```
+
+   [kac-linkrefs]: https://keepachangelog.com/en/1.1.0/#how
+
+6. **Bump the pinned version in user-facing docs** *(temporary — remove
+   this step once we publish to PyPI).* Until `nasde` is on PyPI, the
+   install command in the README pins to a specific git tag, and that
+   tag number has to be updated alongside the release. Otherwise a
+   copy-paste from the README installs a stale version and nobody
+   notices.
+
+   Find the stale pins:
+
+   ```bash
+   grep -rn "@v[0-9]" README.md docs/ examples/
+   ```
+
+   Expected hits today: two `uv tool install …@vOLD` lines in `README.md`
+   (one in *Quick start*, one in *Installation reference*), plus the
+   `(e.g. \`vOLD\`)` example sentence nearby. Update each to `vNEW`.
+   Anywhere else `@vOLD` appears in user-facing docs, update it too.
+
+   Skip: anything inside `CHANGELOG.md` (those pins are historical and
+   must stay on the version they described) and anywhere `vOLD` appears
+   as a reference for a diff/compare link.
+
+7. Open a PR titled `chore: release vX.Y.Z`. The PR body should be the
    changelog section for this release, so reviewers see exactly what
    goes out.
 
-6. **Wait for CI to go green, then merge.** Prefer a squash merge so the
+8. **Wait for CI to go green, then merge.** Prefer a squash merge so the
    release commit is a single entry.
 
 ## Step 2 — Tag and push
@@ -285,7 +327,10 @@ doc in the same PR so the promise matches reality.
 - **PyPI publishing.** We'll want a `publish-to-pypi.yml` workflow that
   triggers on tag push, uses PyPI Trusted Publishers (no long-lived token),
   and `uv publish` from the same wheel `hatch-vcs` produces. Document here
-  once set up and link back from the README.
+  once set up and link back from the README. **When this lands, delete
+  Step 6 ("Bump the pinned version in user-facing docs") and the matching
+  `# 2b` block in the TL;DR** — `pip install nasde-toolkit` is
+  version-agnostic, so the README pins go away too.
 - **Dependency automation.** Dependabot or Renovate would keep
   `uv.lock` fresh without a human in the loop. For now, the `pip-audit`
   CI gate catches anything that acquires a CVE.


### PR DESCRIPTION
Release PR per [`docs/RELEASING.md`](docs/RELEASING.md).

- **`CHANGELOG.md`**: move `[Unreleased]` entries under `## [0.2.1] — 2026-04-22`, add a fresh empty `[Unreleased]`, refresh compare links, list `#26` in the PR link-ref table.
- **`docs/RELEASING.md`**:
  - Document the CHANGELOG PR link-ref table (Keep a Changelog style) — every PR cited from an entry needs a matching `[#NN]: …/pull/NN` line at the bottom. TL;DR + Step 1.
  - Add a **temporary** step ("Bump the pinned version in user-facing docs") covering the fact that until we're on PyPI, the `uv tool install …@vX.Y.Z` pin in the README has to move with each release. Future-work note spells out when to delete that step (the moment we flip PyPI publishing on, `pip install nasde-toolkit` becomes version-agnostic and the pin goes away).
- **`README.md`**: bump the two `@v0.2.0` install commands to `@v0.2.1` (Quick start + Installation reference) and the example version string nearby.

## Changes in v0.2.1

### Changed
- Modernized dependencies: `harbor` 0.1.45 → 0.4.0, `opik` 1.10.39 → 2.0.9. Brings upstream bugfixes and removes a long-standing Opik monkey-patch that is no longer needed. `ConfigurableCodex` simplified by ~80 LOC thanks to Harbor 0.4 adding first-class support for files-to-inject. (#25)
- Default reviewer model bumped to `claude-opus-4-7` across README, ARCHITECTURE, bundled `nasde-benchmark-runner` skill, and example benchmarks (`ddd-architectural-challenges`, `refactoring-skill`). `nasde-dev-skill` stays on Sonnet 4.6 as documented in [benchmark results](docs/benchmark-results.md).

### Security
- Added `pip-audit` as a CI gate. Fixes 20 known CVEs across the transitive dependency tree, including 1 CRITICAL and 3 HIGH in `litellm` / `cbor2`. New vulnerabilities will now fail the quality gate instead of shipping silently. (#25)

### Added
- `CHANGELOG.md`, `SECURITY.md`, `docs/RELEASING.md`. (#26)

### Docs
- README: unified "what NASDE does" opener around four steps, mentioning the rough `test.sh` pass/fail gate that precedes LLM-as-a-judge scoring.
- README: scoring section now calls out that criteria can cover the agent's run-time signals — tool-call trajectory, token usage, wall-clock duration — alongside the produced artifacts.

## Post-merge

1. `git checkout main && git pull`
2. `git tag v0.2.1 && git push origin v0.2.1`
3. `gh release create v0.2.1 --latest --notes-file <CHANGELOG excerpt>`
4. `uv build` — verify the wheel resolves to `0.2.1`, not `0.2.1.dev…+gabcdef`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)