### PR TITLE
feat(evaluator): independent per-dimension scoring scales (ADR-008)

### DIFF
--- a/.claude/skills/nasde-benchmark-creator/SKILL.md
+++ b/.claude/skills/nasde-benchmark-creator/SKILL.md
@@ -46,7 +46,8 @@ Examples by domain:
 - **DDD**: `domain_modeling`, `architecture_compliance`, `extensibility`, `test_quality`
 
 Rules:
-- 3-5 dimensions, scores summing to 100
+- Pick whatever number of dimensions actually captures the quality you care about — there is no required minimum or maximum.
+- Each dimension declares its own `max_score` (any positive integer). Scales are independent — a coarse pass/fail-ish dimension can be 0–3 while a richly graded one can be 0–50 in the same rubric. There is no requirement for the total to sum to 100. `normalized_score` is computed automatically from the actual sum of `max_score` values. See ADR-008.
 - Names in snake_case
 - Each dimension has: `name`, `title`, `max_score`, `description`
 
@@ -175,21 +176,25 @@ Per-task rubric. Structure:
 ```markdown
 # Assessment Criteria: <Task Name>
 
-Evaluate across N dimensions. Each dimension is scored 0–<max_score> points.
+Evaluate across N dimensions. Each dimension uses its own scale (0–`max_score`),
+defined in `assessment_dimensions.json`. The ladder below shows what each score
+means for one specific dimension — repeat for each dimension.
 
 ## 1. <Dimension Name> (0–<max_score>)
 
 | Score | Criteria |
 |-------|----------|
-| 0     | <worst case> |
-| 12    | <middle case> |
-| 25    | <best case> |
+| 0           | <worst case> |
+| <middle>    | <middle case> |
+| <max_score> | <best case> |
 
 **Key checks:**
 - Specific things to look for
 ```
 
-Scores should have at least 5 levels for granularity.
+Pick a `max_score` that matches the granularity you can actually distinguish.
+A coarse pass/fail-ish dimension might be 0–3; a richly graded one might be 0–50.
+Choose the resolution per dimension, independently.
 
 ### solution/solve.sh (optional)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ A benchmark project managed by `nasde` has this layout:
 ```
 my-benchmark/
   nasde.toml                # Project config (name, defaults, docker, evaluation, reporting)
-  assessment_dimensions.json    # Scoring dimensions (benchmark-wide, 3-5 dimensions, sum to 100)
+  assessment_dimensions.json    # Scoring dimensions (benchmark-wide, each with independent max_score)
   tasks/
     <task-name>/
       task.toml                 # Task config: Harbor sections + [nasde.source] for auto-Dockerfile
@@ -184,14 +184,14 @@ project_name = "my-benchmark"
     {
       "name": "snake_case_name",
       "title": "Human-Readable Title",
-      "max_score": 25,
-      "description": "What this dimension measures"
+      "max_score": 10,
+      "description": "What this dimension measures (max_score can be any positive integer — pick what fits the granularity)"
     }
   ]
 }
 ```
 
-Dimensions are benchmark-specific. Total scores should sum to 100. Typically 3-5 dimensions.
+Dimensions are benchmark-specific. Each dimension declares its own `max_score` (any positive integer) — there is no requirement that scores sum to a particular total or that you use a particular dimension count. Pick the scale per dimension that matches the granularity you can actually distinguish; `normalized_score` is computed from the actual sum of `max_score` values. See [ADR-008](docs/adr/008-independent-dimension-scales.md).
 
 ### task.toml
 

