### PR TITLE
chore(scripts): add Windows PowerShell OAuth token exporter

### DIFF
--- a/.claude/skills/nasde-benchmark-runner/SKILL.md
+++ b/.claude/skills/nasde-benchmark-runner/SKILL.md
@@ -17,68 +17,80 @@ Run coding agent benchmarks with `nasde` and verify results. The two-stage pipel
 
 ## Authentication setup
 
-Before running any benchmark, set up authentication tokens. Both are needed for cross-agent benchmarks.
+Before running any benchmark, set up authentication tokens for the agents you plan to run. Both OS and auth method matter — pick the right command per row.
 
-### Claude Code (OAuth token from subscription)
+### Step 1 — Ask the user which auth they prefer
 
-```bash
-source scripts/export_oauth_token.sh
-```
+**Always ask the user before running, never assume.** Two questions:
 
-This extracts `CLAUDE_CODE_OAUTH_TOKEN` from macOS Keychain (written by `claude` CLI login). Required for both Claude agent runs AND assessment evaluation (which spawns the `claude` CLI as a subprocess when `[evaluation] backend = "claude"`).
+1. **Which agents will you run?** (Claude / Codex / Gemini, any combination)
+2. **For each agent, OAuth (subscription) or API key (per-token billing)?** Default recommendation: OAuth where available — no per-token cost, no env vars to manage.
 
-Alternatively, set `ANTHROPIC_API_KEY` for API billing.
+Then detect their OS and pick the matching script row from the table below. On Windows, also ask whether they're in **PowerShell** or **WSL** (cmd.exe is not directly supported — see "Windows: cmd.exe" below).
 
-### Codex (ChatGPT subscription or API key)
+### Step 2 — Run the right script per agent × OS
 
-**Option 1: ChatGPT subscription (OAuth)** — uses ChatGPT Plus/Pro/Business plan credits, no per-token API cost:
+Priority order: **Claude → Codex → Gemini.** Claude is required even for non-Claude variants when `[evaluation] backend = "claude"` (default), because the assessment evaluator spawns `claude` CLI as a subprocess.
 
-```bash
-codex login                                # one-time: authenticate via ChatGPT
-source scripts/export_codex_oauth_token.sh # validate tokens are present
-```
+#### Claude Code
 
-NASDE auto-detects `~/.codex/auth.json` with `auth_mode: "chatgpt"` and injects OAuth tokens into the sandbox. No env vars needed.
+| OS / shell | OAuth (subscription) | API key |
+|---|---|---|
+| macOS | `source scripts/export_oauth_token.sh` (reads Keychain entry "Claude Code-credentials") | `export ANTHROPIC_API_KEY=sk-ant-...` |
+| Linux | `source scripts/export_oauth_token.sh` (reads `~/.claude/.credentials.json`) | `export ANTHROPIC_API_KEY=sk-ant-...` |
+| Windows PowerShell | `. .\scripts\export_oauth_token.ps1` (reads `%USERPROFILE%\.claude\.credentials.json`) | `$env:ANTHROPIC_API_KEY = 'sk-ant-...'` |
+| Windows WSL (Ubuntu) | `source scripts/export_oauth_token.sh` (Linux path) | `export ANTHROPIC_API_KEY=sk-ant-...` |
 
-**Option 2: API key** — billed per-token through OpenAI Platform:
+Prerequisite for OAuth: `claude` CLI installed and `claude` ran once to log in.
 
-```bash
-export $(grep CODEX_API_KEY .env)
-```
+The script exports `CLAUDE_CODE_OAUTH_TOKEN`. This is required for both Claude variant runs AND assessment evaluation (when `[evaluation] backend = "claude"` — the default).
 
-Or set directly: `export CODEX_API_KEY=sk-proj-...`
+#### Codex
 
