### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# CODEOWNERS for nasde-toolkit
+#
+# GitHub uses this file to auto-request reviews from the listed owners
+# whenever a PR changes matching files. Docs:
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
+#
+# Last matching pattern wins, so more specific rules go at the bottom.
+
+# Default owner for everything in the repo.
+*                       @szjanikowski


### PR DESCRIPTION
## Summary

Add a minimal `.github/CODEOWNERS` assigning `@szjanikowski` as the default owner.

## Why

- Auto-requests a reviewer on every PR — useful for external contributors who don't know who to tag.
- Forms the basis for an optional "Require review from Code Owners" branch-protection rule on `main` later on.

Sole owner for now; we can expand the list when additional maintainers actively review.

## Test plan

- [ ] File is picked up by GitHub (open a test PR later and confirm the reviewer request appears automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)