### PR TITLE
feat: PyPI publishing + in-CLI update notifier

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,114 @@
+name: Publish
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      test_pypi:
+        description: "Publish to TestPyPI instead of PyPI"
+        type: boolean
+        default: true
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  quality-gate:
+    name: Quality gate
+    uses: ./.github/workflows/quality-gate.yml
+    permissions:
+      contents: read
+
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    needs: quality-gate
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Verify built version matches tag
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        run: |
+          set -euo pipefail
+          tag_version="${GITHUB_REF_NAME#v}"
+          wheel=$(ls dist/nasde_toolkit-*.whl)
+          built_version=$(basename "$wheel" | sed -E 's/^nasde_toolkit-([^-]+)-.*\.whl$/\1/')
+          if [ "$tag_version" != "$built_version" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME → expected version $tag_version, hatch-vcs produced $built_version"
+            exit 1
+          fi
+          echo "Built version $built_version matches tag $GITHUB_REF_NAME"
+
+      - name: Upload distribution artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/project/nasde-toolkit/
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Download distribution artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: dist/*
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'workflow_dispatch' && inputs.test_pypi
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/nasde-toolkit/
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distribution artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 concurrency:
   group: quality-${{ github.ref }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,15 +9,35 @@ description = "Noesis Agentic Software Development Evals Toolkit"
 readme = "README.md"
 requires-python = ">=3.12"
 license = "MIT"
+keywords = ["evaluation", "agents", "llm", "coding-agents", "evals", "harbor", "opik"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Testing",
+    "Topic :: Software Development :: Quality Assurance",
+]
 dependencies = [
     "typer>=0.15",
     "rich>=14.1",
     "platformdirs>=4.0",
+    "packaging>=25,<26",
     "harbor>=0.4,<0.5",
     "opik>=2,<3",
     # Transitive via harbor/opik. Pinned to fix GHSA-xqmj-j6mv-4862 (litellm <1.83.7).
     "litellm>=1.83.7",
 ]
+
+[project.urls]
+Homepage = "https://noesis.vision/nasde/"
+Source = "https://github.com/NoesisVision/nasde-toolkit"
+Issues = "https://github.com/NoesisVision/nasde-toolkit/issues"
+Changelog = "https://github.com/NoesisVision/nasde-toolkit/blob/main/CHANGELOG.md"
+Documentation = "https://github.com/NoesisVision/nasde-toolkit/tree/main/docs"
 
 [project.scripts]
 nasde = "nasde_toolkit.cli:app"

--- a/src/nasde_toolkit/cli.py
+++ b/src/nasde_toolkit/cli.py
@@ -87,6 +87,10 @@ def main(
     ),
 ) -> None:
     """Noesis Agentic Software Development Evals Toolkit."""
+    from nasde_toolkit._version import __version__
+    from nasde_toolkit.update_check import maybe_notify_update
+
+    maybe_notify_update(console, current_version=__version__)
     if ctx.invoked_subcommand is None:
         console.print(ctx.get_help())
         raise typer.Exit()

--- a/src/nasde_toolkit/update_check.py
+++ b/src/nasde_toolkit/update_check.py
@@ -1,0 +1,166 @@
+"""PyPI update notifier for the nasde CLI.
+
+Fetches the latest released version of nasde-toolkit from PyPI and prints a
+one-line notice on stderr when the user is running an older release. Notify-only:
+never auto-updates and never prompts. Skips silently in CI, non-TTY contexts,
+when explicitly disabled, and on dev/pre-release builds.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Literal
+
+from packaging.version import InvalidVersion, Version
+from platformdirs import user_cache_dir
+from rich.console import Console
+
+_PYPI_JSON_URL = "https://pypi.org/pypi/nasde-toolkit/json"
+_CHANGELOG_URL = "https://github.com/NoesisVision/nasde-toolkit/blob/main/CHANGELOG.md"
+_CACHE_TTL = timedelta(hours=24)
+_FETCH_TIMEOUT_SEC = 2.0
+
+_BumpKind = Literal["none", "patch", "minor", "major"]
+
+
+@dataclass(frozen=True)
+class _CacheEntry:
+    checked_at: str
+    latest_version: str
+
+
+def maybe_notify_update(console: Console, *, current_version: str) -> None:
+    """Display one-line update notice if a newer release is available.
+
+    Never raises. Skips silently when stderr is not a TTY, NASDE_NO_UPDATE_CHECK
+    or CI is set, current_version is dev/pre-release, or PyPI is unreachable.
+    """
+    try:
+        if not _should_check(current_version):
+            return
+        latest = _resolve_latest_version()
+        if latest is None:
+            return
+        try:
+            current = Version(current_version)
+        except InvalidVersion:
+            return
+        bump = _classify_bump(current, latest)
+        if bump == "none":
+            return
+        _print_notice(console, bump, current, latest)
+    except Exception:
+        return
+
+
+def _should_check(current_version: str) -> bool:
+    if os.environ.get("NASDE_NO_UPDATE_CHECK"):
+        return False
+    if os.environ.get("CI"):
+        return False
+    if not sys.stderr.isatty():
+        return False
+    try:
+        parsed = Version(current_version)
+    except InvalidVersion:
+        return False
+    return not ((parsed.is_devrelease or parsed.is_prerelease) and not os.environ.get("NASDE_FORCE_UPDATE_CHECK"))
+
+
+def _resolve_latest_version() -> Version | None:
+    cache = _read_cache()
+    now = datetime.now(UTC)
+    if cache is not None:
+        try:
+            checked_at = datetime.fromisoformat(cache.checked_at)
+            cached_version = Version(cache.latest_version)
+        except (ValueError, InvalidVersion):
+            cache = None
+        else:
+            if now - checked_at < _CACHE_TTL:
+                return cached_version
+    fetched = _fetch_latest_version(_FETCH_TIMEOUT_SEC)
+    if fetched is None:
+        return None
+    _write_cache(_CacheEntry(checked_at=now.isoformat(), latest_version=str(fetched)))
+    return fetched
+
+
+def _fetch_latest_version(timeout: float) -> Version | None:
+    try:
+        with urllib.request.urlopen(_PYPI_JSON_URL, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError):
+        return None
+    raw = payload.get("info", {}).get("version")
+    if not isinstance(raw, str):
+        return None
+    try:
+        return Version(raw)
+    except InvalidVersion:
+        return None
+
+
+def _read_cache() -> _CacheEntry | None:
+    path = _cache_path()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return _CacheEntry(
+            checked_at=data["checked_at"],
+            latest_version=data["latest_version"],
+        )
+    except (OSError, json.JSONDecodeError, KeyError, TypeError):
+        return None
+
+
+def _write_cache(entry: _CacheEntry) -> None:
+    path = _cache_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(asdict(entry)), encoding="utf-8")
+    except OSError:
+        return
+
+
+def _cache_path() -> Path:
+    return Path(user_cache_dir("nasde-toolkit", "noesis")) / "update-check.json"
+
+
+def _classify_bump(current: Version, latest: Version) -> _BumpKind:
+    if latest <= current:
+        return "none"
+    if latest.major > current.major:
+        return "major"
+    if latest.minor > current.minor:
+        return "minor"
+    return "patch"
+
+
+def _print_notice(console: Console, bump: _BumpKind, current: Version, latest: Version) -> None:
+    stderr = Console(stderr=True, soft_wrap=True) if not console.stderr else console
+    message = _format_message(bump, current, latest)
+    stderr.print(message)
+
+
+def _format_message(bump: _BumpKind, current: Version, latest: Version) -> str:
+    upgrade_cmd = "[bold]uv tool upgrade nasde-toolkit[/bold]"
+    if bump == "patch":
+        return f"Update available: nasde-toolkit {current} → {latest}. Run {upgrade_cmd} to update."
+    if bump == "minor":
+        return (
+            f"Update available: nasde-toolkit {current} → {latest} (new features). "
+            f"Changelog: {_CHANGELOG_URL}. Run {upgrade_cmd}."
+        )
+    return (
+        f"[yellow]Major update available[/yellow]: nasde-toolkit {current} → {latest}. "
+        f"May contain breaking changes. Review release notes: {_CHANGELOG_URL}."
+    )

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,0 +1,204 @@
+"""Tests for the PyPI update notifier."""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from packaging.version import Version
+from rich.console import Console
+
+from nasde_toolkit import update_check
+
+
+@pytest.fixture(autouse=True)
+def _isolate_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("NASDE_NO_UPDATE_CHECK", raising=False)
+    monkeypatch.delenv("NASDE_FORCE_UPDATE_CHECK", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setattr(update_check, "_cache_path", lambda: tmp_path / "update-check.json")
+    monkeypatch.setattr("sys.stderr.isatty", lambda: True)
+
+
+def _make_console() -> Console:
+    return Console(file=io.StringIO(), force_terminal=False, width=200)
+
+
+def _stub_response(version: str) -> bytes:
+    return json.dumps({"info": {"version": version}}).encode("utf-8")
+
+
+class _FakeUrlopen:
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def __enter__(self) -> _FakeUrlopen:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def test_skips_when_no_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.stderr.isatty", lambda: False)
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        update_check.maybe_notify_update(_make_console(), current_version="0.3.0")
+    mock_urlopen.assert_not_called()
+
+
+def test_skips_when_no_update_check_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NASDE_NO_UPDATE_CHECK", "1")
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        update_check.maybe_notify_update(_make_console(), current_version="0.3.0")
+    mock_urlopen.assert_not_called()
+
+
+def test_skips_when_ci_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CI", "true")
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        update_check.maybe_notify_update(_make_console(), current_version="0.3.0")
+    mock_urlopen.assert_not_called()
+
+
+def test_skips_dev_version() -> None:
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        update_check.maybe_notify_update(
+            _make_console(),
+            current_version="0.2.2.dev9+gf024b8e7",
+        )
+    mock_urlopen.assert_not_called()
+
+
+def test_force_check_overrides_dev_skip(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NASDE_FORCE_UPDATE_CHECK", "1")
+    with patch("urllib.request.urlopen", return_value=_FakeUrlopen(_stub_response("0.5.0"))) as mock_urlopen:
+        update_check.maybe_notify_update(
+            _make_console(),
+            current_version="0.2.2.dev9+gf024b8e7",
+        )
+    mock_urlopen.assert_called_once()
+
+
+def test_cache_hit_no_newer(tmp_path: Path) -> None:
+    cache_path = tmp_path / "update-check.json"
+    cache_path.write_text(
+        json.dumps(
+            {
+                "checked_at": datetime.now(UTC).isoformat(),
+                "latest_version": "0.3.0",
+            }
+        )
+    )
+    console = _make_console()
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        update_check.maybe_notify_update(console, current_version="0.3.0")
+    mock_urlopen.assert_not_called()
+    assert console.file.getvalue() == ""  # type: ignore[union-attr]
+
+
+def test_cache_hit_newer_known_skips_fetch_but_prints(tmp_path: Path) -> None:
+    cache_path = tmp_path / "update-check.json"
+    cache_path.write_text(
+        json.dumps(
+            {
+                "checked_at": datetime.now(UTC).isoformat(),
+                "latest_version": "0.4.0",
+            }
+        )
+    )
+    console = _make_console()
+    with patch("urllib.request.urlopen") as mock_urlopen, patch.object(update_check, "_print_notice") as mock_print:
+        update_check.maybe_notify_update(console, current_version="0.3.0")
+    mock_urlopen.assert_not_called()
+    mock_print.assert_called_once()
+
+
+def test_cache_miss_fetches_and_writes(tmp_path: Path) -> None:
+    cache_path = tmp_path / "update-check.json"
+    assert not cache_path.exists()
+    with patch("urllib.request.urlopen", return_value=_FakeUrlopen(_stub_response("0.4.0"))):
+        update_check.maybe_notify_update(_make_console(), current_version="0.3.0")
+    assert cache_path.exists()
+    written = json.loads(cache_path.read_text())
+    assert written["latest_version"] == "0.4.0"
+    assert "checked_at" in written
+
+
+def test_stale_cache_triggers_refetch(tmp_path: Path) -> None:
+    cache_path = tmp_path / "update-check.json"
+    stale = (datetime.now(UTC) - timedelta(hours=48)).isoformat()
+    cache_path.write_text(json.dumps({"checked_at": stale, "latest_version": "0.3.0"}))
+    with patch("urllib.request.urlopen", return_value=_FakeUrlopen(_stub_response("0.4.0"))) as mock_urlopen:
+        update_check.maybe_notify_update(_make_console(), current_version="0.3.0")
+    mock_urlopen.assert_called_once()
+    written = json.loads(cache_path.read_text())
+    assert written["latest_version"] == "0.4.0"
+
+
+def test_network_failure_silent() -> None:
+    console = _make_console()
+    with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("offline")):
+        update_check.maybe_notify_update(console, current_version="0.3.0")
+    assert console.file.getvalue() == ""  # type: ignore[union-attr]
+
+
+def test_corrupt_cache_treated_as_miss(tmp_path: Path) -> None:
+    cache_path = tmp_path / "update-check.json"
+    cache_path.write_text("{not valid json")
+    with patch("urllib.request.urlopen", return_value=_FakeUrlopen(_stub_response("0.4.0"))) as mock_urlopen:
+        update_check.maybe_notify_update(_make_console(), current_version="0.3.0")
+    mock_urlopen.assert_called_once()
+
+
+def test_invalid_pypi_payload_silent() -> None:
+    console = _make_console()
+    bad_response = json.dumps({"info": {"version": "not-a-version"}}).encode("utf-8")
+    with patch("urllib.request.urlopen", return_value=_FakeUrlopen(bad_response)):
+        update_check.maybe_notify_update(console, current_version="0.3.0")
+    assert console.file.getvalue() == ""  # type: ignore[union-attr]
+
+
+@pytest.mark.parametrize(
+    ("current", "latest", "expected"),
+    [
+        ("0.3.0", "0.3.1", "patch"),
+        ("0.3.0", "0.4.0", "minor"),
+        ("0.3.0", "1.0.0", "major"),
+        ("0.3.0", "0.3.0", "none"),
+        ("0.3.0", "0.2.9", "none"),
+        ("1.2.3", "1.2.4", "patch"),
+        ("1.2.3", "1.3.0", "minor"),
+        ("1.2.3", "2.0.0", "major"),
+    ],
+)
+def test_classify_bump(current: str, latest: str, expected: str) -> None:
+    assert update_check._classify_bump(Version(current), Version(latest)) == expected
+
+
+@pytest.mark.parametrize(
+    ("bump", "expected_substring"),
+    [
+        ("patch", "uv tool upgrade nasde-toolkit"),
+        ("minor", "new features"),
+        ("major", "breaking changes"),
+    ],
+)
+def test_format_message_includes_key_phrases(bump: str, expected_substring: str) -> None:
+    message = update_check._format_message(bump, Version("0.3.0"), Version("0.4.0"))  # type: ignore[arg-type]
+    assert expected_substring in message
+
+
+def test_invalid_current_version_silent() -> None:
+    console = _make_console()
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        update_check.maybe_notify_update(console, current_version="not-a-version")
+    mock_urlopen.assert_not_called()
+    assert console.file.getvalue() == ""  # type: ignore[union-attr]

--- a/uv.lock
+++ b/uv.lock
@@ -1430,6 +1430,7 @@ dependencies = [
     { name = "harbor" },
     { name = "litellm" },
     { name = "opik" },
+    { name = "packaging" },
     { name = "platformdirs" },
     { name = "rich" },
     { name = "typer" },
@@ -1448,6 +1449,7 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.83.7" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14" },
     { name = "opik", specifier = ">=2,<3" },
+    { name = "packaging", specifier = ">=25,<26" },
     { name = "platformdirs", specifier = ">=4.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "rich", specifier = ">=14.1" },
@@ -1568,11 +1570,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.1"
+version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds automated PyPI publishing via `.github/workflows/publish.yml` using **Trusted Publishing (OIDC)** — no API tokens, no secrets. Tag push (`v*`) → publish to PyPI; manual `workflow_dispatch` with `test_pypi=true` → publish to TestPyPI for dry-run verification.
- Adds an in-CLI **update notifier** (`src/nasde_toolkit/update_check.py`) wired into the Typer callback. Checks PyPI for newer releases on startup, prints a one-line notice on stderr (severity-tinted: patch/minor/major), with a 24h cache via `platformdirs`. **Notify-only** — never auto-applies, never prompts (avoids breakage in CI, pipes, and agent-harness invocations).
- Enriches `pyproject.toml` with `[project.urls]`, `keywords`, and `classifiers` so the PyPI project page renders properly. Pins `packaging>=25,<26` explicitly (used by the notifier; `harbor` already requires it transitively).
- Reuses `quality-gate.yml` as a `workflow_call` prerequisite of `publish.yml` so a release cannot ship without lint/typecheck/tests/audit passing on the tagged commit.

This is the **first half** of the PyPI migration. README install instructions intentionally still pin `@v0.2.1` — they'll move to `uv tool install nasde-toolkit` in a follow-up PR **after the first PyPI publish exists**, to avoid pointing users at a 404.

## What's NOT in this PR (deliberately)

- README/RELEASING.md install-instruction migration — separate follow-up PR.
- Auto-apply patch updates / interactive prompts — explicit non-goal. CLI runs from agent harnesses where stdin isn't human; auto-update of an installed tool from inside its own running process is unsafe (`uv tool` / `pipx` / `pip` have different upgrade semantics). Notify-only is the right primitive.

## One-time setup required before the first publish

The workflow won't do anything until Trusted Publishers are bound. Roughly 15 minutes:

1. **PyPI**: account on pypi.org with 2FA → https://pypi.org/manage/account/publishing/ → "Add a new pending publisher" with project `nasde-toolkit`, owner `NoesisVision`, repo `nasde-toolkit`, workflow `publish.yml`, environment `pypi`.
2. **TestPyPI**: same flow on test.pypi.org with environment `testpypi`.
3. **GitHub**: Settings → Environments → create `pypi` and `testpypi` (no secrets, no required reviewers).

After setup: manual `workflow_dispatch` with `test_pypi=true` to verify against TestPyPI; then tag `v0.3.1` to ship the first real release.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — 29 files formatted
- [x] `uv run mypy src/nasde_toolkit/` — no issues, 18 files
- [x] `uv run pytest tests/` — 139 passed (24 new in `test_update_check.py`)
- [x] `uv build` — produces wheel + sdist; verified METADATA contains all 5 project URLs, 9 classifiers, keywords, and MIT license
- [x] Smoke: `nasde --version` and `NASDE_NO_UPDATE_CHECK=1 nasde` both render correctly
- [ ] After merge: manual `workflow_dispatch publish.yml` with `test_pypi=true` to verify TestPyPI publish end-to-end before tagging
- [ ] After Trusted Publisher setup: tag `v0.3.1` to verify production publish

## Notifier behavior matrix

| Condition | Network call? | Prints notice? |
|---|---|---|
| `nasde --version` | ❌ (eager `--version` callback exits before notifier runs) | ❌ |
| `CI=true` env | ❌ | ❌ |
| `NASDE_NO_UPDATE_CHECK=1` | ❌ | ❌ |
| `not stderr.isatty()` (pipe, redirect) | ❌ | ❌ |
| Dev/pre-release version (e.g. `0.2.2.dev9+...`) | ❌ unless `NASDE_FORCE_UPDATE_CHECK=1` | ❌ |
| Cache fresh (<24h), `latest == current` | ❌ | ❌ |
| Cache fresh, `latest > current` | ❌ | ✅ |
| Cache stale or missing | ✅ (2s timeout, silently swallows failures) | ✅ if newer |