--- a/docs/adr/008-independent-dimension-scales.md
+++ b/docs/adr/008-independent-dimension-scales.md
@@ -1,0 +1,53 @@
+# ADR-008: Independent per-dimension scoring scales
+
+**Status:** Accepted
+**Date:** 2026-05-04
+
+## Context
+
+Earlier versions of `nasde` baked a specific scoring shape into the assessment evaluator: every dimension was assumed to be on a 0–25 scale, totals were assumed to sum to 100, and authoring guidance recommended "3–5 dimensions". This assumption leaked into multiple layers:
+
+- `evaluator.py` defaulted `DimensionScore.max_score` to `25`, clamped every score with `min(25, ...)`, and computed `normalized_score = total / 100.0`.
+- The evaluator prompt told the LLM "Each dimension is 0–25 points" and showed a JSON output template with hardcoded `"max_score": 25`.
+- Console output printed `Score: X/100` regardless of actual totals.
+- The `nasde init` scaffold generated an `assessment_dimensions.json` with four dimensions, each `max_score: 25`, totaling 100.
+- The `nasde-benchmark-creator` skill instructed authors to use "3-5 dimensions, scores summing to 100".
+- `CLAUDE.md` documented the same constraint.
+
+This was wrong on two counts.
+
+**Methodologically**: nothing about LLM-as-a-Judge requires uniform scales. The dominant pattern in modern eval frameworks (G-Eval, MT-Bench, RAGAS, DeepEval, OpenAI Evals, Inspect AI) is **independent per-dimension scales** — each dimension picks the granularity that matches what it measures. A coarse "did the agent follow instructions?" check is naturally pass/fail or 1–3; a fine-grained "code quality" rubric may want 1–10 or 0–100. Forcing both onto a 0–25 scale destroys resolution. The "scores sum to 100" convention comes from academic grading rubrics and HR scorecards — useful in those contexts, but not load-bearing for evals.
+
+**Practically**: benchmark authors found themselves either stretching weak dimensions to fit a 25-point scale, or compressing rich rubrics that wanted finer gradation. The fixed 3–5 count discouraged comprehensive rubrics. The clamp at 25 silently truncated any score the LLM produced above 25 — so an author who *did* write a 0–50 dimension would see correct-looking results that were quietly broken.
+
+## Decision
+
+Each dimension declares its own `max_score` independently. There is no constraint on:
+
+- the value of any individual `max_score` (any positive integer),
+- the sum of `max_score` across dimensions (does not need to be 100),
+- the number of dimensions (no recommended minimum or maximum).
+
+`max_score` is **required** in every dimension entry — there is no default. A missing `max_score` is an authoring error and produces a clear validation failure rather than silently picking 25.
+
+Implementation:
+
+- `DimensionScore.max_score` becomes a required field (no default).
+- Score clamping is per-dimension: `min(dimension.max_score, score)` instead of `min(25, score)`.
+- `normalized_score = total / sum(d.max_score for d in dimensions)`. Backwards compatible: a setup with four dimensions × 25 still normalizes to `100 / 100 = 1.0`.
+- The evaluator prompt is constructed dynamically — it lists each dimension with its own range (`<name>: 0-<max_score>`) rather than telling the LLM "0–25 points".
+- Console output reads `Score: <total>/<sum_of_max_scores>` — the denominator reflects the actual rubric, not a hardcoded 100.
+
+## Consequences
+
+- **Backwards compatible.** Existing benchmarks with the old 4×25=100 shape continue to work unchanged. Their `normalized_score` stays identical.
+- **Higher resolution where it matters.** Authors can give a finicky dimension a 0–100 scale and a coarse one a 0–3 scale in the same rubric.
+- **No silent truncation.** Scores above a dimension's `max_score` are clamped *to that dimension's* max, not to 25.
+- **Stricter validation.** A dimension entry without `max_score` is now rejected at load time. (Previously it would silently default to 25.) This is a one-time correction for any rubric that relied on the implicit default.
+- **Documentation simpler to teach.** The guidance becomes "pick the scale that matches the granularity you can actually distinguish" rather than "carve 100 points across 3–5 dimensions" — closer to how mature eval frameworks describe rubric design.
+
+## References
+
+- G-Eval (Liu et al., 2023) — uses 1–5 per criterion, criteria scored independently.
+- MT-Bench (Zheng et al., 2023) — 1–10 per turn.
+- RAGAS, DeepEval — per-metric independent scales, no aggregation constraint.

--- a/src/nasde_toolkit/evaluator.py
+++ b/src/nasde_toolkit/evaluator.py
@@ -33,7 +33,7 @@ class DimensionScore:
 
     name: str
     score: int
-    max_score: int = 25
+    max_score: int
     reasoning: str = ""
 
 
