### PR TITLE
ci: scope Quality Gate concurrency to the calling workflow

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -8,7 +8,14 @@ on:
   workflow_call:
 
 concurrency:
-  group: quality-${{ github.ref }}
+  # github.workflow is the CALLER's workflow name ("Quality Gate" on a direct
+  # push/PR, "Publish" when invoked via `uses:` from publish.yml). Keying the
+  # group on it keeps the publish-embedded gate out of the standalone gate's
+  # group, so the release push's gate isn't cancelled by the follow-up publish
+  # run (which renders as a red ✗ on main even though nothing failed).
+  # NOTE: this relies on each caller declaring an explicit `name:` — without one
+  # GitHub falls back to the file path and the group silently changes.
+  group: quality-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ See [docs/RELEASING.md](docs/RELEASING.md) for the release procedure.
 - Added the NASDE branding source assets and updated the README and
   documentation website to use the new brand. ([#73])
 
+### Fixed
+- Quality Gate no longer shows a spurious red ✗ on `main` after a release: the
+  concurrency group is now scoped per calling workflow so the publish-embedded
+  gate no longer cancels the standalone push-triggered one. ([#74])
+
 ## [0.5.0] — 2026-06-24
 
 ### Added
@@ -602,4 +607,5 @@ Initial release under the **nasde-toolkit** name (rebrand from
 [#70]: https://github.com/NoesisVision/nasde-toolkit/pull/70
 [#71]: https://github.com/NoesisVision/nasde-toolkit/pull/71
 [#73]: https://github.com/NoesisVision/nasde-toolkit/pull/73
+[#74]: https://github.com/NoesisVision/nasde-toolkit/pull/74
 [gh-litellm-2026-04]: https://github.com/BerriAI/litellm/security/advisories/GHSA-xqmj-j6mv-4862


### PR DESCRIPTION
## Problem

After a release, `main` showed a **red ✗** at the release commit — looking like CI was failing. It wasn't. The mark was a standalone **Quality Gate** run with conclusion **`cancelled`** (GitHub renders `cancelled` identically to a failure). The code was healthy: every other gate run on that commit passed all jobs and the release shipped to PyPI.

## Root cause (structural, recurs on every release)

`publish.yml` calls `quality-gate.yml` as a **reusable workflow** (`uses:`). A reusable workflow's `concurrency` is evaluated in the **caller's** ref context. When Publish runs on `main`, its embedded quality-gate joins the **same** group `quality-refs/heads/main` as the standalone Quality Gate triggered by the push to `main`.

The standard release flow — *merge release PR to main* (push → standalone gate) immediately followed by a *tag push / dry-run dispatch* (→ Publish, whose embedded gate shares the group) — therefore triggers `cancel-in-progress: true`, which cancels the older standalone gate. Red ✗.

## Fix

Key the concurrency group on `github.workflow` as well:

```yaml
group: quality-${{ github.workflow }}-${{ github.ref }}
```

`github.workflow` resolves to the **caller's** workflow name (`"Quality Gate"` on a direct push/PR, `"Publish"` when invoked via `uses:`), so the standalone gate and the publish-embedded gate never share a group — while each still de-dupes among its own runs (the cancellation savings concurrency was added for are preserved). A comment documents the one caveat: this relies on each caller declaring an explicit `name:` (both do today), else GitHub falls back to the file path and the group silently changes.

## Verification

- [x] YAML parses (`quality-gate.yml` + `publish.yml`).
- [ ] This PR's own Quality Gate runs and de-dupes on re-push.
- [ ] After merge: a dry-run `gh workflow run publish.yml --ref main` immediately after a push to main no longer cancels the standalone Quality Gate (both complete green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)