### PR TITLE
docs(skill): clarify --all-variants is sequential, not parallel

### DIFF
--- a/.claude/skills/nasde-benchmark-runner/SKILL.md
+++ b/.claude/skills/nasde-benchmark-runner/SKILL.md
@@ -144,13 +144,15 @@ nasde run --variant baseline -C path/to/benchmark --without-eval
 
 ### Parallel runs (multiple variants)
 
-Running multiple variants simultaneously is safe — each job directory includes a unique random suffix to prevent collisions:
+**Do not use `--all-variants` when you want parallelism.** `--all-variants` runs variants **sequentially** in a single process (one variant after another). To run two or more variants in parallel, launch separate `nasde run` processes with `&` and `wait` — each job directory gets a unique random suffix, so concurrent runs are collision-safe:
 
 ```bash
 nasde run --variant vanilla --tasks my-task -C path/to/benchmark &
 nasde run --variant guided --tasks my-task -C path/to/benchmark &
 wait
 ```
+
+Use `--all-variants` only when you want one variant after another (e.g. to limit total resource use, or when running Claude variants where parallel runs risk Docker OOM — see warning below).
 
 For deterministic job names, use `--job-suffix`:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ See [docs/RELEASING.md](docs/RELEASING.md) for the release procedure.
   `nasde-benchmark-from-history`, `nasde-benchmark-from-public-repos`) gained a
   "Critical: line endings on Windows" section** so AI agents authoring benchmarks
   in user repos enforce the same LF policy. ([#47])
+- **`nasde-benchmark-runner` skill: clarified parallel-runs guidance.** Explicit
+  warning that `--all-variants` runs variants sequentially in a single process —
+  to run two or more variants in parallel, launch separate `nasde run` processes
+  with `&` and `wait`. Prevents agents from picking `--all-variants` when they
+  actually want concurrency.
 
 ### Fixed
 - **Windows `core.autocrlf=true` no longer breaks Linux benchmark trials.** Repo-wide


### PR DESCRIPTION
## Summary
- Adds an explicit warning in the `nasde-benchmark-runner` skill that `--all-variants` runs variants **sequentially** in a single process — agents wanting parallelism must launch separate `nasde run` processes with `&` and `wait`.
- Documents when `--all-variants` is actually the right choice (sequential resource budgeting, Claude variants where parallel runs risk Docker OOM).
- Adds a CHANGELOG entry under `[0.3.3]`. Last-moment tweak before the `v0.3.3` tag is cut.

## Why
The "Parallel runs (multiple variants)" section showed the `&` + `wait` pattern but never said anything about `--all-variants`. An agent reading "I want to run all variants" could reasonably reach for `--all-variants` and silently lose concurrency. The CLI iterates variants in a `for` loop (`cli.py::_run_all_variants`), so this isn't a config knob — it's a deliberate sequential mode.

## Test plan
- [ ] Diff is docs-only (`SKILL.md` + `CHANGELOG.md`); no code/CI surface touched.
- [ ] CHANGELOG entry sits under existing `[0.3.3]` section with the same prose style as neighbors.
- [ ] Quality-gate workflow passes (markdown only, should be a no-op).