-API key always takes priority over OAuth when both are present.
+| OS / shell | OAuth (ChatGPT subscription) | API key |
+|---|---|---|
+| macOS | `codex login` once, then `source scripts/export_codex_oauth_token.sh` | `export CODEX_API_KEY=sk-proj-...` (or `OPENAI_API_KEY`) |
+| Linux | `codex login` once, then `source scripts/export_codex_oauth_token.sh` | `export CODEX_API_KEY=sk-proj-...` |
+| Windows PowerShell | `codex login` once, then `. .\scripts\export_codex_oauth_token.ps1` | `$env:CODEX_API_KEY = 'sk-proj-...'` |
+| Windows WSL (Ubuntu) | `codex login` once, then `source scripts/export_codex_oauth_token.sh` | `export CODEX_API_KEY=sk-proj-...` |
 
-### Gemini CLI (Google account or API key)
+The OAuth scripts only **validate** `~/.codex/auth.json` (or `%USERPROFILE%\.codex\auth.json`) — Harbor injects the file into the sandbox automatically. API key always takes priority over OAuth when both are present.
 
-**Option 1: Google account OAuth** — uses Google account credits, no per-token API cost:
+#### Gemini CLI
 
-```bash
-gemini login                                # one-time: authenticate via Google account
-source scripts/export_gemini_oauth_token.sh # validate tokens are present
-```
+| OS / shell | OAuth (Google account) | API key |
+|---|---|---|
+| macOS | `gemini login` once, then `source scripts/export_gemini_oauth_token.sh` | `export GEMINI_API_KEY=...` |
+| Linux | `gemini login` once, then `source scripts/export_gemini_oauth_token.sh` | `export GEMINI_API_KEY=...` |
+| Windows PowerShell | `gemini login` once, then `. .\scripts\export_gemini_oauth_token.ps1` | `$env:GEMINI_API_KEY = '...'` |
+| Windows WSL (Ubuntu) | `gemini login` once, then `source scripts/export_gemini_oauth_token.sh` | `export GEMINI_API_KEY=...` |
 
-NASDE auto-detects `~/.gemini/oauth_creds.json` and injects OAuth credentials into the sandbox. No env vars needed.
-
-**Option 2: API key** — billed through Google AI Studio or Vertex AI:
-
-```bash
-export GEMINI_API_KEY=your-key
-```
-
-Or for Vertex AI: `export GOOGLE_API_KEY=your-key` + `export GOOGLE_CLOUD_PROJECT=your-project`
-
-API key always takes priority over OAuth when both are present.
+The OAuth scripts export `GEMINI_OAUTH_CREDS` (the raw JSON) — `ConfigurableGemini` reads that env var and injects credentials into the sandbox. API key always takes priority over OAuth.
 
 ### Combined setup for cross-agent runs
 
+**macOS / Linux / Windows WSL:**
 ```bash
 source scripts/export_oauth_token.sh         # Claude (subscription)
-# Codex: either codex login (subscription) or:
-export $(grep CODEX_API_KEY .env)            # Codex (API key)
-source scripts/export_gemini_oauth_token.sh  # Gemini (Google account)
+source scripts/export_codex_oauth_token.sh   # Codex (subscription) — or: export CODEX_API_KEY=...
+source scripts/export_gemini_oauth_token.sh  # Gemini (Google account) — or: export GEMINI_API_KEY=...
 ```
+
+**Windows PowerShell:**
+```powershell
+. .\scripts\export_oauth_token.ps1
+. .\scripts\export_codex_oauth_token.ps1
+. .\scripts\export_gemini_oauth_token.ps1
+```
+
+### Windows: cmd.exe
+
+cmd.exe is **not supported directly** — `.ps1` requires PowerShell, `.sh` requires bash. Two workarounds:
+
+1. **Open PowerShell** (`powershell.exe`) and dot-source the `.ps1` script. This is the simplest path on a vanilla Windows install.
+2. **Use WSL** (`wsl -d Ubuntu`) and source the `.sh` script. This is the recommended path if you also want Docker Desktop with the WSL2 backend, which is the most common dev setup.
+
+If a user is in cmd.exe, point them to one of these two — don't try to extract the token manually.
 
 ## Running benchmarks
 