@@ -229,7 +229,8 @@ async def evaluate_trial(
     evaluation.evaluator_model = eval_config.model
     evaluation.timestamp = datetime.now(UTC).isoformat()
 
-    console.print(f"  Score: {evaluation.total_score}/100 ({evaluation.normalized_score:.2f})")
+    total_max = sum(dim.max_score for dim in evaluation.dimensions)
+    console.print(f"  Score: {evaluation.total_score}/{total_max} ({evaluation.normalized_score:.2f})")
     for dim in evaluation.dimensions:
         console.print(f"    {dim.name}: {dim.score}/{dim.max_score}")
 
@@ -265,7 +266,26 @@ def _load_expected_dimensions(dimensions_path: Path) -> list[dict] | None:
         return None
     data = _load_json(dimensions_path)
     dims: list[dict] | None = data.get("dimensions", [])
+    _validate_expected_dimensions(dims, dimensions_path)
     return dims
+
+
+def _validate_expected_dimensions(dims: list[dict] | None, source: Path) -> None:
+    if not dims:
+        return
+    for index, dim in enumerate(dims):
+        name = dim.get("name") or f"<dimension #{index}>"
+        if "max_score" not in dim:
+            raise ValueError(
+                f"{source}: dimension '{name}' is missing required field 'max_score'. "
+                "Each dimension must declare its own scale (any positive integer)."
+            )
+        max_score = dim["max_score"]
+        if not isinstance(max_score, int) or max_score <= 0:
+            raise ValueError(
+                f"{source}: dimension '{name}' has invalid max_score={max_score!r}. "
+                "max_score must be a positive integer."
+            )
 
 
 def _resolve_agent_name(trial_dir: Path) -> str:
@@ -316,7 +336,10 @@ def _build_evaluator_prompt(
     trajectory_path: str | None = None,
 ) -> str:
     """Build the evaluation prompt with optional dimension constraints and ground truth."""
+    scoring_guidance = _format_scoring_guidance(expected_dimensions)
     dimension_constraint = _format_dimension_constraint(expected_dimensions)
+    output_schema = _format_output_schema(expected_dimensions)
+    dimension_count_rule = _format_dimension_count_rule(expected_dimensions)
     ground_truth_section = _format_ground_truth_section(ground_truth)
     trajectory_section = _format_trajectory_section(trajectory_path)
 
@@ -338,9 +361,12 @@ def _build_evaluator_prompt(
 
 ## Evaluation criteria
 
-Score the output on the following dimensions. Each dimension is 0–25 points.
-Follow the rubric EXACTLY — assign the score that matches the description, not higher.
+Score the output on the dimensions defined below. Each dimension has its own
+independent scale — use the exact range listed for each one, do NOT assume a
+shared scale across dimensions. Follow the rubric EXACTLY — assign the score
+that matches the description, not higher.
 
+{scoring_guidance}
 <criteria>
 {criteria}
 </criteria>
@@ -357,23 +383,21 @@ After your analysis, output a single JSON block with your evaluation.
 The JSON MUST be the last code block in your response:
 
 ```json
-{{
-  "dimensions": [
-    {{"name": "<dimension_snake_case>", "score": <0-25>, "max_score": 25,
-      "reasoning": "<1-3 sentences with specific evidence references>"}},
-    ...
-  ],
-  "total_score": <sum of all dimension scores>,
-  "normalized_score": <total_score / 100.0>,
-  "summary": "<2-3 sentence overall assessment>"
-}}
+{output_schema}
 ```
 
 IMPORTANT:
 - Be precise — reference specific files and content you found.
 - Do NOT inflate scores. If evidence is missing, score lower.
-{dimension_constraint}- Output exactly {len(expected_dimensions) if expected_dimensions else 4} dimensions.
-"""
+- Each dimension's `score` must be between 0 and that dimension's `max_score`.
+{dimension_constraint}{dimension_count_rule}"""
+
+
+def _format_scoring_guidance(expected_dimensions: list[dict] | None) -> str:
+    if not expected_dimensions:
+        return ""
+    lines = [f"- `{d['name']}`: 0–{d['max_score']} points" for d in expected_dimensions]
+    return "Score ranges per dimension:\n" + "\n".join(lines) + "\n"
 
 
 def _format_dimension_constraint(expected_dimensions: list[dict] | None) -> str:
@@ -382,6 +406,43 @@ def _format_dimension_constraint(expected_dimensions: list[dict] | None) -> str:
     names = [d["name"] for d in expected_dimensions]
     names_list = ", ".join(f"`{n}`" for n in names)
     return f"- Output EXACTLY these dimension names in this order: {names_list}.\n"
+
+
+def _format_dimension_count_rule(expected_dimensions: list[dict] | None) -> str:
+    if not expected_dimensions:
+        return ""
+    return f"- Output exactly {len(expected_dimensions)} dimensions.\n"
+
+
+def _format_output_schema(expected_dimensions: list[dict] | None) -> str:
+    if not expected_dimensions:
+        return (
+            "{\n"
+            '  "dimensions": [\n'
+            '    {"name": "<dimension_snake_case>", "score": <int>, "max_score": <int>,\n'
+            '      "reasoning": "<1-3 sentences with specific evidence references>"}\n'
+            "  ],\n"
+            '  "total_score": <sum of all dimension scores>,\n'
+            '  "normalized_score": <total_score / sum of all max_score values>,\n'
+            '  "summary": "<2-3 sentence overall assessment>"\n'
+            "}"
+        )
+    dim_lines = ",\n".join(
+        f'    {{"name": "{d["name"]}", "score": <0-{d["max_score"]}>, "max_score": {d["max_score"]},\n'
+        f'      "reasoning": "<1-3 sentences with specific evidence references>"}}'
+        for d in expected_dimensions
+    )
+    total_max = sum(d["max_score"] for d in expected_dimensions)
+    return (
+        "{\n"
+        '  "dimensions": [\n'
+        f"{dim_lines}\n"
+        "  ],\n"
+        f'  "total_score": <sum of all dimension scores, max {total_max}>,\n'
+        f'  "normalized_score": <total_score / {total_max}>,\n'
+        '  "summary": "<2-3 sentence overall assessment>"\n'
+        "}"
+    )
 
 
 def _format_ground_truth_section(ground_truth: str) -> str:
@@ -435,19 +496,14 @@ def _parse_evaluation_response(
     except json.JSONDecodeError:
         return None
 
-    dimensions = [
-        DimensionScore(
-            name=d["name"],
-            score=max(0, min(25, int(d["score"]))),
-            max_score=d.get("max_score", 25),
-            reasoning=d.get("reasoning", ""),
-        )
-        for d in data.get("dimensions", [])
-    ]
+    expected_by_name = {d["name"]: d for d in (expected_dimensions or [])}
+    dimensions = [_build_dimension_score(d, expected_by_name) for d in data.get("dimensions", [])]
 
     _validate_dimensions(dimensions, expected_dimensions)
 
     total = sum(d.score for d in dimensions)
+    total_max = sum(d.max_score for d in dimensions)
+    normalized = round(total / total_max, 4) if total_max > 0 else 0.0
 
     return EvaluationResult(
         task_name="",
@@ -457,8 +513,26 @@ def _parse_evaluation_response(
         timestamp="",
         dimensions=dimensions,
         total_score=total,
-        normalized_score=round(total / 100.0, 4),
+        normalized_score=normalized,
         summary=data.get("summary", ""),
+    )
+
+
+def _build_dimension_score(raw: dict, expected_by_name: dict[str, dict]) -> DimensionScore:
+    name = raw["name"]
+    expected = expected_by_name.get(name, {})
+    max_score = int(raw.get("max_score") or expected.get("max_score") or 0)
+    if max_score <= 0:
+        raise ValueError(
+            f"Dimension '{name}' has no usable max_score (evaluator response did not include one "
+            "and assessment_dimensions.json did not provide it either)."
+        )
+    score = max(0, min(max_score, int(raw["score"])))
+    return DimensionScore(
+        name=name,
+        score=score,
+        max_score=max_score,
+        reasoning=raw.get("reasoning", ""),
     )
 
 

--- a/src/nasde_toolkit/scaffold/__init__.py
+++ b/src/nasde_toolkit/scaffold/__init__.py
@@ -31,29 +31,30 @@ project_name = "{name}"
 
 ASSESSMENT_DIMENSIONS_TEMPLATE = """\
 {
+  "_comment": "Independent per-dimension max_score. See docs/adr/008.",
   "dimensions": [
     {
       "name": "domain_modeling",
       "title": "Domain Modeling",
-      "max_score": 25,
+      "max_score": 20,
       "description": "Correct use of DDD building blocks or simpler patterns as appropriate for domain complexity"
     },
     {
       "name": "architecture_compliance",
       "title": "Architecture Compliance",
-      "max_score": 25,
+      "max_score": 10,
       "description": "Respecting layer boundaries, project conventions, separation of concerns"
     },
     {
       "name": "extensibility",
       "title": "Extensibility",
-      "max_score": 25,
+      "max_score": 5,
       "description": "OCP, Strategy/Policy patterns, ease of adding similar features"
     },
     {
       "name": "test_quality",
       "title": "Test Quality",
-      "max_score": 25,
+      "max_score": 15,
       "description": "Coverage, isolation from externals, edge cases, test conventions"
     }
   ]

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,11 +1,19 @@
-"""Tests for evaluator trajectory integration."""
+"""Tests for evaluator trajectory integration and dimension scoring."""
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
+import pytest
+
 from nasde_toolkit.config import EvaluationConfig
-from nasde_toolkit.evaluator import _build_evaluator_prompt, _resolve_trajectory_path
+from nasde_toolkit.evaluator import (
+    _build_evaluator_prompt,
+    _load_expected_dimensions,
+    _parse_evaluation_response,
+    _resolve_trajectory_path,
+)
 
 
 def test_evaluate_trial_uses_configured_backend() -> None:
@@ -70,3 +78,144 @@ def test_resolve_trajectory_path_returns_relative_path_when_file_exists(tmp_path
     eval_config = EvaluationConfig(include_trajectory=True)
     result = _resolve_trajectory_path(tmp_path, eval_config)
     assert result == "../../agent/trajectory.json"
+
+
+# ---------------------------------------------------------------------------
+# Per-dimension max_score (ADR-008)
+# ---------------------------------------------------------------------------
+
+
+def _write_dimensions(tmp_path: Path, dims: list[dict]) -> Path:
+    path = tmp_path / "assessment_dimensions.json"
+    path.write_text(json.dumps({"dimensions": dims}))
+    return path
+
+
+def test_load_dimensions_accepts_arbitrary_max_scores(tmp_path: Path) -> None:
+    raw = [
+        {"name": "a", "max_score": 10},
+        {"name": "b", "max_score": 5},
+        {"name": "c", "max_score": 100},
+        {"name": "d", "max_score": 3},
+        {"name": "e", "max_score": 50},
+        {"name": "f", "max_score": 20},
+        {"name": "g", "max_score": 1},
+    ]
+    path = _write_dimensions(tmp_path, raw)
+    loaded = _load_expected_dimensions(path)
+    assert loaded == raw
+
+
+def test_load_dimensions_rejects_missing_max_score(tmp_path: Path) -> None:
+    path = _write_dimensions(tmp_path, [{"name": "a"}])
+    with pytest.raises(ValueError, match="missing required field 'max_score'"):
+        _load_expected_dimensions(path)
+
+
+def test_load_dimensions_rejects_non_positive_max_score(tmp_path: Path) -> None:
+    path = _write_dimensions(tmp_path, [{"name": "a", "max_score": 0}])
+    with pytest.raises(ValueError, match="invalid max_score"):
+        _load_expected_dimensions(path)
+
+
+def test_parse_response_normalizes_against_actual_max_sum() -> None:
+    expected = [
+        {"name": "a", "max_score": 10},
+        {"name": "b", "max_score": 5},
+        {"name": "c", "max_score": 100},
+        {"name": "d", "max_score": 3},
+        {"name": "e", "max_score": 50},
+        {"name": "f", "max_score": 20},
+        {"name": "g", "max_score": 1},
+    ]
+    response = """```json
+{
+  "dimensions": [
+    {"name": "a", "score": 10, "max_score": 10, "reasoning": ""},
+    {"name": "b", "score": 5, "max_score": 5, "reasoning": ""},
+    {"name": "c", "score": 100, "max_score": 100, "reasoning": ""},
+    {"name": "d", "score": 3, "max_score": 3, "reasoning": ""},
+    {"name": "e", "score": 50, "max_score": 50, "reasoning": ""},
+    {"name": "f", "score": 20, "max_score": 20, "reasoning": ""},
+    {"name": "g", "score": 1, "max_score": 1, "reasoning": ""}
+  ],
+  "summary": "perfect"
+}
+```"""
+    result = _parse_evaluation_response(response, expected)
+    assert result is not None
+    assert result.total_score == 189
+    assert result.normalized_score == 1.0
+
+
+def test_parse_response_clamps_per_dimension_not_to_25() -> None:
+    expected = [{"name": "rich", "max_score": 50}]
+    response = """```json
+{
+  "dimensions": [
+    {"name": "rich", "score": 47, "max_score": 50, "reasoning": "ok"}
+  ],
+  "summary": "high"
+}
+```"""
+    result = _parse_evaluation_response(response, expected)
+    assert result is not None
+    assert result.dimensions[0].score == 47
+    assert result.dimensions[0].max_score == 50
+    assert result.normalized_score == 0.94
+
+
+def test_parse_response_clamps_overshoot_to_dimension_max() -> None:
+    expected = [{"name": "small", "max_score": 10}]
+    response = """```json
+{
+  "dimensions": [
+    {"name": "small", "score": 999, "max_score": 10, "reasoning": "x"}
+  ],
+  "summary": "overshoot"
+}
+```"""
+    result = _parse_evaluation_response(response, expected)
+    assert result is not None
+    assert result.dimensions[0].score == 10
+
+
+def test_parse_response_backwards_compat_4x25() -> None:
+    expected = [
+        {"name": "a", "max_score": 25},
+        {"name": "b", "max_score": 25},
+        {"name": "c", "max_score": 25},
+        {"name": "d", "max_score": 25},
+    ]
+    response = """```json
+{
+  "dimensions": [
+    {"name": "a", "score": 25, "max_score": 25, "reasoning": ""},
+    {"name": "b", "score": 25, "max_score": 25, "reasoning": ""},
+    {"name": "c", "score": 25, "max_score": 25, "reasoning": ""},
+    {"name": "d", "score": 25, "max_score": 25, "reasoning": ""}
+  ],
+  "summary": "ok"
+}
+```"""
+    result = _parse_evaluation_response(response, expected)
+    assert result is not None
+    assert result.total_score == 100
+    assert result.normalized_score == 1.0
+
+
+def test_prompt_lists_per_dimension_ranges_not_shared_25() -> None:
+    prompt = _build_evaluator_prompt(
+        instruction="x",
+        criteria="y",
+        expected_dimensions=[
+            {"name": "small", "max_score": 3},
+            {"name": "medium", "max_score": 20},
+            {"name": "large", "max_score": 100},
+        ],
+    )
+    assert "0–25 points" not in prompt
+    assert "Each dimension is 0–25" not in prompt
+    assert "`small`: 0–3 points" in prompt
+    assert "`medium`: 0–20 points" in prompt
+    assert "`large`: 0–100 points" in prompt


### PR DESCRIPTION
## Summary
- Removes hardcoded `sum-to-100` / `max_score=25` / `3-5 dimensions` assumptions from the evaluator pipeline. Each dimension now declares its own `max_score` (any positive integer); normalization divides by the actual sum of `max_score` values instead of `100`.
- Backwards-compatible — existing `4×25=100` rubrics produce identical `normalized_score`. Bonus: `examples/nasde-dev-skill` (5×25=125) was previously broken (`normalized_score > 1.0`) and now normalizes correctly to `total/125`.
- Full rationale in [ADR-008](docs/adr/008-independent-dimension-scales.md): aligns with G-Eval / MT-Bench / RAGAS, removes silent score truncation when authors used `max_score > 25`.

## Changes
- `evaluator.py`:
  - `DimensionScore.max_score` no longer defaults to 25 (now required)
  - Score clamp is per-dimension (`min(d.max_score, score)`), not `min(25, ...)`
  - `normalized_score = total / sum(max_scores)` instead of `total / 100.0`
  - Validates `max_score` is present and positive when loading `assessment_dimensions.json`
  - Evaluator prompt dynamically lists per-dimension ranges and JSON schema
  - Console output: `Score: X/<actual_total>` instead of hardcoded `/100`
- Scaffold: `nasde init` template now uses mixed scales (20/10/5/15) to communicate intent
- Docs: `CLAUDE.md` and `nasde-benchmark-creator` skill drop the sum-to-100 guidance, link to ADR-008
- Tests: 8 new tests covering arbitrary scales, missing-`max_score` errors, per-dim clamping, and 4×25 backwards compatibility

## Test plan
- [x] `uv run pytest` — 123/123 green
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] E2E smoke test on `examples/refactoring-skill` (4 dims, scales 30/25/25/20):
  - Trial: `reward=1.000` in 3:42
  - Assessment: `Score: 81/100 (0.81)`, per-dim `30/30, 18/25, 13/25, 20/20` — `behavior_preservation` correctly hit 30/30 (would have been silently clamped to 25 under old code)
  - `assessment_eval.json` schema preserved, `normalized_score = 0.81` correct
- [x] Verified existing examples (`ddd-architectural-challenges`, `refactoring-skill`, `nasde-dev-skill`) all parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)