### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ See [docs/RELEASING.md](docs/RELEASING.md) for the release procedure.
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-05-21
+
 ### Added
 - **`[nasde.plugin]` in `task.toml` — ship a local Claude Code plugin into the
   sandbox with one declaration.** Mirrors `[nasde.source]`: stages the plugin
@@ -19,19 +21,30 @@ See [docs/RELEASING.md](docs/RELEASING.md) for the release procedure.
   MCP server (from its `.mcp.json`) into the task — with the env a
   baked-not-installed plugin needs. Composes with `[nasde.source]` and with a
   hand-written `environment/Dockerfile`. Removes the frozen-plugin-snapshot
-  workaround. See [ADR-009](docs/adr/009-plugin-and-skill-by-reference.md).
+  workaround. See [ADR-009](docs/adr/009-plugin-and-skill-by-reference.md). ([#51])
 - **Skill-by-reference: `[[skill]]` array in `variant.toml`.** Reference a skill
   from a source path (optional `ref`) instead of copying it into
   `variants/<v>/skills/`. The whole skill directory (including `references/`) is
   staged into the sandbox. Shares the plugin's skill-registration machinery.
-  See [ADR-009](docs/adr/009-plugin-and-skill-by-reference.md).
+  See [ADR-009](docs/adr/009-plugin-and-skill-by-reference.md). ([#51])
 
 ### Fixed
 - **`variants/<v>/skills/<name>/` now carries `references/` and sibling files**,
   not just `SKILL.md`. Previously only `SKILL.md` was injected, silently breaking
   skills that read `references/*.md` at runtime. Backward compatible — the
   copy-into-`variants/` path keeps working, now correctly.
-  See [ADR-009](docs/adr/009-plugin-and-skill-by-reference.md).
+  See [ADR-009](docs/adr/009-plugin-and-skill-by-reference.md). ([#51])
+
+### Security
+- **Pinned `idna>=3.15` and `urllib3>=2.7.0`** (transitive via harbor/opik/supabase)
+  to address CVE-2026-45409 (idna) and CVE-2026-44431 / CVE-2026-44432 (urllib3). ([#51])
+
+### CI
+- **`pip-audit` now ignores the disputed pyjwt advisory PYSEC-2025-183 / CVE-2025-45768.**
+  Upstream rejects the classification — alleged weak-key behavior is the calling
+  application's responsibility, and pyjwt 2.12.1 has no fix release. pyjwt enters
+  our tree only transitively via `harbor → supabase-auth / mcp`, so we cannot
+  upgrade past it. `pip-audit --strict` still hard-fails on every other CVE. ([#52])
 
 ### Post-review hardening (ADR-009)
 
@@ -347,7 +360,8 @@ Initial release under the **nasde-toolkit** name (rebrand from
 - `v0.1.0` represents the first public-oriented baseline; earlier commits
   on the `sdlc-eval-kit` history are not cataloged here.
 
-[Unreleased]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.3.3...HEAD
+[Unreleased]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.3.3...v0.4.0
 [0.3.3]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.3.0...v0.3.2
 [0.3.0]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.2.1...v0.3.0
@@ -374,4 +388,6 @@ Initial release under the **nasde-toolkit** name (rebrand from
 [#47]: https://github.com/NoesisVision/nasde-toolkit/pull/47
 [#48]: https://github.com/NoesisVision/nasde-toolkit/pull/48
 [#50]: https://github.com/NoesisVision/nasde-toolkit/pull/50
+[#51]: https://github.com/NoesisVision/nasde-toolkit/pull/51
+[#52]: https://github.com/NoesisVision/nasde-toolkit/pull/52
 [gh-litellm-2026-04]: https://github.com/BerriAI/litellm/security/advisories/GHSA-xqmj-j6mv-4862


### PR DESCRIPTION
Promote the `[Unreleased]` section to `[0.4.0]` (2026-05-21) per `docs/RELEASING.md`.

## Highlights — what users get in 0.4.0

### Added — plugin support and skill-by-reference (ADR-009, #51)

- **`[nasde.plugin]` in `task.toml`.** Ship a local Claude Code plugin into the sandbox with one declaration: stages the plugin tree (at an optional `ref` via a temporary git worktree) into the Docker build context, generates/augments the Dockerfile to `COPY` it to `install_root` and run an optional build command, registers the plugin's `skills/` for the agent (whole skill dir incl. `references/`), and auto-wires every server from `<plugin>/.mcp.json` into the task — env-wrapped for the baked-not-installed plugin's `CLAUDE_PLUGIN_ROOT` etc. Composes with `[nasde.source]` and with hand-written `environment/Dockerfile`. Retires the frozen-plugin-snapshot workaround.
- **Skill-by-reference: `[[skill]]` array in `variant.toml`.** Reference a skill from a source path (optional `ref`) instead of copying it into `variants/<v>/skills/`. The whole skill directory (including `references/`) is staged into `/app/.claude/skills/<name>/`. Shares the plugin's skill-registration machinery.

### Fixed (#51)

- **`variants/<v>/skills/<name>/` now carries `references/` and sibling files**, not just `SKILL.md`. Previously only `SKILL.md` was injected, silently breaking skills that read `references/*.md` at runtime. Backward compatible — the copy-into-`variants/` path keeps working, now correctly.

### Security (#51)

- Pinned `idna>=3.15` and `urllib3>=2.7.0` (transitive via harbor/opik/supabase) to address CVE-2026-45409 (idna) and CVE-2026-44431 / CVE-2026-44432 (urllib3).

### CI (#52)

- `pip-audit` now ignores the disputed pyjwt advisory PYSEC-2025-183 / CVE-2025-45768 (upstream rejects classification; pyjwt 2.12.1 has no fix; we cannot upgrade past it since it enters our tree only transitively via `harbor → supabase-auth / mcp`). `pip-audit --strict` still hard-fails on every other CVE.

## Backward compatibility

No `[nasde.plugin]` / `[[skill]]` → behavior is byte-for-byte as before. Existing `variants/<v>/skills/` copies keep working and now also carry `references/` (a strict improvement). Hand-written `harbor_config.json` entries are preserved across runs via the `_nasde_derived_keys` meta-list.

## Pre-flight per `docs/RELEASING.md`

- [x] CI green on main — `quality-gate.yml` and `example-validation.yml` both passing on `a484c77` (last main commit).
- [x] `[Unreleased]` not half-finished — only the two PRs intended for this release (#51 feature, #52 CI patch) merged since v0.3.3.
- [x] CHANGELOG entries cite their PRs and link-refs are added at the bottom.
- [x] Compare links updated: new `[0.4.0]` row + `[Unreleased]` shifted to compare against `v0.4.0`.
- [x] Working tree clean before this branch.

## Version-bump rationale (per RELEASING.md "Pre-1.0 policy")

`### Added` entries → at minimum minor. Plugin + skill-by-reference is a meaningful new user-facing capability (new `task.toml` section, new `variant.toml` array), even though it's fully opt-in and existing benchmarks keep working unchanged. → **minor: 0.3.3 → 0.4.0**.

## After merge

Tag from `main` (NOT this branch) and push:

```bash
git checkout main && git pull
git tag v0.4.0
git push origin v0.4.0
```

`publish.yml` then runs quality-gate → build → TestPyPI → smoke → PyPI → smoke → GitHub Release.

## Test plan

- [ ] CI green on this PR (quality-gate × Linux × Windows × py3.12 / py3.13, example-validation, dogfooding).
- [ ] After merge & tag push: watch `publish.yml` via `gh run watch`; confirm PyPI page renders 0.4.0 and `uv tool install nasde-toolkit && nasde --version` prints `0.4.0` (no `.devN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)