--- a/scripts/export_codex_oauth_token.ps1
+++ b/scripts/export_codex_oauth_token.ps1
@@ -1,0 +1,61 @@
+# Validate Codex OAuth auth.json for ChatGPT subscription-based authentication.
+#
+# Windows-equivalent of scripts/export_codex_oauth_token.sh.
+#
+# Dot-source this script before running nasde to verify your ChatGPT
+# subscription credentials:
+#
+#     . .\scripts\export_codex_oauth_token.ps1
+#     nasde run --variant codex-vanilla -C my-benchmark
+#
+# Prerequisites: run `codex login` to authenticate via ChatGPT.
+# Reads %USERPROFILE%\.codex\auth.json. NASDE injects this file into the
+# sandbox automatically — this script only validates it.
+
+$ErrorActionPreference = 'Stop'
+
+$authPath = Join-Path $env:USERPROFILE '.codex\auth.json'
+
+if (-not (Test-Path $authPath)) {
+    Write-Error "$authPath not found. Run 'codex login' to authenticate via ChatGPT subscription."
+    return
+}
+
+try {
+    $auth = Get-Content $authPath -Raw | ConvertFrom-Json
+} catch {
+    Write-Error "Failed to parse $authPath : $_"
+    return
+}
+
+if ($auth.auth_mode -ne 'chatgpt') {
+    Write-Error "auth_mode is '$($auth.auth_mode)', expected 'chatgpt'. Run 'codex login' to authenticate via ChatGPT subscription."
+    return
+}
+
+$accessToken = $auth.tokens.access_token
+if ([string]::IsNullOrEmpty($accessToken)) {
+    Write-Error "access_token is empty in $authPath. Run 'codex login' to re-authenticate."
+    return
+}
+
+# Decode JWT payload (middle segment) to read exp claim. Pad base64url to
+# multiple of 4 with '=' before decoding.
+try {
+    $payloadSegment = $accessToken.Split('.')[1]
+    $padded = $payloadSegment.Replace('-', '+').Replace('_', '/')
+    switch ($padded.Length % 4) { 2 { $padded += '==' } 3 { $padded += '=' } }
+    $payloadJson = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($padded))
+    $exp = ($payloadJson | ConvertFrom-Json).exp
+} catch {
+    $exp = 0
+}
+
+$now = [int][double]::Parse((Get-Date -UFormat %s))
+if ($exp -gt 0 -and $now -gt $exp) {
+    Write-Warning "access_token expired. Run 'codex login' to refresh."
+    Write-Warning "Proceeding anyway -- Codex CLI may auto-refresh via refresh_token."
+}
+
+$preview = $accessToken.Substring(0, [Math]::Min(20, $accessToken.Length))
+Write-Host "OK Codex OAuth validated (auth_mode=chatgpt, token=$preview...)" -ForegroundColor Green

