### PR TITLE
fix(runner): resolve own job_dir from config, not globally-newest dir (BUG #2)

### DIFF
--- a/src/nasde_toolkit/runner.py
+++ b/src/nasde_toolkit/runner.py
@@ -109,7 +109,7 @@ async def run_benchmark(
             project_name=config.reporting.project_name or config.name,
             project_dir=config.project_dir,
         )
-        _print_job_summary(result, _find_latest_job(config.project_dir))
+        _print_job_summary(result, _job_dir_from_config(merged_config))
         console.print("\n[bold green]Benchmark execution completed[/bold green]\n")
 
 
@@ -704,6 +704,23 @@ def _resolve_jobs_dir(project_dir: Path) -> Path:
     return project_dir / "jobs"
 
 
+def _job_dir_from_config(merged_config: dict) -> Path | None:
+    """Resolve this run's own job directory from the config it submitted.
+
+    Harbor writes each job into ``jobs_dir / job_name`` — both stamped onto the
+    merged config by ``_build_merged_config`` before the job starts. Reading
+    them back is exact and race-free: it never depends on scanning ``jobs/``
+    for the newest directory, which under concurrent runs can belong to a
+    different, still-running job.
+    """
+    jobs_dir = merged_config.get("jobs_dir")
+    job_name = merged_config.get("job_name")
+    if not jobs_dir or not job_name:
+        return None
+    job_dir: Path = Path(jobs_dir) / job_name
+    return job_dir
+
+
 # ---------------------------------------------------------------------------
 # Opik monkey-patch: deferred Step metrics (ADR-006)
 # ---------------------------------------------------------------------------
@@ -891,7 +908,7 @@ async def _run_job_with_streaming_eval(
         if assessment_tasks:
             console.print(f"[dim]Waiting for {len(assessment_tasks)} assessment evaluation(s)...[/dim]")
             await asyncio.gather(*assessment_tasks, return_exceptions=True)
-    _print_job_summary(result, _find_latest_job(config.project_dir))
+    _print_job_summary(result, _job_dir_from_config(merged_config))
     console.print("\n[bold green]Benchmark execution completed[/bold green]\n")
 
 
@@ -937,14 +954,26 @@ def _print_job_summary(result: JobResult, job_dir: Path | None = None) -> None:
     console.print(f"  Trials: {result.stats.n_completed_trials}")
     console.print(f"  Errors: {result.stats.n_errored_trials}")
 
-    rows = _collect_economics_rows(job_dir) if job_dir is not None else []
-    if rows and job_dir is not None:
-        _print_economics_table(rows)
-        _print_label_legend(rows)
-        _print_location_hints(job_dir)
+    if job_dir is not None:
+        rows = _collect_economics_rows(job_dir)
+        if rows:
+            _print_economics_table(rows)
+            _print_label_legend(rows)
+            _print_location_hints(job_dir)
+        elif result.stats.evals:
+            _warn_missing_economics(job_dir)
+            _print_eval_counts_table(result)
     elif result.stats.evals:
         _print_eval_counts_table(result)
     console.print()
+
+
+def _warn_missing_economics(job_dir: Path) -> None:
+    console.print(
+        f"[yellow]WARN: no assessment_summary.json found under {job_dir} — "
+        "cost/efficiency table skipped. Did assessment evaluation complete? "
+        f"Re-run with [bold]nasde eval {job_dir}[/bold].[/yellow]"
+    )
 
 
 def _print_economics_table(rows: list[dict]) -> None:
@@ -1079,48 +1108,3 @@ def _fmt_tokens(total: float | None) -> str:
     if total >= 1_000:
         return f"{total / 1_000:.0f}k"
     return str(int(total))
-
-
-# ---------------------------------------------------------------------------
-# Post-hoc assessment
-# ---------------------------------------------------------------------------
-
-
-async def _run_post_hoc_assessment(
-    config: ProjectConfig,
-    with_opik: bool,
-    job_dir: Path | None = None,
-    max_concurrent_eval: int = 10,
-) -> None:
-    target_job = job_dir or _find_latest_job(config.project_dir)
-    if not target_job:
-        console.print("[yellow]WARN: No job directory found for assessment[/yellow]")
-        return
-
-    console.print("\n[bold]Running assessment evaluation...[/bold]\n")
-
-    os.environ.pop("CLAUDECODE", None)
-
-    from nasde_toolkit.evaluator import evaluate_job
-
-    await evaluate_job(
-        job_dir=target_job,
-        project_root=config.project_dir,
-        project_name=config.reporting.project_name,
-        with_opik=with_opik,
-        max_concurrent=max_concurrent_eval,
-        eval_config=config.evaluation,
-    )
-
-
-def _find_latest_job(project_dir: Path) -> Path | None:
-    jobs_dir = _resolve_jobs_dir(project_dir)
-    if not jobs_dir.exists():
-        return None
-
-    job_dirs = sorted(
-        [d for d in jobs_dir.iterdir() if d.is_dir()],
-        key=lambda p: p.name,
-        reverse=True,
-    )
-    return job_dirs[0] if job_dirs else None

--- a/tests/test_runner_economics.py
+++ b/tests/test_runner_economics.py
@@ -7,7 +7,14 @@ from pathlib import Path
 
 import pytest
 
-from nasde_toolkit.runner import _collect_economics_rows, _fmt_score, _sample_std, _short_label
+from nasde_toolkit.runner import (
+    _collect_economics_rows,
+    _fmt_score,
+    _job_dir_from_config,
+    _print_job_summary,
+    _sample_std,
+    _short_label,
+)
 
 
 def _write_trial(job: Path, name: str, agent: str, model: str, score: float, tokens: int, cost: float) -> None:
@@ -93,3 +100,89 @@ def test_economics_groups_split_by_model(tmp_path: Path) -> None:
     rows = _collect_economics_rows(job)
     assert len(rows) == 2  # same agent_name, different model_name → two rows
     assert {r["full_label"] for r in rows} == {"codex-vanilla / gpt-5.4", "codex-vanilla / gpt-5.5"}
+
+
+def test_job_dir_from_config_resolves_own_job(tmp_path: Path) -> None:
+    jobs_dir = tmp_path / "jobs"
+    jobs_dir.mkdir()
+    merged = {"jobs_dir": str(jobs_dir), "job_name": "2026-06-09__20-29-49__claude-vanilla__abc123"}
+    assert _job_dir_from_config(merged) == jobs_dir / "2026-06-09__20-29-49__claude-vanilla__abc123"
+
+
+def test_job_dir_from_config_ignores_newer_concurrent_job(tmp_path: Path) -> None:
+    jobs_dir = tmp_path / "jobs"
+    own = jobs_dir / "2026-06-09__20-29-49__claude-sonnet__own456"
+    newer_concurrent = jobs_dir / "2026-06-09__20-30-03__codex-gpt__newer789"
+    _write_trial(own, "t__a", "claude-sonnet", "claude-sonnet-4-6", 0.7, 1_000_000, 2.0)
+    newer_concurrent.mkdir(parents=True)  # newer by name, still running → no result.json yet
+
+    newest_by_name = sorted((d for d in jobs_dir.iterdir() if d.is_dir()), key=lambda p: p.name)[-1]
+    assert newest_by_name == newer_concurrent  # what the old _find_latest_job scan WOULD have picked
+
+    merged = {"jobs_dir": str(jobs_dir), "job_name": own.name}
+    resolved = _job_dir_from_config(merged)
+
+    assert resolved == own  # config-based resolution wins over the newest-by-name sibling
+    assert resolved != newest_by_name  # the exact divergence the race fix guarantees
+    assert _collect_economics_rows(resolved)[0]["score"] == pytest.approx(0.7)
+
+
+def test_job_dir_from_config_returns_none_without_keys() -> None:
+    assert _job_dir_from_config({}) is None
+    assert _job_dir_from_config({"jobs_dir": "/x"}) is None
+    assert _job_dir_from_config({"job_name": "j"}) is None
+
+
+def _job_result(n_completed: int) -> object:
+    from harbor.models.job.result import AgentDatasetStats, JobResult, JobStats
+
+    return JobResult(
+        id="00000000-0000-0000-0000-000000000000",
+        started_at="2026-06-09T20:29:49Z",
+        n_total_trials=n_completed,
+        stats=JobStats(
+            n_completed_trials=n_completed,
+            n_errored_trials=0,
+            evals={"claude-vanilla/t": AgentDatasetStats(n_trials=n_completed, n_errors=0)},
+        ),
+    )
+
+
+def _wide_console(monkeypatch: pytest.MonkeyPatch) -> None:
+    from rich.console import Console
+
+    import nasde_toolkit.runner as runner
+
+    monkeypatch.setattr(runner, "console", Console(width=10_000))
+
+
+def _flat(out: str) -> str:
+    return " ".join(out.split())
+
+
+def test_print_job_summary_warns_when_own_job_has_no_economics(
+    tmp_path: Path, capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _wide_console(monkeypatch)
+    job = tmp_path / "job"
+    job.mkdir()  # our own completed job, but assessment never wrote a summary
+
+    _print_job_summary(_job_result(n_completed=1), job)
+
+    out = _flat(capsys.readouterr().out)
+    assert "no assessment_summary.json found" in out
+    assert "nasde eval" in out
+
+
+def test_print_job_summary_renders_economics_for_own_job(
+    tmp_path: Path, capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _wide_console(monkeypatch)
+    job = tmp_path / "job"
+    _write_trial(job, "t__a", "claude-vanilla", "claude-sonnet-4-6", 0.6, 1_000_000, 2.0)
+
+    _print_job_summary(_job_result(n_completed=1), job)
+
+    out = _flat(capsys.readouterr().out)
+    assert "Results by agent/model" in out
+    assert "no assessment_summary.json found" not in out


### PR DESCRIPTION
## Problem

`run()` re-guessed the finished job's directory via `_find_latest_job(project_dir)`, which returned the **globally-newest** dir in `jobs/` (sorted by name = start timestamp, `reverse=True`, `[0]`). Under **parallel runs** that could be a *different, still-running* job:

- **Mild (observed):** the newer concurrent job has no `result.json` yet → `_collect_trial_dirs` returns nothing → empty economics rows → silent fallback to the cost-less "Results by agent/dataset" table. This is exactly why *only one variant* (the one that happened to finish while a newer job was still running) ever showed the cost columns.
- **Serious:** if the newer concurrent job finished a trial *before* the current run printed, `_find_latest_job` would return its ready dir → the current run would print **another model's** cost/score metrics under its own header — a silent mis-attribution of economics. For a tool whose core purpose is cost measurement, that's a correctness bug, not a cosmetic one.

### Confirmed chain of events (from the Krok-1 efficiency run)
Job timestamps are **start** times, not finish:
- sonnet `20-29-49` (started first, **finished first** ~20:43)
- opus `20-29-51`
- gpt-5.4 `20-30-03` (ran ~12 min, to ~20:42–43)
- gpt-5.5 `20-46-08` (sequential, after gpt-5.4)

When sonnet finished (~20:43), `_find_latest_job` returned the newest dir = **gpt-5.4 (`20-30-03`)**, still running → no final `result.json` → `rows=[]` → cost-less table. So only sonnet showed it.

## Fix

Derive the job dir from the merged config **this process submitted** — no guessing:

```python
def _job_dir_from_config(merged_config: dict) -> Path | None:
    jobs_dir = merged_config.get("jobs_dir")
    job_name = merged_config.get("job_name")
    if not jobs_dir or not job_name:
        return None
    return Path(jobs_dir) / job_name
```

`jobs_dir` and `job_name` are stamped onto the merged config by `_build_merged_config` **before** the job starts, and `jobs_dir / job_name` is exactly the dir Harbor writes this job into. Exact, deterministic, race-free — no filesystem scan. Both `run()` call sites (with-eval streaming path and without-eval path) now use it.

### Also
- **Removed dead code:** `_find_latest_job` and `_run_post_hoc_assessment` had no remaining live callers (the `eval` CLI command takes an explicit `job_dir`).
- **No more silent masking:** when the job dir is our own and completed but has no `assessment_summary.json`, `_print_job_summary` now warns (`no assessment_summary.json found … Re-run with nasde eval <dir>`) instead of quietly falling back to the cost-less table.

## Tests

`tests/test_runner_economics.py` (full suite: 356 passing, ruff clean):
- `test_job_dir_from_config_ignores_newer_concurrent_job` — the exact regression: older *own* job (with `result.json`) + a newer-by-name sibling **without** `result.json` (still running); asserts resolution picks **own**. With the old `_find_latest_job` this returned the newer dir.
- `_job_dir_from_config` resolution + missing-key guards.
- `_print_job_summary` warning-path and economics-render-path.

## Note for BUG #1 (efficiency metric)
`_finalize_economics_row` computes efficiency with the same `mean_score / mean_tokens` & `mean_score / mean_cost` formula as the on-disk summaries. When BUG #1 lands, the console table must get the identical change or the printout and the files will diverge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)