### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ See [docs/RELEASING.md](docs/RELEASING.md) for the release procedure.
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-06-24
+
 ### Added
 - **Convention-based layered price overrides ([ADR-013](docs/adr/013-layered-pricing-override.md)).** Model prices
   are now overridable after install without touching the wheel: drop a
@@ -552,7 +554,8 @@ Initial release under the **nasde-toolkit** name (rebrand from
 - `v0.1.0` represents the first public-oriented baseline; earlier commits
   on the `sdlc-eval-kit` history are not cataloged here.
 
-[Unreleased]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.3.3...v0.4.0
 [0.3.3]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/NoesisVision/nasde-toolkit/compare/v0.3.0...v0.3.2


### PR DESCRIPTION
Cuts **v0.5.0**. Moves `[Unreleased]` under the dated `## [0.5.0] — 2026-06-24` header, adds a fresh empty `[Unreleased]`, and updates the compare links (per `docs/RELEASING.md`).

## What's in v0.5.0
- **Layered pricing override + visibility** (ADR-013) — `pricing.toml` at project/`~/.nasde`/bundled, `nasde pricing show --show-source`, run-summary "Pricing used" table, `pricing_used.json` in export. (#71)
- **Token & cost metrics + reasoning-effort control** (ADR-011). (#60, this batch)
- **Rubric calibration via PR/MR review** (`nasde calibrate`, ADR-010). (#59)
- **Native Codex/Gemini skill injection** (ADR-012). (#65, #67)
- **results-export + repeated-evaluation accumulation.** (#57)
- **Harbor 0.6 → 0.13** bump; **Codex ChatGPT OAuth** fix. (#56, #61)
- **NASDE → Nasde rebrand + Starlight docs site.** (#64, #69)
- **job_dir race fix** for parallel runs. (#62)
- **Security:** June-2026 CVE dependency pins (aiohttp/cryptography/python-multipart/pydantic-settings/starlette). (#70)

## After merge
Tag from main and push — `publish.yml` runs quality-gate → build → TestPyPI → smoke → PyPI → GitHub Release:
```
git checkout main && git pull
git tag v0.5.0 && git push origin v0.5.0
```

Minor bump: new features + a `Removed` (scalar efficiency output fields), with user-facing CLI / `nasde.toml` schema / project layout backwards-compatible (pre-1.0 policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)