--- a/scripts/export_gemini_oauth_token.ps1
+++ b/scripts/export_gemini_oauth_token.ps1
@@ -1,0 +1,59 @@
+# Export Gemini CLI OAuth credentials for subscription-based authentication.
+#
+# Windows-equivalent of scripts/export_gemini_oauth_token.sh.
+#
+# Dot-source this script before running nasde to authenticate via your
+# Google account instead of GEMINI_API_KEY:
+#
+#     . .\scripts\export_gemini_oauth_token.ps1
+#     nasde run --variant gemini-vanilla -C my-benchmark
+#
+# Prerequisites: run `gemini login` to authenticate via Google.
+# Reads %USERPROFILE%\.gemini\oauth_creds.json and exports the raw JSON as
+# $env:GEMINI_OAUTH_CREDS. ConfigurableGemini injects this into the sandbox.
+
+$ErrorActionPreference = 'Stop'
+
+$credPath = Join-Path $env:USERPROFILE '.gemini\oauth_creds.json'
+
+if (-not (Test-Path $credPath)) {
+    Write-Error "$credPath not found. Run 'gemini login' to authenticate via Google."
+    return
+}
+
+try {
+    $rawJson = Get-Content $credPath -Raw
+    $parsed = $rawJson | ConvertFrom-Json
+} catch {
+    Write-Error "$credPath does not contain valid JSON credentials: $_"
+    return
+}
+
+if (-not $parsed) {
+    Write-Error "$credPath contains empty credentials."
+    return
+}
+
+$accessToken = $parsed.access_token
+if (-not [string]::IsNullOrEmpty($accessToken)) {
+    try {
+        $payloadSegment = $accessToken.Split('.')[1]
+        $padded = $payloadSegment.Replace('-', '+').Replace('_', '/')
+        switch ($padded.Length % 4) { 2 { $padded += '==' } 3 { $padded += '=' } }
+        $payloadJson = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($padded))
+        $exp = ($payloadJson | ConvertFrom-Json).exp
+    } catch {
+        $exp = 0
+    }
+
+    $now = [int][double]::Parse((Get-Date -UFormat %s))
+    if ($exp -gt 0 -and $now -gt $exp) {
+        Write-Warning "access_token appears expired. Run 'gemini login' to refresh."
+        Write-Warning "Proceeding anyway -- Gemini CLI may auto-refresh via refresh_token."
+    }
+}
+
+$env:GEMINI_OAUTH_CREDS = $rawJson
+
+$preview = $rawJson.Substring(0, [Math]::Min(20, $rawJson.Length))
+Write-Host "OK GEMINI_OAUTH_CREDS exported ($preview...)" -ForegroundColor Green

--- a/scripts/export_oauth_token.ps1
+++ b/scripts/export_oauth_token.ps1
@@ -1,0 +1,40 @@
+# Extract Claude Code OAuth token from %USERPROFILE%\.claude\.credentials.json
+# and export it as $env:CLAUDE_CODE_OAUTH_TOKEN.
+#
+# Windows-equivalent of scripts/export_oauth_token.sh (which reads the macOS
+# Keychain). On Windows, Claude Code stores credentials as plain JSON.
+#
+# Dot-source this script before running nasde so the env var persists in the
+# current PowerShell session:
+#
+#     . .\scripts\export_oauth_token.ps1
+#     nasde run --variant baseline -C my-benchmark
+#
+# Running without dot-source (.\scripts\export_oauth_token.ps1) sets the var
+# only inside the script's child scope and it disappears on return.
+
+$ErrorActionPreference = 'Stop'
+
+$credPath = Join-Path $env:USERPROFILE '.claude\.credentials.json'
+
+if (-not (Test-Path $credPath)) {
+    Write-Error "Could not find '$credPath'. Run 'claude' CLI and log in first."
+    return
+}
+
+try {
+    $token = (Get-Content $credPath -Raw | ConvertFrom-Json).claudeAiOauth.accessToken
+} catch {
+    Write-Error "Failed to parse OAuth token from '$credPath': $_"
+    return
+}
+
+if ([string]::IsNullOrEmpty($token)) {
+    Write-Error "claudeAiOauth.accessToken is empty in '$credPath'."
+    return
+}
+
+$env:CLAUDE_CODE_OAUTH_TOKEN = $token
+
+$preview = $token.Substring(0, [Math]::Min(20, $token.Length))
+Write-Host "OK CLAUDE_CODE_OAUTH_TOKEN exported ($preview...)" -ForegroundColor Green

--- a/scripts/export_oauth_token.sh
+++ b/scripts/export_oauth_token.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Extract Claude Code OAuth token from macOS Keychain and export it.
+# Extract Claude Code OAuth token and export it as CLAUDE_CODE_OAUTH_TOKEN.
 #
 # Source this script before running nasde to authenticate via your
 # Claude Pro/Max subscription instead of ANTHROPIC_API_KEY:
