### PR TITLE
fix(examples): add [task] name to all example tasks

### DIFF
--- a/examples/ddd-architectural-challenges/tasks/csharp-anemic-to-rich-domain/task.toml
+++ b/examples/ddd-architectural-challenges/tasks/csharp-anemic-to-rich-domain/task.toml
@@ -1,5 +1,9 @@
 version = "1.0"
 
+[task]
+name = "ddd-architectural-challenges/csharp-anemic-to-rich-domain"
+description = "Refactor an anemic domain model to a rich domain model in a C# e-commerce application"
+
 [metadata]
 name = "csharp-anemic-to-rich-domain"
 description = "Refactor an anemic domain model to a rich domain model in a C# e-commerce application"

--- a/examples/ddd-architectural-challenges/tasks/ddd-threshold-discount/task.toml
+++ b/examples/ddd-architectural-challenges/tasks/ddd-threshold-discount/task.toml
@@ -1,5 +1,9 @@
 version = "1.0"
 
+[task]
+name = "ddd-architectural-challenges/ddd-threshold-discount"
+description = "Implement a threshold-based discount type in a complex DDD e-commerce system by extending an existing discriminated union"
+
 [metadata]
 name = "ddd-threshold-discount"
 description = "Implement a threshold-based discount type in a complex DDD e-commerce system by extending an existing discriminated union"

--- a/examples/ddd-architectural-challenges/tasks/ddd-weather-discount/task.toml
+++ b/examples/ddd-architectural-challenges/tasks/ddd-weather-discount/task.toml
@@ -1,5 +1,9 @@
 version = "1.0"
 
+[task]
+name = "ddd-architectural-challenges/ddd-weather-discount"
+description = "Implement a weather-based discount feature in a complex DDD e-commerce system using external API"
+
 [metadata]
 name = "ddd-weather-discount"
 description = "Implement a weather-based discount feature in a complex DDD e-commerce system using external API"

--- a/examples/ddd-architectural-challenges/tasks/java-order-dispatch-domain-entities/task.toml
+++ b/examples/ddd-architectural-challenges/tasks/java-order-dispatch-domain-entities/task.toml
@@ -1,5 +1,9 @@
 version = "1.0"
 
+[task]
+name = "ddd-architectural-challenges/java-order-dispatch-domain-entities"
+description = "Move order dispatch logic from service layer into domain entities in a refactoring kata"
+
 [metadata]
 language = "Java"
 framework = "plain Java"

--- a/examples/nasde-dev-skill/tasks/add-multi-attempt-support/task.toml
+++ b/examples/nasde-dev-skill/tasks/add-multi-attempt-support/task.toml
@@ -1,5 +1,9 @@
 version = "1.0"
 
+[task]
+name = "nasde-dev-skill/add-multi-attempt-support"
+description = "Add --attempts/-n flag for multiple independent trial attempts per task"
+
 [metadata]
 name = "add-multi-attempt-support"
 description = "Add --attempts/-n flag for multiple independent trial attempts per task"

--- a/examples/refactoring-skill/tasks/java-expense-report-extract-hierarchy/task.toml
+++ b/examples/refactoring-skill/tasks/java-expense-report-extract-hierarchy/task.toml
@@ -1,5 +1,9 @@
 version = "1.0"
 
+[task]
+name = "refactoring-skill/java-expense-report-extract-hierarchy"
+description = "Extract expense type hierarchy and separate formatting from calculation in a procedural expense report"
+
 [metadata]
 language = "Java"
 framework = "JUnit"

--- a/examples/refactoring-skill/tasks/java-trip-service-break-dependency/task.toml
+++ b/examples/refactoring-skill/tasks/java-trip-service-break-dependency/task.toml
@@ -1,5 +1,9 @@
 version = "1.0"
 
+[task]
+name = "refactoring-skill/java-trip-service-break-dependency"
+description = "Break static dependency, Extract Method, and introduce dependency injection in a legacy service"
+
 [metadata]
 language = "Java"
 framework = "JUnit"

--- a/examples/refactoring-skill/tasks/python-gilded-rose-polymorphism/task.toml
+++ b/examples/refactoring-skill/tasks/python-gilded-rose-polymorphism/task.toml
@@ -1,5 +1,9 @@
 version = "1.0"
 
+[task]
+name = "refactoring-skill/python-gilded-rose-polymorphism"
+description = "Replace nested conditionals with polymorphism in the Gilded Rose kata and add Conjured items support"
+
 [metadata]
 language = "Python"
 framework = "pytest"

--- a/examples/refactoring-skill/tasks/python-theatrical-players-extract-method/task.toml
+++ b/examples/refactoring-skill/tasks/python-theatrical-players-extract-method/task.toml
@@ -1,5 +1,9 @@
 version = "1.0"
 
+[task]
+name = "refactoring-skill/python-theatrical-players-extract-method"
+description = "Extract Method and Replace Conditional with Polymorphism on a statement rendering function"
+
 [metadata]
 language = "Python"
 framework = "pytest"


### PR DESCRIPTION
## Summary

- Adds `[task] name = "<project>/<task-name>"` and `[task] description` to all 9 example task.toml files across `ddd-architectural-challenges`, `refactoring-skill`, and `nasde-dev-skill`.
- Harbor expects `[task] name` in `org/name` format. Without it the trace input emitted to Opik carries `task.name = null`, leaving the "task" column blank in experiment / trace views.
- Discovered while running `nasde run --variant claude-vanilla --tasks ddd-threshold-discount --with-opik` and inspecting the trace via Opik REST API — `input.task.name` was `null` even though `[metadata] name` was set (Harbor reads `[task]`, not `[metadata]`).

## Test plan

- [x] `nasde run --variant claude-vanilla --tasks ddd-threshold-discount --with-opik` (full pipeline already executed before fix; will repeat after merge to confirm `task.name` no longer null in Opik)
- [ ] Spot-check Opik trace input — `input.task.name` should now be the `org/name` string instead of `null`
- [ ] No regressions on other examples — each task still resolves via existing discovery (filename → name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)