### PR TITLE
deps: raise the typer floor to >=0.26 (fresh installs died on typer._click)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ See [docs/RELEASING.md](docs/RELEASING.md) for the release procedure.
 - Quality Gate no longer shows a spurious red ✗ on `main` after a release: the
   concurrency group is now scoped per calling workflow so the publish-embedded
   gate no longer cancels the standalone push-triggered one. ([#74])
+- `uv tool install` / `pip install` from a fresh resolver no longer produces a
+  `nasde` that dies on `ModuleNotFoundError: No module named 'typer._click'`:
+  the `typer` floor is raised from `>=0.16` to `>=0.26` — `cli.py` has imported
+  `typer._click` (the vendored Click) since the harbor 0.13 bump, but the floor
+  was never lifted, so an unlocked resolve could still pick typer 0.25. ([#82])
 
 ### Security
 - **Pinned `aiohttp>=3.14.3`, `cryptography>=50.0.0` and `h2>=4.4.1`** (all
@@ -654,4 +659,5 @@ Initial release under the **nasde-toolkit** name (rebrand from
 [#78]: https://github.com/NoesisVision/nasde-toolkit/pull/78
 [#80]: https://github.com/NoesisVision/nasde-toolkit/pull/80
 [#81]: https://github.com/NoesisVision/nasde-toolkit/pull/81
+[#82]: https://github.com/NoesisVision/nasde-toolkit/pull/82
 [gh-litellm-2026-04]: https://github.com/BerriAI/litellm/security/advisories/GHSA-xqmj-j6mv-4862

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
 ]
 dependencies = [
-    "typer>=0.16",
+    "typer>=0.26",
     "rich>=14.1,<16",
     "platformdirs>=4.0",
     "packaging>=25,<26",

--- a/uv.lock
+++ b/uv.lock
@@ -1421,7 +1421,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "supabase", specifier = ">=2.29.0,<3" },
-    { name = "typer", specifier = ">=0.16" },
+    { name = "typer", specifier = ">=0.26" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
## Summary
- \`cli.py\` has imported \`typer._click\` (typer's vendored Click) since the harbor 0.13 bump (#56), but \`pyproject.toml\` still declared \`typer>=0.16\`.
- An unlocked resolve (\`uv tool install .\`, \`pip install\`) could pick typer 0.25.x, and \`nasde\` then failed at import: \`ModuleNotFoundError: No module named 'typer._click'\`. Reproduced today on a fresh \`uv tool install\` of main.
- Floor raised to \`typer>=0.26\` (first version with \`typer._click\`), lock refreshed, CHANGELOG entry under Unreleased/Fixed.

## Test plan
- [x] \`uv run pytest\` — 465 passed
- [x] fresh \`uv tool install --python 3.13 --force <checkout>\` → \`nasde --version\`, \`nasde calibrate --help\` work (typer 0.27.2 resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdLXjgyiC6nVJ51bX9JySn