### PR TITLE
ci: extend quality-gate matrix to Windows; fix codex backend test isolation

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -56,8 +56,13 @@ jobs:
         run: uv run mypy src/nasde_toolkit/
 
   test:
-    name: Unit tests (pytest)
-    runs-on: ubuntu-latest
+    name: Unit tests (pytest) — ${{ matrix.os }} / py${{ matrix.python }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
@@ -67,7 +72,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python }}
 
       - name: Install dependencies
         run: uv sync --extra dev

--- a/tests/test_evaluator_backends.py
+++ b/tests/test_evaluator_backends.py
@@ -223,7 +223,7 @@ def test_codex_backend_validate_auth_succeeds_with_chatgpt_oauth(
     codex_home.mkdir()
     auth_file = codex_home / "auth.json"
     auth_file.write_text('{"auth_mode": "chatgpt", "tokens": {"access_token": "tok"}}')
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
     backend = CodexSubprocessBackend()
     backend.validate_auth()
 
@@ -231,7 +231,7 @@ def test_codex_backend_validate_auth_succeeds_with_chatgpt_oauth(
 def test_codex_backend_validate_auth_fails_without_credentials(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("CODEX_API_KEY", raising=False)
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
     backend = CodexSubprocessBackend()
     with pytest.raises(SystemExit):
         backend.validate_auth()
@@ -263,7 +263,7 @@ def test_codex_backend_env_strips_api_keys_when_oauth_present(
     codex_home = tmp_path / ".codex"
     codex_home.mkdir()
     (codex_home / "auth.json").write_text('{"auth_mode": "chatgpt", "tokens": {"access_token": "tok"}}')
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
     monkeypatch.setenv("CODEX_API_KEY", "sk-stale-key-from-dotenv")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
@@ -278,7 +278,7 @@ def test_codex_backend_env_promotes_codex_key_to_openai_key(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
     monkeypatch.setenv("CODEX_API_KEY", "sk-codex-key")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
@@ -296,7 +296,7 @@ def test_codex_backend_env_preserves_openai_key_priority(
     codex_home = tmp_path / ".codex"
     codex_home.mkdir()
     (codex_home / "auth.json").write_text('{"auth_mode": "chatgpt", "tokens": {"access_token": "tok"}}')
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
     monkeypatch.setenv("OPENAI_API_KEY", "sk-explicit-openai-key")
     monkeypatch.setenv("CODEX_API_KEY", "sk-stale-codex-key")
 


### PR DESCRIPTION
## Summary

Follow-up to #43. Extends the quality-gate to actually catch Windows-only breakage and fixes the two remaining Windows-only test isolation bugs on `main`.

- **`.github/workflows/quality-gate.yml`** — pytest job now runs on `[ubuntu-latest, windows-latest] × [3.12, 3.13]` with `fail-fast: false`. Lint/typecheck/audit stay single-OS (pure-Python checks, no platform variance).
- **`tests/test_evaluator_backends.py`** — replace `monkeypatch.setenv("HOME", str(tmp_path))` with `monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)` in the five codex-oauth tests. `HOME` doesn't drive `Path.home()` on Windows (which reads `USERPROFILE`), so `_has_chatgpt_oauth()` was leaking into the dev's real `~/.codex/auth.json` and flipping the strip/promote branches in `_build_env`. The new pattern matches what `tests/test_runner.py:315,398` already uses and is cross-platform.

The ticket flagged a missing `monkeypatch.delenv("CODEX_API_KEY")` for `test_codex_backend_env_strips_api_keys_when_oauth_present`, but the test already does `monkeypatch.setenv("CODEX_API_KEY", ...)` which overrides the dev shell. The actual cause was the same `Path.home()` issue — `_has_chatgpt_oauth()` returned `False` (real `~/.codex` not visible), so the OAuth-strip branch never fired and `CODEX_API_KEY` survived in `env`.

No production-code change.

## Test plan

- [x] `uv run pytest tests/ -v` on local Windows — 147 passed, including the three previously failing tests.
- [x] `uv run ruff check tests/test_evaluator_backends.py` — clean.
- [x] `uv run ruff format --check tests/test_evaluator_backends.py` — clean.
- [ ] CI: all four matrix cells (`{ubuntu, windows} × {3.12, 3.13}`) green on this PR.

## Out of scope

- macOS coverage — no realistic Windows-style platform bugs hiding there; can be added separately if a need arises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)