### PR TITLE
fix(build): drop local-version segment from hatch-vcs output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ nasde = "nasde_toolkit.cli:app"
 
 [tool.hatch.version]
 source = "vcs"
+raw-options = { local_scheme = "no-local-version" }
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/nasde_toolkit/_version.py"


### PR DESCRIPTION
## Summary

The TestPyPI dry-run of `publish.yml` (added in #36) failed with:

\`\`\`
400 Bad Request: The use of local versions in '0.3.1.dev1+g29425212e' is not allowed.
\`\`\`

PyPI/TestPyPI both reject uploads with [PEP 440 local version identifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/#local-version-identifiers) — the segment after \`+\` (\`+gHASH\`) is reserved for distinguishing local builds and is forbidden on the public index.

## Fix

Set \`local_scheme = "no-local-version"\` on hatch-vcs. This strips only the \`+gHASH\` suffix; everything else is unchanged:

| Build context | Before | After |
|---|---|---|
| Untagged commit (\`main\`) | \`0.3.1.dev1+g29425212e\` | \`0.3.1.dev1\` |
| Tagged commit (\`v0.3.1\`) | \`0.3.1\` | \`0.3.1\` (unchanged) |

Dev versions remain PyPI-acceptable as pre-releases (PEP 440 \`.devN\`). Tagged release versions are unaffected.

## Test plan

- [x] \`uv build\` locally → wheel filename is \`nasde_toolkit-0.3.1.dev1-py3-none-any.whl\` (no \`+gHASH\`)
- [x] \`uv run pytest\` → 147 passed
- [ ] After merge: re-run \`workflow_dispatch publish.yml\` with \`test_pypi=true\` to verify TestPyPI accepts the upload