@@ -8,21 +8,35 @@
 #   source scripts/export_oauth_token.sh
 #   nasde run --variant baseline -C my-benchmark
 #
-# The token is extracted from the macOS Keychain entry "Claude Code-credentials"
-# which is written by Claude Code when you authenticate via `claude` CLI.
+# Storage backend depends on OS:
+#   - macOS: Keychain entry "Claude Code-credentials" (written by `claude` CLI)
+#   - Linux: plain JSON at ~/.claude/.credentials.json
+# Windows users: see scripts/export_oauth_token.ps1 (PowerShell).
 
-# NOTE: Do NOT use `set -e` here — this script is sourced into the user's
+# NOTE: Do NOT use `set -e` here -- this script is sourced into the user's
 # shell, so errexit would persist and kill the terminal on any later non-zero
 # exit code. Each command already has its own `|| { ... }` error handling.
 
-_raw_creds="$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null)" || {
-    echo "ERROR: Could not read 'Claude Code-credentials' from macOS Keychain." >&2
-    echo "Make sure you are logged into Claude Code ('claude' CLI) on this machine." >&2
+_raw_creds=""
+
+if command -v security >/dev/null 2>&1; then
+    _raw_creds="$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null)"
+fi
+
+if [ -z "$_raw_creds" ] && [ -f "$HOME/.claude/.credentials.json" ]; then
+    _raw_creds="$(cat "$HOME/.claude/.credentials.json")"
+fi
+
+if [ -z "$_raw_creds" ]; then
+    echo "ERROR: Could not read Claude Code credentials." >&2
+    echo "  - macOS: keychain entry 'Claude Code-credentials' missing" >&2
+    echo "  - Linux: ~/.claude/.credentials.json missing" >&2
+    echo "Run 'claude' CLI and log in first." >&2
     return 1 2>/dev/null || exit 1
-}
+fi
 
 CLAUDE_CODE_OAUTH_TOKEN="$(echo "$_raw_creds" | python3 -c "import sys,json; print(json.load(sys.stdin)['claudeAiOauth']['accessToken'])")" || {
-    echo "ERROR: Failed to parse OAuth token from Keychain credentials." >&2
+    echo "ERROR: Failed to parse OAuth token from Claude credentials." >&2
     return 1 2>/dev/null || exit 1
 }
 export CLAUDE_CODE_OAUTH_TOKEN


### PR DESCRIPTION
## Summary
- Adds `scripts/export_oauth_token.ps1`, the Windows-side counterpart of `scripts/export_oauth_token.sh`.
- Reads `%USERPROFILE%\.claude\.credentials.json` (where the `claude` CLI stores credentials on Windows — no Keychain) and exports `$env:CLAUDE_CODE_OAUTH_TOKEN` in the current PowerShell session.
- Use via dot-source: `. .\scripts\export_oauth_token.ps1`

## Why
Existing `export_oauth_token.sh` calls `security find-generic-password`, which only exists on macOS. Windows users had to extract the token manually before running `nasde run`.

## Verification
End-to-end check on Windows 11 + Docker Desktop:
- Dot-sourcing the script sets `$env:CLAUDE_CODE_OAUTH_TOKEN` (108-char token).
- `docker run --rm -e CLAUDE_CODE_OAUTH_TOKEN ubuntu:22.04 ...` reproduces the same length inside the container.
- Harbor's `ClaudeCode.run()` reads the var via `os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "")` (`harbor/agents/installed/claude_code.py:979`) and forwards it to `environment.exec(env=...)`, so `nasde run` inherits it transparently.

## Test plan
- [ ] On Windows: `. .\scripts\export_oauth_token.ps1` prints `OK CLAUDE_CODE_OAUTH_TOKEN exported (sk-ant-oat01-...)`.
- [ ] `$env:CLAUDE_CODE_OAUTH_TOKEN.Length` reports the current token length.
- [ ] `nasde run --variant claude-vanilla -C examples/...` from the same PowerShell session uses the subscription token (no `ANTHROPIC_API_KEY` needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)