### PR TITLE
ci: ignore disputed pyjwt CVE PYSEC-2025-183 in quality gate

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -100,4 +100,8 @@ jobs:
             > requirements.txt
 
       - name: Run pip-audit
-        run: uvx --with pip pip-audit -r requirements.txt --strict
+        # PYSEC-2025-183 (CVE-2025-45768): disputed advisory against pyjwt — upstream
+        # rejects the classification (key length is the application's responsibility),
+        # there is no fix release (2.12.1 is latest), and pyjwt is only a transitive
+        # dep via harbor → supabase-auth / mcp. Revisit if upstream ever ships a fix.
+        run: uvx --with pip pip-audit -r requirements.txt --strict --ignore-vuln PYSEC-2025-183


### PR DESCRIPTION
## Summary
- CVE audit on \`main\` started failing because pip-audit found PYSEC-2025-183 / CVE-2025-45768 against pyjwt 2.12.1.
- The advisory is disputed by the upstream maintainer (key length is the calling application's responsibility), there is **no fix release** (2.12.1 is the latest pyjwt), and pyjwt only enters our tree transitively via \`harbor → supabase-auth / mcp\` — we can't upgrade past it.
- Add a surgical \`--ignore-vuln PYSEC-2025-183\` so \`pip-audit --strict\` still hard-fails on every other CVE, with a comment explaining why and a pointer to revisit if upstream ever ships a fix.

## Test plan
- [ ] Quality Gate / CVE audit (pip-audit) passes on this PR
- [ ] Verified locally with the same export pipeline: \`No known vulnerabilities found, 1 ignored\`